### PR TITLE
Fixed minor typos in docs

### DIFF
--- a/docs/api/api-c-con.md
+++ b/docs/api/api-c-con.md
@@ -75,7 +75,7 @@ fprintf(stderr, "hello over there in browser debug console land\n");
 ~~~
 
 ### twr_divcon
-This funciton has been removed.
+This function has been removed.
 
 ### twr_windowcon
 This function has been removed.
@@ -94,7 +94,7 @@ void io_cls(struct IoConsoleWindow* iow);
 ~~~
 
 ### io_getc32
-Waits for the user to enter and then returns a unicode code point. 
+Waits for the user to hit enter and then returns a unicode code point. 
 
 To return characters encoded with the current locale, see `io_mbgetc`
 

--- a/docs/api/api-c-d2d.md
+++ b/docs/api/api-c-d2d.md
@@ -66,9 +66,9 @@ Some commands have extra details that you need to be aware of to avoid performan
 * getLineDash takes in a buffer_length, double * array (the buffer), and returns the amount of the buffer filled. If there are more line segments than can fit in the buffer_length, a warning is printed and the excess is voided. If you want to know the size before hand for allocation, the getLineDashLength function is available.
 
 ## Extra Notes
-The functions listed below are primarily around the JavaScript Canvas 2D API -- which can be found [here](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D). However, there are differences needed to call from C.  For example some items keep resources stored on the JavaScript side (such as d2d_createlineargradient) which are referenced by an ID rather than the objects themselves.
+The functions listed below are based on the JavaScript Canvas 2D API ([found here](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D)). However, there are some slight differences since it is made for C rather than JavaScript.  For example some items keep resources stored on the JavaScript side (such as d2d_createlineargradient) which are referenced by an ID rather than the objects themselves.
 
-In addition, there are alternative functions like d2d_setstrokestylergba,  which calls the same underlying function as d2d_setstrokestyle, but takes in a color as a number rather than CSS style string.
+Additionally, there are alternative functions like d2d_setstrokestylergba,  which calls the same underlying function as d2d_setstrokestyle, but takes in a color as a number rather than CSS style string.
 
 As noted above, putImageData requires that the image data be alive until flush is called, however, other functions like d2d_filltext don't have this same issue because they copy the string on to the heap. This allows it to be cleaned up with flush() and ensures that it stays alive long enough to be transferred to typescript.
 

--- a/docs/api/api-c-stdlib.md
+++ b/docs/api/api-c-stdlib.md
@@ -95,7 +95,7 @@ Note that _fcvt_s as currently enabled has these limitations:
    - values must be less than 1e+21
    - values negative exponents must be smaller than 1e-99
 
-There is a full featured version of _fcvt_s in the source code, but is not currently enabled, since the version enabled is smaller and works in most use cases.
+There is a full featured version of _fcvt_s in the source code, but it is not currently enabled, since the version enabled is smaller and works in most use cases.
 ## assert.h
 ~~~
 void assert(int expression);

--- a/docs/api/api-typescript.md
+++ b/docs/api/api-typescript.md
@@ -131,7 +131,7 @@ You will also need to set the tabindex attribute in your tag like this to enable
 
 [See this example](../examples/examples-stdio-div.md) on character input.
 
-Note that this section describes blocking input.  As an alternative, you can send events (keyboard, mouse, timer, etc) to a non-blocking C function from JavaScript using `callC`.  See the `balls` or `pong` examples.
+Note that this section describes blocking input.  As an alternative, you can send events (keyboard, mouse, timer, etc) to a non-blocking C function from JavaScript using `callC`.  See the [`balls`](../examples/examples-balls.md) or [`pong`](../examples/examples-pong.md) examples.
 
 ### SharedArrayBuffers
 `twrWasmModuleAsync` uses SharedArrayBuffers which require certain HTTP headers to be set. Note that `twrWasmModule` has an advantage in that it does **not** use SharedArrayBuffers.

--- a/docs/examples/examples-helloworld.md
+++ b/docs/examples/examples-helloworld.md
@@ -4,7 +4,7 @@ description: Simple C example prints to an HTML div tag using WebAssembly with t
 ---
 
 # Hello World - WebAssembly C Example
-This example is an very simple twr-wasm program.  It uses WebAssembly and C to print "hello, world!" to an HTML `<div>` tag.
+This example is a very simple twr-wasm program.  It uses WebAssembly and C to print "hello, world!" to an HTML `<div>` tag.
 
 Also see: [Hello World - Step-by-Step C to Wasm](../gettingstarted/helloworld.md).
 

--- a/docs/examples/examples-multi-io.md
+++ b/docs/examples/examples-multi-io.md
@@ -11,7 +11,7 @@ This example demos six simultaneous consoles:
 - Two "`<canvas> ` tag as a character terminal"
 - Two "`<canvas> ` tag  as 2D draw surface" consoles.
   
-The multi-io example also demonstrates:
+The multi-io example also demos:
 
 * Creating consoles in JavaScript/TypeScript
 * Using consoles in C/C++ and JavaScript/TypeScript

--- a/docs/examples/examples-stdio-canvas.md
+++ b/docs/examples/examples-stdio-canvas.md
@@ -1,6 +1,6 @@
 ---
 title: WebAssembly Example of a Terminal Using a Canvas Tag
-description: This WebAssembly C example demos a character "terminal" with input and output direct to a <canvas> tag using twr-wasm
+description: This WebAssembly C example demos a character 'terminal' with input and output direct to a <canvas> tag using twr-wasm
 ---
 
 # stdio-canvas - Terminal Using a Canvas Tag

--- a/docs/gettingstarted/charencoding.md
+++ b/docs/gettingstarted/charencoding.md
@@ -21,7 +21,7 @@ twr-wasm supports ASCII, UNICODE, and extended-ASCII (in the form of Windows-125
 
 These days UNICODE with UTF-8 encoding is the most popular method of displaying and encoding text. UTF-8 is popular because it has the deep character glyph definitions of UNICODE with an encoding that provides (a) the best backwards compatibility with ASCII, and (b) a compact memory footprint.  It does this at the expense of some multibyte complexities.
 
-UTF-8 is variable length, and uses between one to four bytes to represent any unicode code point, with ASCII compatibility in the first 128 bytes.  It is also the standard for the web, and the default for clang. But because UTF-8 uses a variable number of bytes per character it can make string manipulation in C a bit harder than ASCII, Windows-1252 or UTF-32.
+UTF-8 is variable length, and uses between one to four bytes to represent any unicode code point, with ASCII compatibility in the first 128 characters.  It is also the standard for the web, and the default for clang. But because UTF-8 uses a variable number of bytes per character it can make string manipulation in C a bit harder than ASCII, Windows-1252 or UTF-32.
 
 In this document you will see the term "locale". This term originated (at least as its commonly used in programming) in the standard C library, and is also used in the standard C++ library (libc++ in twr-wasm).  A locale refers to a region of the world, along with a specific character encoding. The twr-wasm standard c runtime uses a label akin to this to define a locale: `en-US.UTF-8`. Of note is that libc++ and the standard C runtime have different domains for their locales (ie, they don't directly impact each other).  You can learn more about locales by searching the internet. 
 

--- a/docs/gettingstarted/compiler-opts.md
+++ b/docs/gettingstarted/compiler-opts.md
@@ -4,7 +4,7 @@ description: Learn to compile and link a WebAssembly module using clang and wasm
 ---
 
 # Compiling, Linking, and Memory Options
-This section described how to use `clang` to compile C/C++ code for WebAssembly, and how to use `wasm-ld` to link your files into a .wasm module, when using twr-wasm.
+This section describes how to use `clang` to compile C/C++ code for WebAssembly, and how to use `wasm-ld` to link your files into a .wasm module, when using twr-wasm.
 
 twr-wasm lets you use clang directly, without a wrapper.  This section describes the needed clang compile options and the wasm-ld link options.  You can also take a look at the [example makefiles](../examples/examples-overview.md).
 

--- a/docs/gettingstarted/debugging.md
+++ b/docs/gettingstarted/debugging.md
@@ -15,7 +15,7 @@ libc++.a is not built with debug symbols.
 In order to enable C/C++ source debugging with Wasm and clang, do the following:
 
 1. Use Chrome
-2. Install the Chrome extension: C/C++ DevTools Support (DWARF) ( https://chromewebstore.google.com/detail/pdcpmagijalfljmkmjngeonclgbbannb )
+2. Install the Chrome extension: [C/C++ DevTools Support (DWARF)](https://chromewebstore.google.com/detail/pdcpmagijalfljmkmjngeonclgbbannb)
 3. Use the clang compile flag -g to add debug annotation to your object files
 4. You may want to turn off optimization to allow the debugger to have a bit more logical behavior (remove the `-O` flag or set to `-O0`) 
 5. You may want to use the version of the twr-wasm C library that has debug symbols enabled (twrd.a).  Only if you want to step into the twrd.a source.


### PR DESCRIPTION
As the title said, I proof read all of the documentation and corrected typos or formatting issues as I found them.

One thing to note, it seems like mkdocs doesn't properly sanitize the description field as [https://twiddlingbits.dev/docsite/examples/examples-stdio-canvas/](https://twiddlingbits.dev/docsite/examples/examples-stdio-canvas/) shows an extra little bar near the top with the last part of the description. The fix was to simply change "terminal" to 'terminal'.