### PR TITLE
Added extra -eq flags and added release versions to docs

### DIFF
--- a/docs/gettingstarted/compiler-opts.md
+++ b/docs/gettingstarted/compiler-opts.md
@@ -8,8 +8,8 @@ This section described how to use clang to compile C/C++ code for WebAssembly, a
 
 twr-wasm lets you use clang directly, without a wrapper.  This section describes the needed clang compile options and the wasm-ld link options.  You can also take a look at the [example makefiles](../examples/examples-overview.md).
 
-# Compiler Notes
-Release was built with clang version 17.0.6 and wasm-ld 17.0.6.
+## Compiler Notes
+twr-wasm has been tested with clang 17.0.6 and wasm-ld 17.0.6.
 
 If you are using nix, the default clang packages are wrapped with flags that break compilation. The following packages don't have this issue:
 * llvmPackages_18.clang-unwrapped (clang 18.1.7)

--- a/docs/more/building.md
+++ b/docs/more/building.md
@@ -19,7 +19,7 @@ You will need these core tools, versions used in release are in ():
 - TypeScript (5.4.5)
 - clang tool chain (17.0.6) - for C/C++ code
 - wasm-ld (17.0.6) - to link the .wasm files
-- wat2wasm (1.0.35) - to compile WebAssembly (.wat) files of which I have a few 
+- wat2wasm (1.0.34) - to compile WebAssembly (.wat) files of which I have a few 
 - GNU make (4.4.1)
 - git - to clone twr-wasm source, or to clone llvm, if you want to build libc++
 

--- a/docs/more/building.md
+++ b/docs/more/building.md
@@ -14,13 +14,13 @@ https://github.com/twiddlingbits/twr-wasm
 The `main` branch contains the latest release.  The `dev` branch is work in progress.
 
 ## Tools Needed to Build twr-wasm Source
-You will need these core tools:
+You will need these core tools, versions used in release are in ():
 
-- TypeScript
-- clang tool chain - for C/C++ code
-- wasm-ld - to link the .wasm files
-- wat2wasm - to compile WebAssembly (.wat) files of which I have a few 
-- GNU make
+- TypeScript (5.4.5)
+- clang tool chain (17.0.6) - for C/C++ code
+- wasm-ld (17.0.6) - to link the .wasm files
+- wat2wasm (1.0.35) - to compile WebAssembly (.wat) files of which I have a few 
+- GNU make (4.4.1)
 - git - to clone twr-wasm source, or to clone llvm, if you want to build libc++
 
 In addition, you might need:

--- a/examples/buildall.sh
+++ b/examples/buildall.sh
@@ -5,7 +5,7 @@
 # after running this script, examples can be most easily be executed by using the VS Code "Run and Debug" menu
 # or use buildbundle.sh to bundle and then execute with a local server (see buildbundle.sh)
 
-if [ $(uname -o)="Msys" ]; then
+if [ $(uname -o) -eq "Msys" ]; then
 export MSYS_NO_PATHCONV=1
 make="mingw32-make"
 else

--- a/examples/buildbundle.sh
+++ b/examples/buildbundle.sh
@@ -19,7 +19,7 @@
 
 set -e  # exit if any command returns non zero
 
-if [ $(uname -o)="Msys" ]; then
+if [ $(uname -o) -eq "Msys" ]; then
 export MSYS_NO_PATHCONV=1
 fi
 


### PR DESCRIPTION
* Added -eq flags to the remaining two .sh files that I missed in #1 .
* Fixed some minor working in [compiler-opts.md](https://github.com/twiddlingbits/twr-wasm/blob/a2b8e30eeecdd49af6cf5c13942245f9a457389b/docs/gettingstarted/compiler-opts.md)
* Added the versions release uses for some of the tools listed in [building.md](https://github.com/twiddlingbits/twr-wasm/blob/a2b8e30eeecdd49af6cf5c13942245f9a457389b/docs/more/building.md)