### PR TITLE
Minor Improvements to d2d-tests Font Hashes and Minor Pong Change

### DIFF
--- a/examples/pong/pong.cpp
+++ b/examples/pong/pong.cpp
@@ -135,7 +135,6 @@ void Pong::render() {
         this->renderEndGame();
     }
     this->canvas.endDrawSequence();
-    printf("avail: %ld\n", avail());
 }
 void Pong::renderBackground() {
    #ifdef ASYNC

--- a/examples/tests-d2d/tests-d2d.c
+++ b/examples/tests-d2d/tests-d2d.c
@@ -355,9 +355,17 @@ void test_case(int id, bool first_run) {
 
       case SetFont:
       {
-         d2d_setfont(ds, "48px serif");
-         d2d_filltext(ds, "Test Text", 50.0, 50.0);
-         test_img_hash(ds, first_run, test_strs[id], 0xA04DF203);
+         const char* font = "48px serif";
+         d2d_setfont(ds, font);
+         char out[15] = {0};
+         d2d_getcanvaspropstring(ds, "font", out, 15);
+         if (first_run) {
+            if (strcmp(font, out) == 0) {
+               printf("%s test was successful!\n", test_strs[id]);
+            } else {
+               printf("%s test failed! Expected %s got %s\n", test_strs[id], font, out);
+            }
+         }
       }
       break;
 


### PR DESCRIPTION
* Added multiple hash support for testing and added multiple hashes (My Laptop, My Desktop, and the hashes you sent) for each of the text-based tests so they can be tested at least between our devices.
* Switched SetFont to test against d2d_getcanvaspropstring to avoid the above issue
  * Though, as a side note, should some of the functions like setFont, setFillStyle, setStrokeStyle, setLineCap, SetLineJoin, etc be deprecated in favor of d2d_getcanvaspropstring and d2d_getcanvaspropdouble or should they be left be? 
* removed available memory printf statement from Ping