### PR TITLE
Improved Docs and Renamed tests-d2d test case

### DIFF
--- a/examples/tests-d2d/tests-d2d.c
+++ b/examples/tests-d2d/tests-d2d.c
@@ -129,7 +129,7 @@ enum Test {
    CreateLinearGradient, //also tests releaseid, setfillstylegradient, and addColorStop
    CreateRadialGradient,
 
-   ImageDataAndPutImageData,
+   CToImageDataAndPutImageData,
    LoadAndDrawImage,
    
    GetCanvasPropDouble,
@@ -189,7 +189,7 @@ const char* test_strs[50] = {
    "CreateLinearGradient",
    "CreateRadialGradient",
 
-   "ImageDataAndPutImageData",
+   "CToImageDataAndPutImageData",
    "LoadAndDrawImage",
    
    "GetCanvasPropDouble",
@@ -618,7 +618,7 @@ void test_case(int id, bool first_run) {
       }
       break;
 
-      case ImageDataAndPutImageData:
+      case CToImageDataAndPutImageData:
       {
          #define base_width 3
          #define base_height 3


### PR DESCRIPTION
* Imporved api-c-d2d.md docs example for d2d_drawimage and d2d_releaseid
* Renamed tests-d2d test case for ImageDataAndPutImageData to CToImageDataAndPutImageData since d2d_imagedata was depreciated in favor of d2d_imagedatatoc