### PR TITLE
Module Seperation, Signed WasmMemory views, and minor fixes

### DIFF
--- a/docs/api/api-c-d2d.md
+++ b/docs/api/api-c-d2d.md
@@ -206,6 +206,8 @@ double d2d_getcanvaspropdouble(struct d2d_draw_seq* ds, const char* prop_name);
 void d2d_getcanvaspropstring(struct d2d_draw_seq* ds, const char* prop_name, char* buffer, unsigned long buffer_len);
 void d2d_setcanvaspropdouble(struct d2d_draw_seq* ds, const char* prop_name, double val);
 void d2d_setcanvaspropstring(struct d2d_draw_seq* ds, const char* prop_name, const char* val);
+
+int d2d_idexists(struct d2d_draw_seq* ds, long id);
 ~~~
 
 d2d_measuretext() returns this structure:

--- a/docs/api/api-c-d2d.md
+++ b/docs/api/api-c-d2d.md
@@ -207,7 +207,7 @@ void d2d_getcanvaspropstring(struct d2d_draw_seq* ds, const char* prop_name, cha
 void d2d_setcanvaspropdouble(struct d2d_draw_seq* ds, const char* prop_name, double val);
 void d2d_setcanvaspropstring(struct d2d_draw_seq* ds, const char* prop_name, const char* val);
 
-int d2d_idexists(struct d2d_draw_seq* ds, long id);
+int d2d_doesidexist(struct d2d_draw_seq* ds, long id);
 ~~~
 
 d2d_measuretext() returns this structure:

--- a/examples/multi-io/multi-io-mod.c
+++ b/examples/multi-io/multi-io-mod.c
@@ -46,10 +46,22 @@ void multi() {
    struct d2d_draw_seq* ds=d2d_start_draw_sequence_with_con(100, draw1);
    d2d_setfillstyle(ds, "lightblue");
    d2d_fillrect(ds, 110, 10, 100, 100);
+   if (d2d_idexists(ds, 1)) {
+      twr_conlog("Error! Canvas object 1 in draw1 shouldn't be shared with the base multi-io module!");
+      abort();
+   }
+   d2d_getimagedata(ds, 1, 10, 10, 100*3, 100);
+   d2d_putimagedata(ds, 1, 10, 100 + 30);
    d2d_end_draw_sequence(ds);
 
    ds=d2d_start_draw_sequence_with_con(100, draw2);
    d2d_setfillstyle(ds, "#FF6666");  // lightred
    d2d_fillrect(ds, 110, 10, 100, 100);
+   if (d2d_idexists(ds, 1)) {
+      twr_conlog("Error! Canvas object 1 in draw2 shouldn't be shared with the base multi-io module!");
+      abort();
+   }
+   d2d_getimagedata(ds, 1, 10, 10, 100*3, 100);
+   d2d_putimagedata(ds, 1, 10, 100 + 30);
    d2d_end_draw_sequence(ds);   
 }

--- a/examples/multi-io/multi-io-mod.c
+++ b/examples/multi-io/multi-io-mod.c
@@ -46,7 +46,7 @@ void multi() {
    struct d2d_draw_seq* ds=d2d_start_draw_sequence_with_con(100, draw1);
    d2d_setfillstyle(ds, "lightblue");
    d2d_fillrect(ds, 110, 10, 100, 100);
-   if (d2d_idexists(ds, 1)) {
+   if (d2d_doesidexist(ds, 1)) {
       twr_conlog("Error! Canvas object 1 in draw1 shouldn't be shared with the base multi-io module!");
       abort();
    }
@@ -57,7 +57,7 @@ void multi() {
    ds=d2d_start_draw_sequence_with_con(100, draw2);
    d2d_setfillstyle(ds, "#FF6666");  // lightred
    d2d_fillrect(ds, 110, 10, 100, 100);
-   if (d2d_idexists(ds, 1)) {
+   if (d2d_doesidexist(ds, 1)) {
       twr_conlog("Error! Canvas object 1 in draw2 shouldn't be shared with the base multi-io module!");
       abort();
    }

--- a/examples/multi-io/multi-io.c
+++ b/examples/multi-io/multi-io.c
@@ -65,6 +65,10 @@ void multi() {
    struct d2d_draw_seq* ds=d2d_start_draw_sequence_with_con(100, draw1);
    d2d_setfillstyle(ds, "blue");
    d2d_fillrect(ds, 10, 10, 100, 100);
+   if (d2d_idexists(ds, 1)) {
+      twr_conlog("Error! Canvas object 1 shouldn't exist for draw1 yet!");
+      abort();
+   }
    d2d_getimagedata(ds, 1, 10, 10, 100, 100);
    d2d_putimagedata(ds, 1, 10 + 100*2, 10);
    d2d_end_draw_sequence(ds);
@@ -72,6 +76,10 @@ void multi() {
    ds=d2d_start_draw_sequence_with_con(100, draw2);
    d2d_setfillstyle(ds, "red");
    d2d_fillrect(ds, 10, 10, 100, 100);
+   if (d2d_idexists(ds, 1)) {
+      twr_conlog("Error! Canvas object 1 shouldn't exist for draw2 yet!");
+      abort();
+   }
    d2d_getimagedata(ds, 1, 10, 10, 100, 100);
    d2d_putimagedata(ds, 1, 10 + 100*2, 10);
    d2d_end_draw_sequence(ds);

--- a/examples/multi-io/multi-io.c
+++ b/examples/multi-io/multi-io.c
@@ -65,11 +65,15 @@ void multi() {
    struct d2d_draw_seq* ds=d2d_start_draw_sequence_with_con(100, draw1);
    d2d_setfillstyle(ds, "blue");
    d2d_fillrect(ds, 10, 10, 100, 100);
+   d2d_getimagedata(ds, 1, 10, 10, 100, 100);
+   d2d_putimagedata(ds, 1, 10 + 100*2, 10);
    d2d_end_draw_sequence(ds);
 
    ds=d2d_start_draw_sequence_with_con(100, draw2);
    d2d_setfillstyle(ds, "red");
    d2d_fillrect(ds, 10, 10, 100, 100);
+   d2d_getimagedata(ds, 1, 10, 10, 100, 100);
+   d2d_putimagedata(ds, 1, 10 + 100*2, 10);
    d2d_end_draw_sequence(ds);
 
    char buffer[100];

--- a/examples/multi-io/multi-io.c
+++ b/examples/multi-io/multi-io.c
@@ -65,7 +65,7 @@ void multi() {
    struct d2d_draw_seq* ds=d2d_start_draw_sequence_with_con(100, draw1);
    d2d_setfillstyle(ds, "blue");
    d2d_fillrect(ds, 10, 10, 100, 100);
-   if (d2d_idexists(ds, 1)) {
+   if (d2d_doesidexist(ds, 1)) {
       twr_conlog("Error! Canvas object 1 shouldn't exist for draw1 yet!");
       abort();
    }
@@ -76,7 +76,7 @@ void multi() {
    ds=d2d_start_draw_sequence_with_con(100, draw2);
    d2d_setfillstyle(ds, "red");
    d2d_fillrect(ds, 10, 10, 100, 100);
-   if (d2d_idexists(ds, 1)) {
+   if (d2d_doesidexist(ds, 1)) {
       twr_conlog("Error! Canvas object 1 shouldn't exist for draw2 yet!");
       abort();
    }

--- a/examples/pong/index.html
+++ b/examples/pong/index.html
@@ -16,6 +16,14 @@
         <a id="control_text"></a>
 
         <script type="module">
+            const urlParams = new URLSearchParams(document.location.search);
+            const gameType = urlParams.get("type");
+            //resize canvas for singlePlayer pong
+            if (gameType == "singlePlayer") {
+               const canvas = document.getElementById("twr_d2dcanvas");
+               canvas.width = 600;
+               canvas.height = 600;
+            }
             import {twrWasmModule, twrWasmModuleAsync} from "twr-wasm";
 
             import jsEventsLib from "./out/jsEventsLib.js"  // libraries use default export

--- a/examples/tests-audio/index.html
+++ b/examples/tests-audio/index.html
@@ -27,7 +27,6 @@
             import {twrWasmModule, twrWasmModuleAsync} from "twr-wasm";
             import clearIODivLib from "./out/clearIODiv.js";
 
-            // const timerLibInit = new timerLib();
             const clearIODivLibInit = new clearIODivLib;
 
             const is_async = window.location.hash=="#async";
@@ -52,28 +51,6 @@
             test_button.onclick = async () => {
                await mod.callC(["testCase", test_select.selectedIndex]);
             }
-
-            // const numTests = await mod.callC(["get_num_tests"])
-            // for (let i = 0; i < numTests; i++) {
-            //    let option = document.createElement("OPTION");
-            //    const testName = mod.getString(await mod.callC(["get_test_name", i]));
-            //    option.innerText = testName;
-            //    option.value = testName;
-            //    test_select.appendChild(option);
-            // }
-
-            // await mod.callC(["test_all"]);
-
-            // test_all_button.onclick = async () => {
-            //    io.innerHTML = "";
-            //    await mod.callC(["test_all"]);
-            // };
-
-            // test_button.onclick = async () => {
-            //    io.innerHTML = "";
-            //    await mod.callC(["test_specific", test_select.selectedIndex]);
-            // }
-
 
         </script>
     </body>

--- a/examples/tests-audio/index.html
+++ b/examples/tests-audio/index.html
@@ -16,7 +16,6 @@
          <button id="test_button">Test</button>
          <button id="test_all_button">Test All</button>
         <div id="twr_iodiv"></div>
-        <canvas id="twr_d2dcanvas" width="600" height="600"></canvas>
 
         <script type="module">
             "use strict";

--- a/examples/tests-d2d/tests-d2d.c
+++ b/examples/tests-d2d/tests-d2d.c
@@ -151,6 +151,7 @@ enum Test {
    CreateLinearGradient, //also tests releaseid, setfillstylegradient, and addColorStop
    CreateRadialGradient,
 
+   GetImageDataAndPutImageData,
    CToImageDataAndPutImageData,
    LoadAndDrawImage,
    LoadAndDrawCroppedImage,
@@ -216,6 +217,7 @@ const char* test_strs[55] = {
    "CreateLinearGradient",
    "CreateRadialGradient",
 
+   "GetImageDataAndPutImageData",
    "CToImageDataAndPutImageData",
    "LoadAndDrawImage",
    "LoadAndDrawCroppedImage",
@@ -726,6 +728,30 @@ void test_case(int id, bool first_run) {
          d2d_releaseid(ds, 1);
 
          test_img_hash(ds, first_run, test_strs[id], 0x44CD7BC4);
+      }
+      break;
+
+      case GetImageDataAndPutImageData:
+      {
+         //draws checkered red, blue tiles in 3x3 grid
+         d2d_setfillstyle(ds, "red");
+         d2d_fillrect(ds, 10, 10, 50, 50); //top-left
+         d2d_fillrect(ds, 10 + 50*2, 10, 50, 50); //top-right
+         d2d_fillrect(ds, 10 + 50*1, 10 + 50*1, 50, 50); //center
+         d2d_fillrect(ds, 10, 10 + 50*2, 50, 50); //bottom-left
+         d2d_fillrect(ds, 10 + 50*2, 10 + 50*2, 50, 50); //bottom-right
+
+         d2d_setfillstyle(ds, "blue");
+         d2d_fillrect(ds, 10 + 50*1, 10, 50, 50); //top-center
+         d2d_fillrect(ds, 10, 10 + 50*1, 50, 50); //center-left
+         d2d_fillrect(ds, 10 + 50*2, 10 + 50*1, 50, 50); //center-right
+         d2d_fillrect(ds, 10 + 50*1, 10 + 50*2, 50, 50); //bottom-center
+
+         d2d_getimagedata(ds, 350, 10, 10, 50*3, 50*3);
+         d2d_putimagedata(ds, 350, 250, 250);
+         d2d_releaseid(ds, 350);
+
+         test_img_hash(ds, first_run, test_strs[id], 0x0000000);
       }
       break;
 

--- a/examples/tests-d2d/tests-d2d.c
+++ b/examples/tests-d2d/tests-d2d.c
@@ -751,7 +751,7 @@ void test_case(int id, bool first_run) {
          d2d_putimagedata(ds, 350, 250, 250);
          d2d_releaseid(ds, 350);
 
-         test_img_hash(ds, first_run, test_strs[id], 0x0000000);
+         test_img_hash(ds, first_run, test_strs[id], 0x91E0A8C7);
       }
       break;
 

--- a/examples/tests-d2d/tests-d2d.c
+++ b/examples/tests-d2d/tests-d2d.c
@@ -100,6 +100,10 @@ void test_img_hash(struct d2d_draw_seq* ds, bool print_result, const char* test,
 }
 
 enum Test {
+   FailIDExists,
+   IDExists,
+   ReleaseIDAndIDExists,
+
    EmptyCanvas,
    FillRect,
    Reset,
@@ -157,10 +161,14 @@ enum Test {
    SetCanvasPropString,
 };
 
-const int START_TEST = EmptyCanvas;
+const int START_TEST = FailIDExists;
 const int END_TEST = SetCanvasPropString;
 
-const char* test_strs[50] = {
+const char* test_strs[55] = {
+   "FailIDExists",
+   "IDExists",
+   "ReleaseIDAndIDExists",
+
    "EmptyCanvas",
    "FillRect",
    "Reset",
@@ -223,6 +231,56 @@ void test_case(int id, bool first_run) {
    d2d_reset(ds);
 
    switch (id) {
+      case FailIDExists:
+      {
+         const long TEST_ID = 210203;
+         if (!d2d_idexists(ds, TEST_ID)) {
+            if (first_run)
+               printf("%s test was successful!\n", test_strs[id]);
+         } else {
+            if (first_run)
+               printf("%s test failed! An Object with ID %ld shouldn't exist!\n", test_strs[id], TEST_ID);
+         }
+      }
+      break;
+
+      case IDExists:
+      {
+         const long TEST_ID = 3042034;
+         d2d_getimagedata(ds, TEST_ID, 0.0, 0.0, 25.0, 25.0);
+
+         if (d2d_idexists(ds, TEST_ID)) {
+            if (first_run)
+               printf("%s test was successful!\n", test_strs[id]);
+            d2d_releaseid(ds, TEST_ID);
+         } else {
+            if (first_run)
+               printf("%s test failed!\n", test_strs[id]);
+         }
+      }
+      break; 
+
+      case ReleaseIDAndIDExists:
+      {
+         const long TEST_ID = 530239;
+         d2d_getimagedata(ds, TEST_ID, 0.0, 0.0, 250, 25.0);
+         
+         if (d2d_idexists(ds, TEST_ID)) {
+            d2d_releaseid(ds, TEST_ID);
+            if (first_run) {
+               if (d2d_idexists(ds, TEST_ID)) {
+                  printf("%s test failed to release object!", test_strs[id]);
+               } else {
+                  printf("%s test was successful!\n", test_strs[id]);
+               }
+            }
+         } else {
+            if (first_run)
+               printf("%s test failed to create object with d2d_getimagedata (or check it's existance)!\n", test_strs[id]);
+         }
+      }
+      break;
+
       case EmptyCanvas:
       {
          test_img_hash(ds, first_run, test_strs[id], 0xEBF5A8C4);

--- a/examples/twr-cpp/canvas.cpp
+++ b/examples/twr-cpp/canvas.cpp
@@ -338,3 +338,8 @@ void twrCanvas::setCanvasPropString(const char* prop_name, const char* val) {
    assert(m_ds);
    d2d_setcanvaspropstring(m_ds, prop_name, val);
 }
+
+bool twrCanvas::idExists(long id) {
+   assert(m_ds);
+   return d2d_idexists(m_ds, id);
+}

--- a/examples/twr-cpp/canvas.cpp
+++ b/examples/twr-cpp/canvas.cpp
@@ -339,7 +339,7 @@ void twrCanvas::setCanvasPropString(const char* prop_name, const char* val) {
    d2d_setcanvaspropstring(m_ds, prop_name, val);
 }
 
-bool twrCanvas::idExists(long id) {
+bool twrCanvas::doesIDExist(long id) {
    assert(m_ds);
-   return d2d_idexists(m_ds, id);
+   return d2d_doesidexist(m_ds, id);
 }

--- a/examples/twr-cpp/canvas.h
+++ b/examples/twr-cpp/canvas.h
@@ -99,6 +99,8 @@ class twrCanvas {
     void setCanvasPropDouble(const char* prop_name, double val);
    void setCanvasPropString(const char* prop_name, const char* val);
 
+   bool idExists(long id);
+
 private:
   struct d2d_draw_seq *m_ds;
 

--- a/examples/twr-cpp/canvas.h
+++ b/examples/twr-cpp/canvas.h
@@ -99,7 +99,7 @@ class twrCanvas {
     void setCanvasPropDouble(const char* prop_name, double val);
    void setCanvasPropString(const char* prop_name, const char* val);
 
-   bool idExists(long id);
+   bool doesIDExist(long id);
 
 private:
   struct d2d_draw_seq *m_ds;

--- a/source/twr-c/draw2d.c
+++ b/source/twr-c/draw2d.c
@@ -695,3 +695,15 @@ void d2d_setcanvaspropstring(struct d2d_draw_seq* ds, const char* prop_name, con
 
    set_ptrs(ds, &r->hdr, (void*)r->prop_name, (void*)r->val);
 }
+
+long d2d_idexists(struct d2d_draw_seq* ds, long id) {
+   long exists = 0;
+   struct d2dins_idexists* r = twr_cache_malloc(sizeof(struct d2dins_idexists));
+   r->hdr.type = D2D_IDEXISTS;
+   r->id = id;
+   r->exists = &exists;
+   set_ptrs(ds, &r->hdr, NULL, NULL);
+   d2d_flush(ds);
+
+   return exists;
+}

--- a/source/twr-c/draw2d.c
+++ b/source/twr-c/draw2d.c
@@ -696,12 +696,12 @@ void d2d_setcanvaspropstring(struct d2d_draw_seq* ds, const char* prop_name, con
    set_ptrs(ds, &r->hdr, (void*)r->prop_name, (void*)r->val);
 }
 
-long d2d_idexists(struct d2d_draw_seq* ds, long id) {
+long d2d_doesidexist(struct d2d_draw_seq* ds, long id) {
    long exists = 0;
-   struct d2dins_idexists* r = twr_cache_malloc(sizeof(struct d2dins_idexists));
-   r->hdr.type = D2D_IDEXISTS;
+   struct d2dins_doesidexist* r = twr_cache_malloc(sizeof(struct d2dins_doesidexist));
+   r->hdr.type = D2D_DOESIDEXIST;
    r->id = id;
-   r->exists = &exists;
+   r->does_exist = &exists;
    set_ptrs(ds, &r->hdr, NULL, NULL);
    d2d_flush(ds);
 

--- a/source/twr-c/twr-draw2d.h
+++ b/source/twr-c/twr-draw2d.h
@@ -65,6 +65,7 @@ enum D2D_Types {
     D2D_GETCANVASPROPSTRING = 61,
     D2D_SETCANVASPROPDOUBLE = 62,
     D2D_SETCANVASPROPSTRING = 63,
+    D2D_IDEXISTS = 64,
 };
 
 #define RGB_TO_RGBA(x) ( ((x)<<8) | 0xFF)
@@ -400,6 +401,12 @@ struct d2dins_setcanvaspropstring {
    const char* prop_name;
 };
 
+struct d2dins_idexists {
+   struct d2d_instruction_hdr hdr;
+   long id;
+   long* exists;
+};
+
 struct d2d_draw_seq {
     struct d2d_instruction_hdr* start;
     struct d2d_instruction_hdr* last;
@@ -508,6 +515,8 @@ double d2d_getcanvaspropdouble(struct d2d_draw_seq* ds, const char* prop_name);
 void d2d_getcanvaspropstring(struct d2d_draw_seq* ds, const char* prop_name, char* buffer, unsigned long buffer_len);
 void d2d_setcanvaspropdouble(struct d2d_draw_seq* ds, const char* prop_name, double val);
 void d2d_setcanvaspropstring(struct d2d_draw_seq* ds, const char* prop_name, const char* val);
+
+long d2d_idexists(struct d2d_draw_seq* ds, long id);
 
 #ifdef __cplusplus
 }

--- a/source/twr-c/twr-draw2d.h
+++ b/source/twr-c/twr-draw2d.h
@@ -65,7 +65,7 @@ enum D2D_Types {
     D2D_GETCANVASPROPSTRING = 61,
     D2D_SETCANVASPROPDOUBLE = 62,
     D2D_SETCANVASPROPSTRING = 63,
-    D2D_IDEXISTS = 64,
+    D2D_DOESIDEXIST = 64,
 };
 
 #define RGB_TO_RGBA(x) ( ((x)<<8) | 0xFF)
@@ -401,10 +401,10 @@ struct d2dins_setcanvaspropstring {
    const char* prop_name;
 };
 
-struct d2dins_idexists {
+struct d2dins_doesidexist {
    struct d2d_instruction_hdr hdr;
    long id;
-   long* exists;
+   long* does_exist;
 };
 
 struct d2d_draw_seq {
@@ -516,7 +516,7 @@ void d2d_getcanvaspropstring(struct d2d_draw_seq* ds, const char* prop_name, cha
 void d2d_setcanvaspropdouble(struct d2d_draw_seq* ds, const char* prop_name, double val);
 void d2d_setcanvaspropstring(struct d2d_draw_seq* ds, const char* prop_name, const char* val);
 
-long d2d_idexists(struct d2d_draw_seq* ds, long id);
+long d2d_doesidexist(struct d2d_draw_seq* ds, long id);
 
 #ifdef __cplusplus
 }

--- a/source/twr-ts/twrconcanvas.ts
+++ b/source/twr-ts/twrconcanvas.ts
@@ -470,7 +470,6 @@ export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas {
                if (mod.isTwrWasmModuleAsync) {  // Uint8ClampedArray doesn't support shared memory, so copy the memory
                   //console.log("D2D_PUTIMAGEDATA wasmModuleAsync");
                   const z = this.precomputedObjects[fullID] as {mem8:Uint8Array, width:number, height:number}; // Uint8Array
-                  console.log(z);
                   const ca=Uint8ClampedArray.from(z.mem8);  // shallow copy
                   imgData=new ImageData(ca, z.width, z.height);
                }

--- a/source/twr-ts/twrconcanvas.ts
+++ b/source/twr-ts/twrconcanvas.ts
@@ -60,6 +60,7 @@ enum D2DType {
     D2D_GETCANVASPROPSTRING = 61,
     D2D_SETCANVASPROPDOUBLE = 62,
     D2D_SETCANVASPROPSTRING = 63,
+    D2D_IDEXISTS = 64,
 }
 
 function calculateID(mod:IWasmModule|IWasmModuleAsync, id: number) {
@@ -844,6 +845,18 @@ export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas {
                if (typeof prevVal != "string") throw new Error("D2D_SETCANVASPROPSTRING with property " + propName + " expected a string, got " + (typeof prevVal) + "!");
 
                (this.ctx as {[key: string]: any})[propName] = val;
+            }
+            break;
+
+            case D2DType.D2D_IDEXISTS:
+            {
+               const id = wasmMem.getLong(currentInsParams);
+               const existsPtr = wasmMem.getLong(currentInsParams + 4);
+
+               const fullID = calculateID(mod, id);
+               const exists = fullID in this.precomputedObjects;
+
+               wasmMem.setLong(existsPtr, exists ? 1 : 0);
             }
             break;
             

--- a/source/twr-ts/twrconcanvas.ts
+++ b/source/twr-ts/twrconcanvas.ts
@@ -60,7 +60,7 @@ enum D2DType {
     D2D_GETCANVASPROPSTRING = 61,
     D2D_SETCANVASPROPDOUBLE = 62,
     D2D_SETCANVASPROPSTRING = 63,
-    D2D_IDEXISTS = 64,
+    D2D_DOESIDEXIST = 64,
 }
 
 function calculateID(mod:IWasmModule|IWasmModuleAsync, id: number) {
@@ -862,7 +862,7 @@ export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas {
             }
             break;
 
-            case D2DType.D2D_IDEXISTS:
+            case D2DType.D2D_DOESIDEXIST:
             {
                const id = wasmMem.getLong(currentInsParams);
                const existsPtr = wasmMem.getLong(currentInsParams + 4);

--- a/source/twr-ts/twrlibaudio.ts
+++ b/source/twr-ts/twrlibaudio.ts
@@ -102,12 +102,13 @@ export default class twrLibAudio extends twrLibrary {
          const channelBuff = arrayBuffer.getChannelData(channel);
          const startPos = dataPtr/1.0 + channel*singleChannelDataLen;
 
-         const dataBuff = mod.wasmMem.mem8u.slice(startPos, startPos + singleChannelDataLen);
+         const dataBuff = mod.wasmMem.mem8.slice(startPos, startPos + singleChannelDataLen);
 
          for (let i = 0; i < singleChannelDataLen; i++) {
             //convert 8-bit PCM to float
             //data is signed, so it will also need to find the negatives
-            channelBuff[i] = dataBuff[i] > 127 ? (dataBuff[i] - 256)/128 : dataBuff[i]/128;
+            // channelBuff[i] = dataBuff[i] > 127 ? (dataBuff[i] - 256)/128 : dataBuff[i]/128;
+            channelBuff[i] = dataBuff[i]/128;
          }
       }
 
@@ -121,11 +122,12 @@ export default class twrLibAudio extends twrLibrary {
          const channelBuff = arrayBuffer.getChannelData(channel);
          const startPos = dataPtr/2.0 + channel*singleChannelDataLen;
 
-         const dataBuff = mod.wasmMem.mem16u.slice(startPos, startPos + singleChannelDataLen);
+         const dataBuff = mod.wasmMem.mem16.slice(startPos, startPos + singleChannelDataLen);
 
          for (let i = 0; i < singleChannelDataLen*2; i += 2) {
             //convert 16-bit PCM to float
-            channelBuff[i] = dataBuff[i] > 32767 ? (dataBuff[i] - 65536)/32768 : dataBuff[i]/32768;
+            // channelBuff[i] = dataBuff[i] > 32767 ? (dataBuff[i] - 65536)/32768 : dataBuff[i]/32768;
+            channelBuff[i] = dataBuff[i]/32768;
          }
       }
 
@@ -139,11 +141,12 @@ export default class twrLibAudio extends twrLibrary {
          const channelBuff = arrayBuffer.getChannelData(channel);
          const startPos = dataPtr/4.0 + channel*singleChannelDataLen;
 
-         const dataBuff = mod.wasmMem.mem32u.slice(startPos, startPos + singleChannelDataLen);
+         const dataBuff = mod.wasmMem.mem32.slice(startPos, startPos + singleChannelDataLen);
 
          for (let i = 0; i < singleChannelDataLen; i++) {
             //convert 32-bit PCM to float
-            channelBuff[i] = dataBuff[i] > 2147483647 ? (dataBuff[i] - 4294967296)/2147483648 : dataBuff[i]/2147483648;
+            // channelBuff[i] = dataBuff[i] > 2147483647 ? (dataBuff[i] - 4294967296)/2147483648 : dataBuff[i]/2147483648;
+            channelBuff[i] = dataBuff[i]/2147483648;
          }
       }
 

--- a/source/twr-ts/twrlibaudio.ts
+++ b/source/twr-ts/twrlibaudio.ts
@@ -106,8 +106,6 @@ export default class twrLibAudio extends twrLibrary {
 
          for (let i = 0; i < singleChannelDataLen; i++) {
             //convert 8-bit PCM to float
-            //data is signed, so it will also need to find the negatives
-            // channelBuff[i] = dataBuff[i] > 127 ? (dataBuff[i] - 256)/128 : dataBuff[i]/128;
             channelBuff[i] = dataBuff[i]/128;
          }
       }
@@ -126,7 +124,6 @@ export default class twrLibAudio extends twrLibrary {
 
          for (let i = 0; i < singleChannelDataLen*2; i += 2) {
             //convert 16-bit PCM to float
-            // channelBuff[i] = dataBuff[i] > 32767 ? (dataBuff[i] - 65536)/32768 : dataBuff[i]/32768;
             channelBuff[i] = dataBuff[i]/32768;
          }
       }
@@ -145,7 +142,6 @@ export default class twrLibAudio extends twrLibrary {
 
          for (let i = 0; i < singleChannelDataLen; i++) {
             //convert 32-bit PCM to float
-            // channelBuff[i] = dataBuff[i] > 2147483647 ? (dataBuff[i] - 4294967296)/2147483648 : dataBuff[i]/2147483648;
             channelBuff[i] = dataBuff[i]/2147483648;
          }
       }

--- a/source/twr-ts/twrmod.ts
+++ b/source/twr-ts/twrmod.ts
@@ -3,7 +3,7 @@ import {IConsole, logToCon} from "./twrcon.js"
 import {twrLibraryInstanceRegistry} from "./twrlibrary.js";
 import {IWasmMemory} from './twrwasmmem.js'
 import {twrWasmCall} from "./twrwasmcall.js"
-import {twrWasmBase, TOnEventCallback} from "./twrwasmbase.js"
+import {twrWasmBase, TOnEventCallback, getNextModuleID} from "./twrwasmbase.js"
 import {twrEventQueueReceive} from "./twreventqueue.js"
 import {twrLibBuiltIns} from "./twrlibbuiltin.js"
 
@@ -45,6 +45,7 @@ export interface IWasmModule {
    fetchAndPutURL: (fnin:URL)=>Promise<[number, number]>;
    divLog:(...params: string[])=>void;
    log:(...params: string[])=>void;
+   readonly id: number;
 }
 
 
@@ -82,6 +83,7 @@ export class twrWasmModule extends twrWasmBase implements IWasmModule {
    putU8!:(u8a:Uint8Array)=>number;
    putArrayBuffer!:(ab:ArrayBuffer)=>number;
 
+   readonly id: number;
    /*********************************************************************/
 
    constructor(opts:IModOpts={}) {
@@ -89,6 +91,8 @@ export class twrWasmModule extends twrWasmBase implements IWasmModule {
       [this.io, this.ioNamesToID] = parseModOptions(opts);
       this.log=logToCon.bind(undefined, this.io.stdio);
       this.divLog=this.log;
+
+      this.id = getNextModuleID();
    }
 
    /*********************************************************************/

--- a/source/twr-ts/twrmod.ts
+++ b/source/twr-ts/twrmod.ts
@@ -3,7 +3,7 @@ import {IConsole, logToCon} from "./twrcon.js"
 import {twrLibraryInstanceRegistry} from "./twrlibrary.js";
 import {IWasmMemory} from './twrwasmmem.js'
 import {twrWasmCall} from "./twrwasmcall.js"
-import {twrWasmBase, TOnEventCallback, getNextModuleID} from "./twrwasmbase.js"
+import {twrWasmBase, TOnEventCallback} from "./twrwasmbase.js"
 import {twrEventQueueReceive} from "./twreventqueue.js"
 import {twrLibBuiltIns} from "./twrlibbuiltin.js"
 
@@ -92,7 +92,7 @@ export class twrWasmModule extends twrWasmBase implements IWasmModule {
       this.log=logToCon.bind(undefined, this.io.stdio);
       this.divLog=this.log;
 
-      this.id = getNextModuleID();
+      this.id = ++twrWasmBase.uniqueID;
    }
 
    /*********************************************************************/

--- a/source/twr-ts/twrmodasync.ts
+++ b/source/twr-ts/twrmodasync.ts
@@ -6,6 +6,7 @@ import {twrWasmModuleCallAsync, TCallCAsync, TCallCImplAsync } from "./twrwasmca
 import {TLibraryMessage, TLibraryProxyParams, twrLibraryInstanceRegistry} from "./twrlibrary.js"
 import {twrEventQueueSend} from "./twreventqueue.js"
 import {twrLibBuiltIns} from "./twrlibbuiltin.js"
+import { getNextModuleID } from "./twrwasmbase.js";
 
 // class twrWasmModuleAsync consist of two parts:
 //   twrWasmModuleAsync runs in the main JavaScript event loop
@@ -56,6 +57,7 @@ export interface IWasmModuleAsync {
    fetchAndPutURL: (fnin:URL)=>Promise<[number, number]>;
    divLog:(...params: string[])=>void;
    log:(...params: string[])=>void;
+   readonly id: number;
 }
 
 export type TModAsyncProxyStartupMsg = {
@@ -111,7 +113,10 @@ export class twrWasmModuleAsync implements IWasmModuleAsync {
    putU8!:(u8a:Uint8Array)=>Promise<number>;
    putArrayBuffer!:(ab:ArrayBuffer)=>Promise<number>;
 
+   readonly id: number;
+
    constructor(opts?:IModOpts) {
+      this.id = getNextModuleID();
 
       [this.io, this.ioNamesToID] = parseModOptions(opts);
 

--- a/source/twr-ts/twrmodasync.ts
+++ b/source/twr-ts/twrmodasync.ts
@@ -6,7 +6,7 @@ import {twrWasmModuleCallAsync, TCallCAsync, TCallCImplAsync } from "./twrwasmca
 import {TLibraryMessage, TLibraryProxyParams, twrLibraryInstanceRegistry} from "./twrlibrary.js"
 import {twrEventQueueSend} from "./twreventqueue.js"
 import {twrLibBuiltIns} from "./twrlibbuiltin.js"
-import { getNextModuleID } from "./twrwasmbase.js";
+import {twrWasmBase} from "./twrwasmbase.js";
 
 // class twrWasmModuleAsync consist of two parts:
 //   twrWasmModuleAsync runs in the main JavaScript event loop
@@ -116,7 +116,7 @@ export class twrWasmModuleAsync implements IWasmModuleAsync {
    readonly id: number;
 
    constructor(opts?:IModOpts) {
-      this.id = getNextModuleID();
+      this.id = ++twrWasmBase.uniqueID;
 
       [this.io, this.ioNamesToID] = parseModOptions(opts);
 

--- a/source/twr-ts/twrwasmbase.ts
+++ b/source/twr-ts/twrwasmbase.ts
@@ -79,3 +79,8 @@ export abstract class twrWasmBase {
    }
 
 }
+
+let nextModuleID = 0;
+export function getNextModuleID() {
+   return nextModuleID++;
+}

--- a/source/twr-ts/twrwasmbase.ts
+++ b/source/twr-ts/twrwasmbase.ts
@@ -17,6 +17,8 @@ export abstract class twrWasmBase {
    callC!:twrWasmCall["callC"];
    abstract ioNamesToID: {[key: string]: number};
 
+   static uniqueID: number = 0;
+
 
    /*********************************************************************/
 
@@ -78,9 +80,4 @@ export abstract class twrWasmBase {
          return -1;
    }
 
-}
-
-let nextModuleID = 0;
-export function getNextModuleID() {
-   return nextModuleID++;
 }

--- a/source/twr-ts/twrwasmmem.ts
+++ b/source/twr-ts/twrwasmmem.ts
@@ -6,7 +6,9 @@ export interface IWasmMemoryBase {
    mem8u:Uint8Array;
    mem8:Int8Array;
    mem16u:Uint16Array;
+   mem16:Int16Array;
    mem32u:Uint32Array;
+   mem32:Int32Array;
    memF:Float32Array;
    memD:Float64Array;
    stringToU8(sin:string, codePage?:number):Uint8Array;
@@ -50,7 +52,9 @@ export class twrWasmMemoryBase implements IWasmMemoryBase {
    mem8u:Uint8Array;
    mem8:Int8Array;
    mem16u:Uint16Array;
+   mem16:Int16Array;
    mem32u:Uint32Array;
+   mem32:Int32Array;
    memF:Float32Array;
    memD:Float64Array;
 
@@ -59,7 +63,9 @@ export class twrWasmMemoryBase implements IWasmMemoryBase {
       this.mem8u = new Uint8Array(memory.buffer);
       this.mem8 = new Int8Array(memory.buffer);
       this.mem16u = new Uint16Array(memory.buffer);
+      this.mem16 = new Int16Array(memory.buffer);
       this.mem32u = new Uint32Array(memory.buffer);
+      this.mem32 = new Int32Array(memory.buffer);
       this.memF = new Float32Array(memory.buffer);
       this.memD = new Float64Array(memory.buffer);
    }


### PR DESCRIPTION
Module Separation: #22 
* As suggested in the linked issue, I added an ID to both IWasmModule and IWasmModuleAsync that use a shared getNextModuleID function so every module has their own unique ID.
* I used this ID to separate precomputed objects in twrconcanvas between modules. This was done via combining the precomputed object ID and the module ID into a 52 bit key (22 bits for module ID, 32 for object ID) to index the precomputed objects list.
* I did something similar for the audio node and playback lists in the audio library.

Signed WasmMemory views: #52 
* Added signed views for 8, 16, and 32 bit integers in WasmMemory
* Renamed the previous unsigned views to mem8u, mem16u, and mem32u respectively with the signed views taking the old names
* Used the signed views in the audio library rather than converting it to signed by hand
* TODO: Ensure the documentation is up to date

Minor Fixes:
* Removed canvas from tests-audio that was copied over during setup
* Fixed initial problem with #38 using the fact that the deeplinks in pong cause a refresh allowing the canvas to be resized before initializing the wasm module. Linked issue should probably be renamed or have the later stuff be split into it's own issue so it can be closed.
* Fixed an issue where PutImageData was incompatible with getImageData while using an AsyncModule 