### PR TITLE
Changes and Example with twr-con-window

### DIFF
--- a/examples/pong/entry-point.cpp
+++ b/examples/pong/entry-point.cpp
@@ -11,39 +11,43 @@ static int ANIMATION_LOOP_EVENT_ID = -1;
 static int KEY_DOWN_EVENT_ID = -1;
 static int KEY_UP_EVENT_ID = -1;
 extern "C" {
-   __attribute__((import_name("registerKeyUpEvent")))
-   void register_key_up_event(int event_id);
+   // __attribute__((import_name("registerKeyUpEvent")))
+   // void register_key_up_event(int event_id);
 
-   __attribute__((import_name("registerKeyDownEvent")))
-   void register_key_down_event(int event_id);
+   // __attribute__((import_name("registerKeyDownEvent")))
+   // void register_key_down_event(int event_id);
 
    __attribute__((import_name("registerAnimationLoop")))
    void register_animation_loop(int event_id);
 
-   __attribute__((import_name("registerMouseMoveEvent")))
-   void register_mouse_move_event(int event_id, const char* element_id, bool relative);
+   // __attribute__((import_name("registerMouseMoveEvent")))
+   // void register_mouse_move_event(int event_id, const char* element_id, bool relative);
 
-   __attribute__((import_name("registerMousePressEvent")))
-   void register_mouse_press_event(int event_id, const char* element_id, bool relative);
+   // __attribute__((import_name("registerMousePressEvent")))
+   // void register_mouse_press_event(int event_id, const char* element_id, bool relative);
 
 
 
    __attribute__((export_name("initMenu")))
    void init_menu() {
       MOUSE_MOVE_EVENT_ID = twr_register_callback("menuMouseMoveCallback");
-      register_mouse_move_event(MOUSE_MOVE_EVENT_ID, "twr_d2dcanvas", true);
+      // register_mouse_move_event(MOUSE_MOVE_EVENT_ID, "twr_d2dcanvas", true);
+      d2d_register_event(D2D_MOUSE_MOVE, MOUSE_MOVE_EVENT_ID);
 
       MOUSE_PRESS_EVENT_ID = twr_register_callback("menuMousePressCallback");
-      register_mouse_press_event(MOUSE_PRESS_EVENT_ID, "twr_d2dcanvas", true);
+      // register_mouse_press_event(MOUSE_PRESS_EVENT_ID, "twr_d2dcanvas", true);
+      d2d_register_event(D2D_MOUSE_DOWN, MOUSE_PRESS_EVENT_ID);
 
       ANIMATION_LOOP_EVENT_ID = twr_register_callback("menuAnimationLoopCallback");
       register_animation_loop(ANIMATION_LOOP_EVENT_ID);
 
       KEY_DOWN_EVENT_ID = twr_register_callback("menuKeyDownCallback");
-      register_key_down_event(KEY_DOWN_EVENT_ID);
+      // register_key_down_event(KEY_DOWN_EVENT_ID);
+      d2d_register_event(D2D_KEY_DOWN, KEY_DOWN_EVENT_ID);
 
       KEY_UP_EVENT_ID = twr_register_callback("menuKeyUpCallback");
-      register_key_up_event(KEY_UP_EVENT_ID);
+      // register_key_up_event(KEY_UP_EVENT_ID);
+      d2d_register_event(D2D_KEY_UP, KEY_UP_EVENT_ID);
 
       menu.setBounds(d2d_get_canvas_prop("canvasWidth"), d2d_get_canvas_prop("canvasHeight"));
    }

--- a/examples/pong/entry-point.cpp
+++ b/examples/pong/entry-point.cpp
@@ -17,8 +17,8 @@ extern "C" {
    // __attribute__((import_name("registerKeyDownEvent")))
    // void register_key_down_event(int event_id);
 
-   __attribute__((import_name("registerAnimationLoop")))
-   void register_animation_loop(int event_id);
+   // __attribute__((import_name("registerAnimationLoop")))
+   // void register_animation_loop(int event_id);
 
    // __attribute__((import_name("registerMouseMoveEvent")))
    // void register_mouse_move_event(int event_id, const char* element_id, bool relative);
@@ -39,7 +39,8 @@ extern "C" {
       d2d_register_event(D2D_MOUSE_DOWN, MOUSE_PRESS_EVENT_ID);
 
       ANIMATION_LOOP_EVENT_ID = twr_register_callback("menuAnimationLoopCallback");
-      register_animation_loop(ANIMATION_LOOP_EVENT_ID);
+      // register_animation_loop(ANIMATION_LOOP_EVENT_ID);
+      d2d_register_event(D2D_ANIMATION_FRAME, ANIMATION_LOOP_EVENT_ID);
 
       KEY_DOWN_EVENT_ID = twr_register_callback("menuKeyDownCallback");
       // register_key_down_event(KEY_DOWN_EVENT_ID);

--- a/examples/pong/index.html
+++ b/examples/pong/index.html
@@ -12,7 +12,7 @@
         </script>
     </head>
     <body>
-        <canvas id="twr_d2dcanvas" width="900" height="600"></canvas><br>
+        <canvas id="twr_d2dcanvas" width="900" height="600" tabindex="1"></canvas><br>
         <a id="control_text"></a>
 
         <script type="module">

--- a/examples/window/Makefile
+++ b/examples/window/Makefile
@@ -8,14 +8,21 @@ $(info $(shell mkdir -p out))
 
 .PHONY: default
 
-default: window.wasm
+default: window.wasm window-a.wasm
 
 window.o: window.c
 	$(CC) $(CFLAGS)  $< -o $@
 
+window-a.o: window.c
+	$(CC) $(CFLAGS)  $< -o $@ -DASYNC
+
 window.wasm: window.o
 	wasm-ld  window.o ../../lib-c/twr.a -o window.wasm \
 		--no-entry --initial-memory=4063232 --max-memory=4063232 \
+
+window-a.wasm: window-a.o
+	wasm-ld window-a.o ../../lib-c/twr.a -o window-a.wasm \
+		--no-entry --shared-memory --no-check-features --initial-memory=4063232 --max-memory=4063232 \
 
 clean:
 	rm -f *.o

--- a/examples/window/Makefile
+++ b/examples/window/Makefile
@@ -1,0 +1,23 @@
+CC := clang
+TWRCFLAGS := --target=wasm32 -nostdinc -nostdlib -isystem  ../../include
+CPPLIB := ../twr-cpp
+CFLAGS := -c -Wall -O3 $(TWRCFLAGS) -I $(CPPLIB)
+CFLAGS_DEBUG := -c -Wall -g -O0  $(TWRCFLAGS) -I $(CPPLIB)
+
+$(info $(shell mkdir -p out))
+
+.PHONY: default
+
+default: window.wasm
+
+window.o: window.c
+	$(CC) $(CFLAGS)  $< -o $@
+
+window.wasm: window.o
+	wasm-ld  window.o ../../lib-c/twr.a -o window.wasm \
+		--no-entry --initial-memory=4063232 --max-memory=4063232 \
+
+clean:
+	rm -f *.o
+	rm -f *.wasm
+	rm -f out/*

--- a/examples/window/index.html
+++ b/examples/window/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Audio Tests</title>
+
+        <script type="importmap">
+            {
+                "imports": {
+                    "twr-wasm": "../../lib-js/index.js"
+                }
+            }
+        </script>
+    </head>
+    <body>
+         <canvas id="window" width="640px" height="480px"></canvas>
+
+         <script type="module">
+            "use strict";
+            
+            import {twrWasmModule, twrWasmModuleAsync, twrConsoleWindow} from "twr-wasm";
+
+            const is_async = window.location.hash=="#async";
+
+            const modCon = is_async ? twrWasmModuleAsync : twrWasmModule;
+            const mod = new modCon({io:{
+               window: new twrConsoleWindow(document.getElementById("window"))
+            }});
+            await mod.loadWasm("./window.wasm");
+
+            await mod.callC(["init"]);
+            
+         </script>
+    </body>
+</html>

--- a/examples/window/index.html
+++ b/examples/window/index.html
@@ -12,7 +12,9 @@
         </script>
     </head>
     <body>
-         <canvas id="window" width="640px" height="480px" tabindex="1"></canvas>
+         <div id="window-resizable-div" style="resize:both;overflow:hidden;width:640px;height:480px;min-width:200px;min-height:200px;">
+            <canvas id="window" width="640px" height="480px" tabindex="1"></canvas>
+         </div>
 
          <script type="module">
             "use strict";
@@ -23,7 +25,9 @@
 
             const modCon = is_async ? twrWasmModuleAsync : twrWasmModule;
 
-            const windowConsole = new twrConsoleWindow(document.getElementById("window"));
+            const windowCanvas = document.getElementById("window");
+            if (windowCanvas == undefined) throw new Error(`Window example: Couldn't find window canvas!`);
+            const windowConsole = new twrConsoleWindow(windowCanvas);
             const mod = new modCon({io:{
                window: windowConsole,
             }});
@@ -31,7 +35,22 @@
 
             await mod.callC(["init"]);
             
-            window.windowConsole = windowConsole;
+            const windowDiv = document.getElementById("window-resizable-div");
+            if (windowDiv == undefined) throw new Error(`Window example: couldn't find window canvas div!`);
+            // window.windowConsole = windowConsole;
+            let prevDivWidth = windowDiv.clientWidth;
+            let prevDivHeight = windowDiv.clientHeight;
+            let resizeObserver = new ResizeObserver(() => {
+               const width = windowDiv.clientWidth;
+               const height = windowDiv.clientHeight;
+               if (width != prevDivWidth || height != prevDivHeight) {
+                  prevDivWidth = width;
+                  prevDivHeight = height;
+                  console.log(`resizing: ${width}, ${height}`);
+                  windowConsole.resizeWindow(width, height);
+               }
+            });
+            resizeObserver.observe(windowDiv);
          </script>
     </body>
 </html>

--- a/examples/window/index.html
+++ b/examples/window/index.html
@@ -22,13 +22,16 @@
             const is_async = window.location.hash=="#async";
 
             const modCon = is_async ? twrWasmModuleAsync : twrWasmModule;
+
+            const windowConsole = new twrConsoleWindow(document.getElementById("window"));
             const mod = new modCon({io:{
-               window: new twrConsoleWindow(document.getElementById("window"))
+               window: windowConsole,
             }});
             await mod.loadWasm(is_async ? "./window-a.wasm" : "./window.wasm");
 
             await mod.callC(["init"]);
             
+            window.windowConsole = windowConsole;
          </script>
     </body>
 </html>

--- a/examples/window/index.html
+++ b/examples/window/index.html
@@ -12,7 +12,7 @@
         </script>
     </head>
     <body>
-         <canvas id="window" width="640px" height="480px"></canvas>
+         <canvas id="window" width="640px" height="480px" tabindex="1"></canvas>
 
          <script type="module">
             "use strict";

--- a/examples/window/index.html
+++ b/examples/window/index.html
@@ -25,7 +25,7 @@
             const mod = new modCon({io:{
                window: new twrConsoleWindow(document.getElementById("window"))
             }});
-            await mod.loadWasm("./window.wasm");
+            await mod.loadWasm(is_async ? "./window-a.wasm" : "./window.wasm");
 
             await mod.callC(["init"]);
             

--- a/examples/window/package.json
+++ b/examples/window/package.json
@@ -1,0 +1,11 @@
+{
+   "@parcel/resolver-default": {
+        "packageExports": true
+   },
+   "alias": {
+        "twr-wasm": "../../lib-js/index.js"
+   },
+   "dependencies": {
+        "twr-wasm": "^2.0.0"
+   }
+}

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -1,0 +1,60 @@
+#include "twr-window.h"
+#include "twr-draw2d.h"
+#include "twr-crt.h"
+#include "stdlib.h"
+
+twr_ioconsole_t* window_con = NULL;
+twr_ioconsole_t* canvas_con = NULL;
+
+long canvas_width = 0;
+long canvas_height = 0;
+
+
+__attribute__((export_name("init")))
+void init() {
+   if (window_con)
+      free(window_con);
+   
+   if (canvas_con)
+      free(canvas_con);
+   
+   window_con = twr_get_console("window");
+   canvas_con = twr_window_get_app_canvas(window_con);
+
+   twr_set_std2d_con(canvas_con);
+
+   canvas_width = io_get_prop(canvas_con, "canvasWidth");
+   canvas_height = io_get_prop(canvas_con, "canvasHeight");
+
+   int ANIMATION_EVENT = twr_register_callback("animationFrame");
+   d2d_register_event(D2D_ANIMATION_FRAME, ANIMATION_EVENT);
+
+   int MOUSE_MOVE_EVENT = twr_register_callback("mouseMoveHandler");
+   d2d_register_event(D2D_MOUSE_MOVE, MOUSE_MOVE_EVENT);
+}
+
+int square_x = 75;
+int square_y = 75;
+int SQUARE_WIDTH = 50;
+int SQUARE_HEIGHT = 50;
+
+__attribute__((export_name("animationFrame")))
+void animation_frame(int id, int delta) {
+   struct d2d_draw_seq* ds = d2d_start_draw_sequence(100);
+
+   d2d_clearrect(ds, 0, 0, 1000, 1000);
+
+   d2d_setfillstylergba(ds, 0x00FF00FF);
+   d2d_fillrect(ds, 0, 0, canvas_width, canvas_height);
+
+   d2d_setfillstylergba(ds, 0xFF0000FF);
+   d2d_fillrect(ds, square_x, square_y, SQUARE_WIDTH, SQUARE_HEIGHT);
+
+   d2d_end_draw_sequence(ds);
+}
+
+__attribute__((export_name("mouseMoveHandler")))
+void mouse_move_handler(int id, int x, int y) {
+   square_x = x - SQUARE_WIDTH/2.0;
+   square_y = y - SQUARE_HEIGHT/2.0;
+}

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -10,6 +10,10 @@ long canvas_width = 0;
 long canvas_height = 0;
 
 
+struct twr_window_widget red_box_button;
+struct twr_window_widget blue_box_button;
+unsigned long box_color = 0xFF0000FF;
+
 __attribute__((export_name("init")))
 void init() {
    if (window_con)
@@ -32,8 +36,67 @@ void init() {
    int MOUSE_MOVE_EVENT = twr_register_callback("mouseMoveHandler");
    d2d_register_event(D2D_MOUSE_MOVE, MOUSE_MOVE_EVENT);
 
-   twr_window_add_menu(window_con, "test");
-   twr_window_add_menu(window_con, "test_two");
+   struct twr_window_menu box_color_menu = twr_window_add_menu(window_con, "Box Color");
+   struct twr_window_menu test_two_menu = twr_window_add_menu(window_con, "test_two");
+
+   struct twr_widget_button_constructor red_box_button_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_BUTTON,
+         .x = 0,
+         .y = 0,
+         .width = -1,
+         .height = 20
+      },
+      .text = "Red",
+      .text_font = "14px Seriph",
+      .text_color = NULL,
+      .button_color = NULL,
+      .selected_button_color = NULL
+   };
+   red_box_button = twr_window_menu_add_widget(&box_color_menu, &red_box_button_cons.base);
+   
+   struct twr_widget_seperator_constructor seperator_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_SEPERATOR,
+         .x = 0,
+         .y = 0,
+         .width = -1,
+         .height = 10
+      },
+      .seperator_text = "-",
+      .seperator_font = NULL,
+      .seperator_color = NULL,
+   };
+   struct twr_window_widget seperator1 = twr_window_menu_add_widget(&box_color_menu, &seperator_cons.base);
+
+   struct twr_widget_button_constructor blue_box_button_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_BUTTON,
+         .x = 0,
+         .y = 0,
+         .width = -1,
+         .height = 20
+      },
+      .text = "Blue",
+      .text_font = "14px Seriph",
+      .text_color = NULL,
+      .button_color = NULL,
+      .selected_button_color = NULL
+   };
+   blue_box_button = twr_window_menu_add_widget(&box_color_menu, &blue_box_button_cons.base);
+
+   int button_callback = twr_register_callback("buttonPressed");
+   twr_window_menu_button_add_callback(&red_box_button, button_callback, (void*)(&red_box_button));
+   twr_window_menu_button_add_callback(&blue_box_button, button_callback, (void*)(&blue_box_button));
+}
+
+__attribute__((export_name("buttonPressed")))
+void button_pressed(int event_id, struct twr_window_widget* button) {
+   if (button->widget_id == red_box_button.widget_id) {
+      box_color = 0xFF0000FF;
+   } else if (button->widget_id == blue_box_button.widget_id) {
+      box_color = 0x0000FFFF;
+   }
 }
 
 int square_x = 75;
@@ -50,7 +113,7 @@ void animation_frame(int id, int delta) {
    d2d_setfillstylergba(ds, 0x00FF00FF);
    d2d_fillrect(ds, 0, 0, canvas_width, canvas_height);
 
-   d2d_setfillstylergba(ds, 0xFF0000FF);
+   d2d_setfillstylergba(ds, box_color);
    d2d_fillrect(ds, square_x, square_y, SQUARE_WIDTH, SQUARE_HEIGHT);
 
    d2d_end_draw_sequence(ds);

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -335,7 +335,7 @@ void setup_prop_menu(struct twr_window_widget *prop_menu) {
          .type = WINDOW_WIDGET_SUB_MENU
       },
       .button_text = "Setters",
-      .min_child_height = -1,
+      .minimum_child_height = -1,
       .minimum_menu_height = -1,
       .minimum_menu_width = -1,
    };
@@ -356,27 +356,37 @@ void setup_prop_menu(struct twr_window_widget *prop_menu) {
          .widget = modified_prop_heap,
       };
       if (prop_data->prop_details->access & WINDOW_WIDGET_PROP_GET) {
-         struct twr_widget_button_constructor get_button_cons = {
-            .base = {
-               .height = 10,
-               .width = -1,
-               .type = WINDOW_WIDGET_BUTTON
-            },
-            .text = prop_data->prop_details->name
-         };
-         struct twr_window_widget get_button = twr_window_menu_add_widget(&getter_menu, &get_button_cons.base);
+         // struct twr_widget_button_constructor get_button_cons = {
+         //    .base = {
+         //       .height = 10,
+         //       .width = -1,
+         //       .type = WINDOW_WIDGET_BUTTON
+         //    },
+         //    .text = prop_data->prop_details->name
+         // };
+         struct twr_window_widget get_button = twr_window_menu_add_button_widget(
+            &getter_menu, 
+            -1, 10, 
+            prop_data->prop_details->name
+         );
+         // struct twr_window_widget get_button = twr_window_menu_add_widget(&getter_menu, &get_button_cons.base);
          twr_window_menu_widget_add_callback(&get_button, getter_event_id, (void*)prop_data);
       }
       if (prop_data->prop_details->access & WINDOW_WIDGET_PROP_SET) {
-         struct twr_widget_button_constructor set_button_cons = {
-            .base = {
-               .height = 10,
-               .width = -1,
-               .type = WINDOW_WIDGET_BUTTON
-            },
-            .text = prop_data->prop_details->name
-         };
-         struct twr_window_widget set_button = twr_window_menu_add_widget(&setter_menu, &set_button_cons.base);
+         // struct twr_widget_button_constructor set_button_cons = {
+         //    .base = {
+         //       .height = 10,
+         //       .width = -1,
+         //       .type = WINDOW_WIDGET_BUTTON
+         //    },
+         //    .text = prop_data->prop_details->name
+         // };
+         // struct twr_window_widget set_button = twr_window_menu_add_widget(&setter_menu, &set_button_cons.base);
+         struct twr_window_widget set_button = twr_window_menu_add_button_widget(
+            &setter_menu,
+            -1, 10,
+            prop_data->prop_details->name
+         );
          twr_window_menu_widget_add_callback(&set_button, setter_event_id, (void*)prop_data);
       }
    }
@@ -437,7 +447,7 @@ void setup_box_options_menu(struct twr_window_widget* box_options_menu) {
       },
       .button_text = "Box Color",
       
-      .min_child_height = -1,
+      .minimum_child_height = -1,
       .minimum_menu_height = -1,
       .minimum_menu_width = -1,
       
@@ -462,15 +472,19 @@ void setup_box_options_menu(struct twr_window_widget* box_options_menu) {
 
 __attribute__((export_name("spawnButtonPressed")))
 void spawn_button_pressed(int event_id, void* ptr) {
-   struct twr_widget_button_constructor new_button_con = {
-      .base = {
-         .width = -1,
-         .height = 20,
-      },
-      .text = "Delete!",
-   };
-   struct twr_window_widget button = twr_window_menu_add_widget(&test_two_menu, &new_button_con.base);
-
+   // struct twr_widget_button_constructor new_button_con = {
+   //    .base = {
+   //       .width = -1,
+   //       .height = 20,
+   //    },
+   //    .text = "Delete!",
+   // };
+   // struct twr_window_widget button = twr_window_menu_add_widget(&test_two_menu, &new_button_con.base);
+   struct twr_window_widget button = twr_window_menu_add_button_widget(
+      &test_two_menu,
+      -1, 10,
+      "Delete!"
+   );
    struct twr_window_widget* heap_button = (struct twr_window_widget*)malloc(sizeof(struct twr_window_widget));
    memcpy(heap_button, &button, sizeof(struct twr_window_widget));
 
@@ -497,16 +511,21 @@ void delete_button_pressed(int event_id, struct twr_window_widget* button) {
 }
 
 void setup_test_two_menu(struct twr_window_widget *test_two_menu) {
-   struct twr_widget_button_constructor spawn_button_constructor = {
-      .base = {
-         .type = WINDOW_WIDGET_BUTTON,
-         .width = -1,
-         .height = 20
-      },
-      .text = "Spawn New Button",
-   };
-   spawn_button = twr_window_menu_add_widget(test_two_menu, &spawn_button_constructor.base);
-   
+   // struct twr_widget_button_constructor spawn_button_constructor = {
+   //    .base = {
+   //       .type = WINDOW_WIDGET_BUTTON,
+   //       .width = -1,
+   //       .height = 20
+   //    },
+   //    .text = "Spawn New Button",
+   // };
+   // spawn_button = twr_window_menu_add_widget(test_two_menu, &spawn_button_constructor.base);
+   spawn_button = twr_window_menu_add_button_widget(
+      test_two_menu,
+      -1, 10,
+      "Spawn New Button"
+   );
+
    int spawn_button_callback = twr_register_callback("spawnButtonPressed");
    twr_window_menu_widget_add_callback(&spawn_button, spawn_button_callback, (void*)0);
    delete_button_callback = twr_register_callback("deleteButtonPressed");
@@ -635,15 +654,20 @@ void setup_extra_menu(struct twr_window_widget *extra_menu) {
    twr_window_menu_widget_add_callback(&extra_center_dot_checkbox, extra_center_dot_event_id, (void*)0);
    extra_widget_array->arr[1] = extra_center_dot_checkbox;
 
-   struct twr_widget_button_constructor randomize_center_dot_color_cons = {
-      .base = {
-         .type = WINDOW_WIDGET_BUTTON,
-         .width = -1,
-         .height = 20,
-      },
-      .text = "Randomize Center Dot Color"
-   };
-   struct twr_window_widget randomize_center_dot_color = twr_window_menu_add_widget(extra_menu, &randomize_center_dot_color_cons.base);
+   // struct twr_widget_button_constructor randomize_center_dot_color_cons = {
+   //    .base = {
+   //       .type = WINDOW_WIDGET_BUTTON,
+   //       .width = -1,
+   //       .height = 20,
+   //    },
+   //    .text = "Randomize Center Dot Color"
+   // };
+   // struct twr_window_widget randomize_center_dot_color = twr_window_menu_add_widget(extra_menu, &randomize_center_dot_color_cons.base);
+   struct twr_window_widget randomize_center_dot_color = twr_window_menu_add_button_widget(
+      extra_menu,
+      -1, 20,
+      "Randomize Center Dot Color"
+   );
    int randomize_center_dot_color_event_id = twr_register_callback("randomizeCenterDotColorCallback");
    twr_window_menu_widget_add_callback(&randomize_center_dot_color, randomize_center_dot_color_event_id, (void*)0);
    extra_widget_array->arr[2] = randomize_center_dot_color;
@@ -654,7 +678,7 @@ void setup_extra_menu(struct twr_window_widget *extra_menu) {
          .height = 20,
          .width = -1,
       },
-      .min_child_height = -1,
+      .minimum_child_height = -1,
       .minimum_menu_height = -1,
       .minimum_menu_width = -1,
       .button_text = "Box Movement"

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -196,27 +196,59 @@ void init() {
    };
    struct twr_window_widget box_color_sub_menu = twr_window_menu_add_widget(&box_color_menu, &sub_menu.base);
 
-   struct twr_widget_radio_menu_constructor radio_menu_constructor = {
-      .base = {
-         .type = WINDOW_WIDGET_RADIO_MENU,
-         .width = -1,
-         .height = -1,
-      },
-      .minimum_height = 10,
-      .minimum_width = 10,
-      .option_height = 20,
-      .selected_symbol = "*",
-   };
-   struct twr_window_widget radio_menu = twr_window_menu_add_widget(&box_color_sub_menu, &radio_menu_constructor.base);
-   twr_window_menu_radio_menu_add_option(&radio_menu, "Red");
-   twr_window_menu_radio_menu_add_option(&radio_menu, "Blue");
-   twr_window_menu_radio_menu_add_option(&radio_menu, "Magenta");
-   twr_window_menu_radio_menu_add_option(&radio_menu, "Yellow");
-   twr_window_menu_radio_menu_add_option(&radio_menu, "Cyan");
-   twr_window_menu_radio_menu_add_option(&radio_menu, "Teal");
+   // struct twr_widget_radio_menu_constructor radio_menu_constructor = {
+   //    .base = {
+   //       .type = WINDOW_WIDGET_RADIO_MENU,
+   //       .width = -1,
+   //       .height = -1,
+   //    },
+   //    .minimum_height = 10,
+   //    .minimum_width = 10,
+   //    .option_height = 20,
+   //    .selected_symbol = "*",
+   // };
+   // struct twr_window_widget radio_menu = twr_window_menu_add_widget(&box_color_sub_menu, &radio_menu_constructor.base);
+   // twr_window_menu_radio_menu_add_option(&radio_menu, "Red");
+   // twr_window_menu_radio_menu_add_option(&radio_menu, "Blue");
+   // twr_window_menu_radio_menu_add_option(&radio_menu, "Magenta");
+   // twr_window_menu_radio_menu_add_option(&radio_menu, "Yellow");
+   // twr_window_menu_radio_menu_add_option(&radio_menu, "Cyan");
+   // twr_window_menu_radio_menu_add_option(&radio_menu, "Teal");
 
+   // int box_color_event = twr_register_callback("boxColorChanged");
+   // twr_window_menu_widget_add_callback(&radio_menu, box_color_event, (void*)0);
+   const char* BOX_COLOR_NAMES[20] = {
+      "Red",
+      "Blue",
+      "Magenta",
+      "Yellow",
+      "Cyan",
+      "Teal"
+   };
+   const int* BOX_COLOR_VALUES = {
+      0xFF0000FF,
+      0x0000FFFF,
+      0xFF00FFFF,
+      0xFFFF00FF,
+      0x00FFFFFF,
+      0x008080FF
+   };
    int box_color_event = twr_register_callback("boxColorChanged");
-   twr_window_menu_widget_add_callback(&radio_menu, box_color_event, (void*)0);
+   struct twr_window_widget main_widget;
+   for (int i = 0; i < 6; i++) {
+      struct twr_widget_radio_item_constructor radio_item_constructor = {
+         .base = {
+            .type = WINDOW_WIDGET_RADIO_ITEM,
+            .width = -1,
+            .height = 10,
+         },
+         .text = BOX_COLOR_NAMES[i],
+      };
+      struct twr_window_widget radioItem = twr_window_menu_add_widget(&box_color_sub_menu, &radio_item_constructor.base);
+      twr_window_menu_widget_add_callback(&radioItem, box_color_event, (void*)(BOX_COLOR_VALUES[i])
+   }
+
+   
 
    struct twr_widget_check_box_constructor check_box_constructor = {
       .base = {

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -11,8 +11,8 @@ long canvas_width = 0;
 long canvas_height = 0;
 
 
-struct twr_window_menu box_color_menu;
-struct twr_window_menu test_two_menu;
+struct twr_window_widget box_color_menu;
+struct twr_window_widget test_two_menu;
 
 unsigned long box_color = 0xFF0000FF;
 
@@ -41,14 +41,12 @@ void init() {
    int MOUSE_MOVE_EVENT = twr_register_callback("mouseMoveHandler");
    d2d_register_event(D2D_MOUSE_MOVE, MOUSE_MOVE_EVENT);
 
-   box_color_menu = twr_window_add_menu(window_con, "Box Color");
+   box_color_menu = twr_window_add_menu(window_con, "Box Options");
    test_two_menu = twr_window_add_menu(window_con, "test_two");
 
    struct twr_widget_button_constructor spawn_button_constructor = {
       .base = {
          .type = WINDOW_WIDGET_BUTTON,
-         .x = 0,
-         .y = 0,
          .width = -1,
          .height = 20
       },
@@ -67,8 +65,6 @@ void init() {
    struct twr_widget_seperator_constructor seperator_cons = {
       .base = {
          .type = WINDOW_WIDGET_SEPERATOR,
-         .x = 0,
-         .y = 0,
          .width = -1,
          .height = 10
       },
@@ -81,12 +77,32 @@ void init() {
    
 
    // struct twr_window_menu radio_menu_header = twr_window_add_menu(window_con, "Radio_Menu");
-   
+   struct twr_widget_sub_menu_constructor sub_menu = {
+      .base = {
+         .type = WINDOW_WIDGET_SUB_MENU,
+         .width = 30,
+         .height = 20,
+      },
+      .button_color = NULL,
+      .selected_button_color = NULL,
+      .button_text = "Box Color",
+      .button_text_font = NULL,
+      .button_text_color = NULL,
+      
+      .menu_border_color = "Black",
+      .menu_border_width = 1.0,
+      .menu_color = NULL,
+      .menu_open_offset = 2.0,
+      .menu_y_padding = 0.0,
+      .min_child_height = 10,
+      .minimum_menu_height = 10,
+      .minimum_menu_width = 10,
+   };
+   struct twr_window_widget box_color_sub_menu = twr_window_menu_add_widget(&box_color_menu, &sub_menu.base);
+
    struct twr_widget_radio_menu_constructor radio_menu_constructor = {
       .base = {
          .type = WINDOW_WIDGET_RADIO_MENU,
-         .x = 0,
-         .y = 0,
          .width = -1,
          .height = -1,
       },
@@ -98,9 +114,10 @@ void init() {
       .option_text_color = "black",
       .option_text_font = "14px Seriph",
       .selected_symbol = "*",
+      .reserved_prefix_length = -1,
       .y_padding = 5,
    };
-   struct twr_window_widget radio_menu = twr_window_menu_add_widget(&box_color_menu, &radio_menu_constructor.base);
+   struct twr_window_widget radio_menu = twr_window_menu_add_widget(&box_color_sub_menu, &radio_menu_constructor.base);
    twr_window_menu_radio_menu_add_option(&radio_menu, "Red");
    twr_window_menu_radio_menu_add_option(&radio_menu, "Blue");
    twr_window_menu_radio_menu_add_option(&radio_menu, "Magenta");
@@ -110,14 +127,28 @@ void init() {
 
    int box_color_event = twr_register_callback("boxColorChanged");
    twr_window_menu_widget_add_callback(&radio_menu, box_color_event, (void*)0);
+
+   struct twr_widget_check_box_constructor check_box_constructor = {
+      .base = {
+         .type = WINDOW_WIDGET_CHECK_BOX,
+         .width = -1,
+         .height = 20
+      },
+      .button_color = NULL,
+      .checked_symbol = "[*]",
+      .unchecked_symbol = "[ ]",
+      .reserved_prefix_space = -1,
+      .selected_button_color = NULL,
+      .text = "Box Outline",
+      .text_color = NULL,
+      .text_font = NULL,
+   };
 }
 
 __attribute__((export_name("spawnButtonPressed")))
 void spawn_button_pressed(int event_id, void* ptr) {
    struct twr_widget_button_constructor new_button_con = {
       .base = {
-         .x = 0,
-         .y = 0,
          .width = -1,
          .height = 20,
       },

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -239,14 +239,11 @@ const int POPUP_TITLE_HEIGHT = 20;
 struct prop_menu_popup prop_menu_data = {
    .state = PROP_MENU_UNOPENED
 };
-__attribute__((export_name("windowPropMenuGetEvent")))
-void window_prop_menu_get_event(int event_id, struct prop_menu_data* prop_data) {
-   struct twr_widget_prop_value* val = twr_window_menu_widget_get_prop(prop_data->widget, prop_data->prop_details->name);
-
+void set_prop_menu_data_to_getter(const char* prop_name, const struct twr_widget_prop_value* val, enum prop_menu_target target) {
    prop_menu_data.state = PROP_MENU_GET;
-   prop_menu_data.target = PROP_MENU_TARGET_WIDGET;
+   prop_menu_data.target = target;
    // prop_menu_data.selected = PROP_MENU_SELECTED_NONE;
-   prop_menu_data.prop_name = prop_data->prop_details->name;
+   prop_menu_data.prop_name = prop_name;
    prop_menu_data.width = 200;
    prop_menu_data.height = BASE_PROP_MENU_HEIGHT + PROP_MENU_HEIGHT_PER_FIELD;
    switch (val->type) {
@@ -263,6 +260,12 @@ void window_prop_menu_get_event(int event_id, struct prop_menu_data* prop_data) 
          sprintf(prop_menu_data.text_buffer.text, "undefined");
       break;
    }
+}
+__attribute__((export_name("windowPropMenuGetEvent")))
+void window_prop_menu_get_event(int event_id, struct prop_menu_data* prop_data) {
+   struct twr_widget_prop_value* val = twr_window_menu_widget_get_prop(prop_data->widget, prop_data->prop_details->name);
+
+   set_prop_menu_data_to_getter(prop_data->prop_details->name, val, PROP_MENU_TARGET_WIDGET);
 
    free(val);
 }
@@ -271,12 +274,11 @@ unsigned int count_ones(unsigned int n) {
    for (; n > 0; n &= (n - 1), i++);
    return i;
 }
-__attribute__((export_name("windowPropMenuSetEvent")))
-void window_prop_menu_set_event(int event_id, struct prop_menu_data* prop_data) {
+void set_prop_menu_data_to_setter(const char* prop_name, struct twr_window_widget* widget, enum WindowWidgetPropVal combined_types, enum prop_menu_target target) {
    prop_menu_data = (struct prop_menu_popup){
-      .prop_name = prop_data->prop_details->name,
+      .prop_name = prop_name,
       .state = PROP_MENU_SET,
-      .target = PROP_MENU_TARGET_WIDGET,
+      .target = target,
       .text_buffer = (struct text_fill_buffer){
          .text = "",
          .length = 0
@@ -290,9 +292,9 @@ void window_prop_menu_set_event(int event_id, struct prop_menu_data* prop_data) 
       // .accepted_types_len = accepted_types_length,
       .accepted_types_len = 0,
       .selected_type = 0,
-      .widget = prop_data->widget,
+      .widget = widget,
       .width = 200,
-      .height = BASE_PROP_MENU_HEIGHT + PROP_MENU_HEIGHT_PER_FIELD * count_ones((unsigned int)prop_data->prop_details->type),
+      .height = BASE_PROP_MENU_HEIGHT + PROP_MENU_HEIGHT_PER_FIELD * count_ones((unsigned int)combined_types),
    };
    const int num_types = 4;
    const enum WindowWidgetPropVal types[] = {
@@ -302,7 +304,7 @@ void window_prop_menu_set_event(int event_id, struct prop_menu_data* prop_data) 
       WINDOW_WIDGET_PROP_UNDEFINED
    };
    for (int i = 0; i < num_types; i++) {
-      if (prop_data->prop_details->type & types[i]) {
+      if (combined_types & types[i]) {
          enum prop_menu_selected to_add;
          switch (types[i]) {
             case WINDOW_WIDGET_PROP_STRING:
@@ -324,6 +326,10 @@ void window_prop_menu_set_event(int event_id, struct prop_menu_data* prop_data) 
          prop_menu_data.accepted_types_len++;
       }
    }
+}
+__attribute__((export_name("windowPropMenuSetEvent")))
+void window_prop_menu_set_event(int event_id, struct prop_menu_data* prop_data) {
+   set_prop_menu_data_to_setter(prop_data->prop_details->name, prop_data->widget, prop_data->prop_details->type, PROP_MENU_TARGET_WIDGET);
 }
 void setup_prop_menu(struct twr_window_widget *prop_menu) {
    struct twr_window_widget modified_prop = twr_window_menu_add_check_box_widget(prop_menu, -1, 10, "Test Widget");
@@ -545,91 +551,26 @@ void setup_menu_prop_menu(struct twr_window_widget *menu_prop_menu) {
    long length = 0;
    struct twr_menu_prop_details* prop_list =  twr_window_menu_list_props(window_con, &length);
    
+   int getter_event_id = twr_register_callback("menuPropMenuGetterCallback");
+   int setter_event_id = twr_register_callback("menuPropMenuSetterCallback");
    for (long i = 0; i < length; i++) {
       struct twr_window_widget getter = twr_window_menu_add_button_widget(&getters, -1, 10, prop_list[i].name);
       struct twr_window_widget setter = twr_window_menu_add_button_widget(&setters, -1, 10, prop_list[i].name);
 
-
+      twr_window_menu_widget_add_callback(&getter, getter_event_id, (void*)&prop_list[i]);
+      twr_window_menu_widget_add_callback(&setter, setter_event_id, (void*)&prop_list[i]);
    }
 }
 
-__attribute__((export_name("menuPropMenuGetterCallback")))
-void menu_prop_menu_getter_callback(int event_id, struct twr_menu_prop_details* details) {
-   prop_menu_data = (struct prop_menu_popup){
-      .prop_name = details->name,
-      .state = PROP_MENU_SET,
-      .target = PROP_MENU_TARGET_MENU,
-      .text_buffer = (struct text_fill_buffer){
-         .text = "",
-         .length = 0
-      },
-      .number_buffer = (struct text_fill_buffer){
-         .text = "",
-         .length = 0
-      },
-      .number_buffer_has_dot = FALSE,
-      // .accepted_types = accepted_types,
-      // .accepted_types_len = accepted_types_length,
-      .accepted_types_len = 0,
-      .selected_type = 0,
-      .width = 200,
-      .height = BASE_PROP_MENU_HEIGHT + PROP_MENU_HEIGHT_PER_FIELD * count_ones((unsigned int)details->type),
-   };
-   const int num_types = 4;
-   const enum WindowWidgetPropVal types[] = {
-      WINDOW_WIDGET_PROP_STRING,
-      WINDOW_WIDGET_PROP_BOOLEAN,
-      WINDOW_WIDGET_PROP_NUMBER,
-      WINDOW_WIDGET_PROP_UNDEFINED
-   };
-   for (int i = 0; i < num_types; i++) {
-      if (details->type & types[i]) {
-         enum prop_menu_selected to_add;
-         switch (types[i]) {
-            case WINDOW_WIDGET_PROP_STRING:
-               to_add = PROP_MENU_SELECTED_STRING;
-            break;
-            case WINDOW_WIDGET_PROP_BOOLEAN:
-            prop_menu_data.accepted_types[prop_menu_data.accepted_types_len] = PROP_MENU_SELECTED_TRUE;
-               prop_menu_data.accepted_types_len++;
-               to_add = PROP_MENU_SELECTED_FALSE;
-            break;
-            case WINDOW_WIDGET_PROP_NUMBER:
-               to_add = PROP_MENU_SELECTED_NUMBER;
-            break;
-            case WINDOW_WIDGET_PROP_UNDEFINED:
-               to_add = PROP_MENU_SELECTED_UNDEFINED;
-            break;
-         }
-         prop_menu_data.accepted_types[prop_menu_data.accepted_types_len] = to_add;
-         prop_menu_data.accepted_types_len++;
-      }
-   }
-}
 __attribute__((export_name("menuPropMenuSetterCallback")))
 void menu_prop_menu_setter_callback(int event_id, struct twr_menu_prop_details* details) {
+   set_prop_menu_data_to_setter(details->name, NULL, details->type, PROP_MENU_TARGET_MENU);
+}
+__attribute__((export_name("menuPropMenuGetterCallback")))
+void menu_prop_menu_getter_callback(int event_id, struct twr_menu_prop_details* details) {
    struct twr_widget_prop_value* val = twr_window_menu_get_prop(window_con, details->name);
 
-   prop_menu_data.state = PROP_MENU_GET;
-   prop_menu_data.target = PROP_MENU_TARGET_MENU;
-   // prop_menu_data.selected = PROP_MENU_SELECTED_NONE;
-   prop_menu_data.prop_name = details->name;
-   prop_menu_data.width = 200;
-   prop_menu_data.height = BASE_PROP_MENU_HEIGHT + PROP_MENU_HEIGHT_PER_FIELD;
-   switch (val->type) {
-      case WINDOW_WIDGET_PROP_BOOLEAN:
-         sprintf(prop_menu_data.text_buffer.text, "%s", val->boolean ? "true" : "false");
-      break;
-      case WINDOW_WIDGET_PROP_NUMBER:
-         sprintf(prop_menu_data.text_buffer.text, "%f", val->number);
-      break;
-      case WINDOW_WIDGET_PROP_STRING:
-         sprintf(prop_menu_data.text_buffer.text, "%s", val->string);
-      break;
-      case WINDOW_WIDGET_PROP_UNDEFINED:
-         sprintf(prop_menu_data.text_buffer.text, "undefined");
-      break;
-   }
+   set_prop_menu_data_to_getter(details->name, val, PROP_MENU_TARGET_MENU);
 
    free(val);
 }
@@ -950,7 +891,7 @@ void key_event_handler(int id, int key) {
                      prop_menu_data.text_buffer.text
                   );
                } else if (target == PROP_MENU_TARGET_MENU) {
-                  twr_window_menu_set_string(
+                  twr_window_menu_set_prop_string(
                      window_con,
                      prop_menu_data.prop_name,
                      prop_menu_data.text_buffer.text
@@ -968,7 +909,7 @@ void key_event_handler(int id, int key) {
                      res
                   );
                } else {
-                  twr_window_menu_set_number(
+                  twr_window_menu_set_prop_number(
                      window_con,
                      prop_menu_data.prop_name,
                      res

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -2,6 +2,7 @@
 #include "twr-draw2d.h"
 #include "twr-crt.h"
 #include "stdlib.h"
+#include "string.h"
 
 twr_ioconsole_t* window_con = NULL;
 twr_ioconsole_t* canvas_con = NULL;
@@ -10,9 +11,15 @@ long canvas_width = 0;
 long canvas_height = 0;
 
 
+struct twr_window_menu box_color_menu;
+struct twr_window_menu test_two_menu;
+
 struct twr_window_widget red_box_button;
 struct twr_window_widget blue_box_button;
 unsigned long box_color = 0xFF0000FF;
+
+struct twr_window_widget spawn_button;
+int delete_button_callback;
 
 __attribute__((export_name("init")))
 void init() {
@@ -36,8 +43,8 @@ void init() {
    int MOUSE_MOVE_EVENT = twr_register_callback("mouseMoveHandler");
    d2d_register_event(D2D_MOUSE_MOVE, MOUSE_MOVE_EVENT);
 
-   struct twr_window_menu box_color_menu = twr_window_add_menu(window_con, "Box Color");
-   struct twr_window_menu test_two_menu = twr_window_add_menu(window_con, "test_two");
+   box_color_menu = twr_window_add_menu(window_con, "Box Color");
+   test_two_menu = twr_window_add_menu(window_con, "test_two");
 
    struct twr_widget_button_constructor red_box_button_cons = {
       .base = {
@@ -67,7 +74,7 @@ void init() {
       .seperator_font = NULL,
       .seperator_color = NULL,
    };
-   struct twr_window_widget seperator1 = twr_window_menu_add_widget(&box_color_menu, &seperator_cons.base);
+   twr_window_menu_add_widget(&box_color_menu, &seperator_cons.base);
 
    struct twr_widget_button_constructor blue_box_button_cons = {
       .base = {
@@ -88,6 +95,59 @@ void init() {
    int button_callback = twr_register_callback("buttonPressed");
    twr_window_menu_button_add_callback(&red_box_button, button_callback, (void*)(&red_box_button));
    twr_window_menu_button_add_callback(&blue_box_button, button_callback, (void*)(&blue_box_button));
+
+   struct twr_widget_button_constructor spawn_button_constructor = {
+      .base = {
+         .type = WINDOW_WIDGET_BUTTON,
+         .x = 0,
+         .y = 0,
+         .width = -1,
+         .height = 20
+      },
+      .text = "Spawn New Button",
+      .text_font = "14px Seriph",
+      .text_color = NULL,
+      .button_color = NULL,
+      .selected_button_color = NULL
+   };
+   spawn_button = twr_window_menu_add_widget(&test_two_menu, &spawn_button_constructor.base);
+   
+   int spawn_button_callback = twr_register_callback("spawnButtonPressed");
+   twr_window_menu_button_add_callback(&spawn_button, spawn_button_callback, (void*)0);
+   delete_button_callback = twr_register_callback("deleteButtonPressed");
+
+   twr_window_menu_add_widget(&test_two_menu, &seperator_cons.base);
+   
+}
+
+__attribute__((export_name("spawnButtonPressed")))
+void spawn_button_pressed(int event_id, void* ptr) {
+   struct twr_widget_button_constructor new_button_con = {
+      .base = {
+         .x = 0,
+         .y = 0,
+         .width = -1,
+         .height = 20,
+      },
+      .text = "Delete!",
+      .text_font = "14px Seriph",
+      .text_color = NULL,
+      .button_color = NULL,
+      .selected_button_color = NULL
+   };
+   struct twr_window_widget button = twr_window_menu_add_widget(&test_two_menu, &new_button_con.base);
+
+   struct twr_window_widget* heap_button = (struct twr_window_widget*)malloc(sizeof(struct twr_window_widget));
+   memcpy(heap_button, &button, sizeof(struct twr_window_widget));
+
+   printf("spawned new button: %d\n", button.widget_id);
+
+   twr_window_menu_button_add_callback(&button, delete_button_callback, (void*)heap_button);
+}
+__attribute__((export_name("deleteButtonPressed")))
+void delete_button_pressed(int event_id, struct twr_window_widget* button) {
+   twr_window_menu_delete_widget(button);
+   free(button);
 }
 
 __attribute__((export_name("buttonPressed")))

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -132,7 +132,7 @@ void init() {
       free(canvas_con);
    
    window_con = twr_get_console("window");
-   canvas_con = twr_window_get_app_canvas(window_con);
+   canvas_con = twr_window_get_draw_canvas(window_con);
 
    twr_set_std2d_con(canvas_con);
 
@@ -161,6 +161,9 @@ void init() {
    int KEY_PRESS_EVENT = twr_register_callback("keyEventHandler");
    d2d_register_event(D2D_KEY_DOWN, KEY_PRESS_EVENT);
 
+   int WINDOW_RESIZE_EVENT = twr_register_callback("windowResizeHandler");
+   twr_window_register_event(window_con, TWR_WINDOW_RESIZE_EVENT, WINDOW_RESIZE_EVENT);
+
 
 
    box_color_menu = twr_window_add_menu(window_con, "Box Options");
@@ -174,6 +177,14 @@ void init() {
    setup_extra_menu(&extra_menu);
    setup_prop_menu(&prop_menu);
    setup_menu_prop_menu(&menu_prop_menu);
+}
+
+__attribute__((export_name("windowResizeHandler")))
+void window_resize_handler(int event_id, long width, long height) {
+   canvas_width = io_get_prop(canvas_con, "canvasWidth");
+   canvas_height = io_get_prop(canvas_con, "canvasHeight");
+
+   printf("new canvas size: %ld, %ld\n", canvas_width, canvas_height);
 }
 
 struct prop_menu_data {

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -31,6 +31,9 @@ void init() {
 
    int MOUSE_MOVE_EVENT = twr_register_callback("mouseMoveHandler");
    d2d_register_event(D2D_MOUSE_MOVE, MOUSE_MOVE_EVENT);
+
+   twr_window_add_menu(window_con, "test");
+   twr_window_add_menu(window_con, "test_two");
 }
 
 int square_x = 75;

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -18,6 +18,7 @@ struct twr_window_widget extra_menu;
 struct twr_window_widget prop_menu;
 struct twr_window_widget menu_prop_menu;
 unsigned long box_color = 0xFF0000FF;
+const long WIDGET_HEIGHT = 15;
 int box_border = 0;
 
 #define COLORS_LEN 76
@@ -343,12 +344,12 @@ void window_prop_menu_set_event(int event_id, struct prop_menu_data* prop_data) 
    set_prop_menu_data_to_setter(prop_data->prop_details->name, prop_data->widget, prop_data->prop_details->type, PROP_MENU_TARGET_WIDGET);
 }
 void setup_prop_menu(struct twr_window_widget *prop_menu) {
-   struct twr_window_widget modified_prop = twr_window_menu_add_check_box_widget(prop_menu, -1, 10, "Test Widget");
+   struct twr_window_widget modified_prop = twr_window_menu_add_check_box_widget(prop_menu, WIDGET_HEIGHT, "Test Widget");
    struct twr_window_widget* modified_prop_heap = (struct twr_window_widget*)malloc(sizeof(struct twr_window_widget));
    *modified_prop_heap = modified_prop;
 
-   struct twr_window_widget setter_menu = twr_window_menu_add_sub_menu_widget_reduced(prop_menu, -1, 10, "Setters");
-   struct twr_window_widget getter_menu = twr_window_menu_add_sub_menu_widget_reduced(prop_menu, -1, 10, "Getters");
+   struct twr_window_widget setter_menu = twr_window_menu_add_sub_menu_widget_reduced(prop_menu, WIDGET_HEIGHT, "Setters");
+   struct twr_window_widget getter_menu = twr_window_menu_add_sub_menu_widget_reduced(prop_menu, WIDGET_HEIGHT, "Getters");
 
    
    long prop_len;
@@ -365,7 +366,7 @@ void setup_prop_menu(struct twr_window_widget *prop_menu) {
       if (prop_data->prop_details->access & WINDOW_WIDGET_PROP_GET) {
          struct twr_window_widget get_button = twr_window_menu_add_button_widget(
             &getter_menu, 
-            -1, 10, 
+            WIDGET_HEIGHT, 
             prop_data->prop_details->name
          );
          twr_window_menu_widget_add_callback(&get_button, getter_event_id, (void*)prop_data);
@@ -373,7 +374,7 @@ void setup_prop_menu(struct twr_window_widget *prop_menu) {
       if (prop_data->prop_details->access & WINDOW_WIDGET_PROP_SET) {
          struct twr_window_widget set_button = twr_window_menu_add_button_widget(
             &setter_menu,
-            -1, 10,
+            WIDGET_HEIGHT,
             prop_data->prop_details->name
          );
          twr_window_menu_widget_add_callback(&set_button, setter_event_id, (void*)prop_data);
@@ -409,7 +410,7 @@ void setup_box_color_sub_menu(struct twr_window_widget* box_color_sub_menu) {
    int box_color_event = twr_register_callback("boxColorChanged");
    struct twr_window_widget root_radio_item;
    for (int i = 0; i < 6; i++) {
-      struct twr_window_widget radioItem = twr_window_menu_add_radio_item_widget(box_color_sub_menu, -1, 10, BOX_COLOR_NAMES[i]);
+      struct twr_window_widget radioItem = twr_window_menu_add_radio_item_widget(box_color_sub_menu, WIDGET_HEIGHT, BOX_COLOR_NAMES[i]);
       twr_window_menu_widget_add_callback(&radioItem, box_color_event, (void*)(BOX_COLOR_VALUES[i]));
 
       if (i == 0) {
@@ -420,10 +421,10 @@ void setup_box_color_sub_menu(struct twr_window_widget* box_color_sub_menu) {
    }
 }
 void setup_box_options_menu(struct twr_window_widget* box_options_menu) {
-   struct twr_window_widget box_color_sub_menu = twr_window_menu_add_sub_menu_widget_reduced(box_options_menu, -1, 20, "Box Color");
+   struct twr_window_widget box_color_sub_menu = twr_window_menu_add_sub_menu_widget_reduced(box_options_menu, WIDGET_HEIGHT, "Box Color");
    setup_box_color_sub_menu(&box_color_sub_menu);
 
-   struct twr_window_widget check_box = twr_window_menu_add_check_box_widget(box_options_menu, -1, 20, "Box Outline");
+   struct twr_window_widget check_box = twr_window_menu_add_check_box_widget(box_options_menu, WIDGET_HEIGHT, "Box Outline");
    int check_box_event = twr_register_callback("boxBorderChanged");
    twr_window_menu_widget_add_callback(&check_box, check_box_event, (void*)0);
 }
@@ -433,7 +434,7 @@ __attribute__((export_name("spawnButtonPressed")))
 void spawn_button_pressed(int event_id, void* ptr) {
    struct twr_window_widget button = twr_window_menu_add_button_widget(
       &test_two_menu,
-      -1, 10,
+      WIDGET_HEIGHT,
       "Delete!"
    );
    struct twr_window_widget* heap_button = (struct twr_window_widget*)malloc(sizeof(struct twr_window_widget));
@@ -464,7 +465,7 @@ void delete_button_pressed(int event_id, struct twr_window_widget* button) {
 void setup_test_two_menu(struct twr_window_widget *test_two_menu) {
    spawn_button = twr_window_menu_add_button_widget(
       test_two_menu,
-      -1, 10,
+      WIDGET_HEIGHT,
       "Spawn New Button"
    );
 
@@ -472,7 +473,7 @@ void setup_test_two_menu(struct twr_window_widget *test_two_menu) {
    twr_window_menu_widget_add_callback(&spawn_button, spawn_button_callback, (void*)0);
    delete_button_callback = twr_register_callback("deleteButtonPressed");
 
-   twr_window_menu_add_seperator_widget(test_two_menu, -1, 10, "-", NULL);
+   twr_window_menu_add_seperator_widget(test_two_menu, WIDGET_HEIGHT, "-", NULL);
 }
 
 void set_widget_visibility(struct twr_window_widget* widget, int visibility) {
@@ -484,9 +485,9 @@ void setup_extra_box_movement_sub_menu(struct twr_window_widget* box_movement_me
    extra_box_movement_items->len = 4;
    extra_box_movement_items->arr = (struct twr_window_widget*)malloc(sizeof(struct twr_window_widget) * extra_box_movement_items->len);
 
-   struct twr_window_widget extra_box_movement_show_box = twr_window_menu_add_check_box_widget(box_movement_menu, -1, 20, "Show");
+   struct twr_window_widget extra_box_movement_show_box = twr_window_menu_add_check_box_widget(box_movement_menu, WIDGET_HEIGHT, "Show");
 
-   extra_box_movement_items->arr[0] = twr_window_menu_add_seperator_widget(box_movement_menu, -1, 10, "-", NULL);
+   extra_box_movement_items->arr[0] = twr_window_menu_add_seperator_widget(box_movement_menu, WIDGET_HEIGHT, "-", NULL);
 
    const char* MOUSE_MOVE_METHOD_NAMES[3] = {
       "On Mouse Movement",
@@ -501,7 +502,7 @@ void setup_extra_box_movement_sub_menu(struct twr_window_widget* box_movement_me
    struct twr_window_widget root_radio_item;
    int extra_box_movement_options_event_id = twr_register_callback("extraBoxMovementOptionCallback");
    for (int i = 0; i < 3; i++) {
-      struct twr_window_widget radio_item = twr_window_menu_add_radio_item_widget(box_movement_menu, -1, 10, MOUSE_MOVE_METHOD_NAMES[i]);
+      struct twr_window_widget radio_item = twr_window_menu_add_radio_item_widget(box_movement_menu, WIDGET_HEIGHT, MOUSE_MOVE_METHOD_NAMES[i]);
       twr_window_menu_widget_add_callback(&radio_item, extra_box_movement_options_event_id, (void*)MOUSE_MOVE_METHOD_TYPES[i]);
       if (i == 0) {
          root_radio_item = radio_item;
@@ -521,30 +522,30 @@ void setup_extra_box_movement_sub_menu(struct twr_window_widget* box_movement_me
 }
 
 void setup_extra_menu(struct twr_window_widget *extra_menu) {
-   struct twr_window_widget extra_check_box = twr_window_menu_add_check_box_widget(extra_menu, -1, 20, "Show Extra Options");
+   struct twr_window_widget extra_check_box = twr_window_menu_add_check_box_widget(extra_menu, WIDGET_HEIGHT, "Show Extra Options");
    int extra_checkbox_event_id = twr_register_callback("extraCheckBoxCallback");
 
    struct DynamicWidgetArray* extra_widget_array = (struct DynamicWidgetArray*)malloc(sizeof(struct DynamicWidgetArray));
    extra_widget_array->len = 4;
    extra_widget_array->arr = (struct twr_window_widget*)malloc(sizeof(struct twr_window_widget) * extra_widget_array->len);
 
-   extra_widget_array->arr[0] = twr_window_menu_add_seperator_widget(extra_menu, -1, 10, "-", NULL);
+   extra_widget_array->arr[0] = twr_window_menu_add_seperator_widget(extra_menu, WIDGET_HEIGHT, "-", NULL);
 
-   struct twr_window_widget extra_center_dot_checkbox = twr_window_menu_add_check_box_widget(extra_menu, -1, 20, "Centered Dot");
+   struct twr_window_widget extra_center_dot_checkbox = twr_window_menu_add_check_box_widget(extra_menu, WIDGET_HEIGHT, "Centered Dot");
    int extra_center_dot_event_id = twr_register_callback("extraCenterDotCallback");
    twr_window_menu_widget_add_callback(&extra_center_dot_checkbox, extra_center_dot_event_id, (void*)0);
    extra_widget_array->arr[1] = extra_center_dot_checkbox;
 
    struct twr_window_widget randomize_center_dot_color = twr_window_menu_add_button_widget(
       extra_menu,
-      -1, 20,
+      WIDGET_HEIGHT,
       "Randomize Center Dot Color"
    );
    int randomize_center_dot_color_event_id = twr_register_callback("randomizeCenterDotColorCallback");
    twr_window_menu_widget_add_callback(&randomize_center_dot_color, randomize_center_dot_color_event_id, (void*)0);
    extra_widget_array->arr[2] = randomize_center_dot_color;
 
-   struct twr_window_widget extra_box_movement_menu = twr_window_menu_add_sub_menu_widget_reduced(extra_menu, -1, 20, "Box Movement");
+   struct twr_window_widget extra_box_movement_menu = twr_window_menu_add_sub_menu_widget_reduced(extra_menu, WIDGET_HEIGHT, "Box Movement");
    setup_extra_box_movement_sub_menu(&extra_box_movement_menu);
    extra_widget_array->arr[3] = extra_box_movement_menu;
 
@@ -556,8 +557,8 @@ void setup_extra_menu(struct twr_window_widget *extra_menu) {
 }
 
 void setup_menu_prop_menu(struct twr_window_widget *menu_prop_menu) {
-   struct twr_window_widget getters = twr_window_menu_add_sub_menu_widget_reduced(menu_prop_menu, -1, 10, "Getters");
-   struct twr_window_widget setters = twr_window_menu_add_sub_menu_widget_reduced(menu_prop_menu, -1, 10, "Setters");
+   struct twr_window_widget getters = twr_window_menu_add_sub_menu_widget_reduced(menu_prop_menu, WIDGET_HEIGHT, "Getters");
+   struct twr_window_widget setters = twr_window_menu_add_sub_menu_widget_reduced(menu_prop_menu, WIDGET_HEIGHT, "Setters");
 
    long length = 0;
    struct twr_menu_prop_details* prop_list =  twr_window_menu_list_props(window_con, &length);
@@ -565,8 +566,8 @@ void setup_menu_prop_menu(struct twr_window_widget *menu_prop_menu) {
    int getter_event_id = twr_register_callback("menuPropMenuGetterCallback");
    int setter_event_id = twr_register_callback("menuPropMenuSetterCallback");
    for (long i = 0; i < length; i++) {
-      struct twr_window_widget getter = twr_window_menu_add_button_widget(&getters, -1, 10, prop_list[i].name);
-      struct twr_window_widget setter = twr_window_menu_add_button_widget(&setters, -1, 10, prop_list[i].name);
+      struct twr_window_widget getter = twr_window_menu_add_button_widget(&getters, WIDGET_HEIGHT, prop_list[i].name);
+      struct twr_window_widget setter = twr_window_menu_add_button_widget(&setters, WIDGET_HEIGHT, prop_list[i].name);
 
       twr_window_menu_widget_add_callback(&getter, getter_event_id, (void*)&prop_list[i]);
       twr_window_menu_widget_add_callback(&setter, setter_event_id, (void*)&prop_list[i]);

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -666,6 +666,8 @@ void animation_frame(int id, int delta) {
       int m_x = (canvas_width - prop_menu_data.width)/2;
       int m_y = (canvas_height - prop_menu_data.height)/2;
 
+      d2d_setcanvaspropstring(ds, "textBaseline", "top");
+
       // printf("((%ld, %ld) + (%d, %d))/2 = (%d, %d)\n", canvas_width, canvas_height, prop_menu_data.width, prop_menu_data.height, m_x, m_y);
       d2d_setfillstylergba(ds, 0xC0C0C0FF);
       d2d_fillrect(ds, m_x, m_y, prop_menu_data.width, prop_menu_data.height);
@@ -694,12 +696,14 @@ void animation_frame(int id, int delta) {
          int row = 0;
          
          int height_per_row = (prop_menu_data.height - POPUP_TITLE_HEIGHT)/prop_menu_data.accepted_types_len;
-         int height_offset = m_y + POPUP_TITLE_HEIGHT;
+         const int EXTRA_TEXT_OFFSET = 5;
+         int height_offset = m_y + POPUP_TITLE_HEIGHT + EXTRA_TEXT_OFFSET;
          for (int i = 0; i < prop_menu_data.accepted_types_len; i++) {
             enum prop_menu_selected selected_type = prop_menu_data.accepted_types[prop_menu_data.selected_type];
             switch (prop_menu_data.accepted_types[i]) {
                case PROP_MENU_SELECTED_TRUE:
                //don't run for true, only false since it renders both
+                  row -= 1;
                break;
                case PROP_MENU_SELECTED_FALSE:
                {
@@ -750,7 +754,7 @@ void animation_frame(int id, int delta) {
                   d2d_fillrect(
                      ds,
                      m_x + x_offset + text_box_offset,
-                     height_offset + height_per_row*row + 2,
+                     height_offset + height_per_row*row + 2 - EXTRA_TEXT_OFFSET,
                      prop_menu_data.width - x_offset*2 - text_box_offset,
                      height_per_row - 2
                   );
@@ -779,7 +783,7 @@ void animation_frame(int id, int delta) {
                   d2d_fillrect(
                      ds,
                      m_x + x_offset + text_box_offset,
-                     height_offset + height_per_row*row + 2,
+                     height_offset + height_per_row*row + 2 - EXTRA_TEXT_OFFSET,
                      prop_menu_data.width - x_offset*2 - text_box_offset,
                      height_per_row - 2
                   );

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -180,12 +180,36 @@ void init() {
    setup_menu_prop_menu(&menu_prop_menu);
 }
 
+int square_x = 75;
+int square_y = 75;
+int SQUARE_WIDTH = 50;
+int SQUARE_HEIGHT = 50;
+void force_square_into_bounds() {
+   //ensure it's within the bottom right bounds
+   if (square_x + SQUARE_WIDTH > canvas_width) {
+      square_x = canvas_width - SQUARE_WIDTH;
+   }
+   if (square_y + SQUARE_HEIGHT >canvas_height) {
+      square_y = canvas_height - SQUARE_HEIGHT;
+   }
+
+   //ensure if it's within the top left bounds
+   // top left is checked seperately so it's prioritized over the bottom right bounds
+   if (square_x < 0) {
+      square_x = 0;
+   }
+   if (square_y < 0) {
+      square_y = 0;
+   }
+}
 __attribute__((export_name("windowResizeHandler")))
 void window_resize_handler(int event_id, long width, long height) {
    canvas_width = io_get_prop(canvas_con, "canvasWidth");
    canvas_height = io_get_prop(canvas_con, "canvasHeight");
 
    printf("new canvas size: %ld, %ld\n", canvas_width, canvas_height);
+
+   force_square_into_bounds();
 }
 
 struct prop_menu_data {
@@ -614,12 +638,6 @@ void box_border_changed(int event_id, void* _, int new_state) {
 }
 
 
-int square_x = 75;
-int square_y = 75;
-int SQUARE_WIDTH = 50;
-int SQUARE_HEIGHT = 50;
-
-
 
 __attribute__((export_name("animationFrame")))
 void animation_frame(int id, int delta) {
@@ -806,6 +824,7 @@ void mouse_move_handler(int id, int x, int y, int button) {
       return;
    square_x = x - SQUARE_WIDTH/2.0;
    square_y = y - SQUARE_HEIGHT/2.0;
+   force_square_into_bounds();
 }
 __attribute__((export_name("keyEventHandler")))
 void key_event_handler(int id, int key) {

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -293,6 +293,10 @@ void setup_test_two_menu(struct twr_window_widget *test_two_menu) {
    twr_window_menu_add_widget(test_two_menu, &seperator_cons.base);
 }
 
+void set_widget_visibility(struct twr_window_widget* widget, int visibility) {
+   twr_window_menu_widget_set_bool(widget, "isVisible", visibility);
+}
+
 void setup_extra_box_movement_sub_menu(struct twr_window_widget* box_movement_menu) {
    struct DynamicWidgetArray* extra_box_movement_items = (struct DynamicWidgetArray*)malloc(sizeof(struct DynamicWidgetArray));
    extra_box_movement_items->len = 4;
@@ -354,7 +358,7 @@ void setup_extra_box_movement_sub_menu(struct twr_window_widget* box_movement_me
    }
 
    for (int i = 0; i < extra_box_movement_items->len; i++) {
-      twr_window_menu_widget_set_visibility(&extra_box_movement_items->arr[i], 0);
+      set_widget_visibility(&extra_box_movement_items->arr[i], 0);
    }
 
    int visibility_event_id = twr_register_callback("extraCheckBoxCallback");
@@ -437,7 +441,7 @@ void setup_extra_menu(struct twr_window_widget *extra_menu) {
    twr_window_menu_widget_add_callback(&extra_check_box, extra_checkbox_event_id, (void*)extra_widget_array);
 
    for (int i = 0; i < extra_widget_array->len; i++) {
-      twr_window_menu_widget_set_visibility(&extra_widget_array->arr[i], 0);
+      set_widget_visibility(&extra_widget_array->arr[i], 0);
    }
 }
 
@@ -459,7 +463,7 @@ void extra_center_dot_callback(int event_id, void* _, int new_state) {
 __attribute__((export_name("extraCheckBoxCallback")))
 void extra_check_box_callback(int event_id, struct DynamicWidgetArray* arr, int new_state) {
    for (int i = 0; i < arr->len; i++) {
-      twr_window_menu_widget_set_visibility(&arr->arr[i], new_state);
+      set_widget_visibility(&arr->arr[i], new_state);
    }
 }
 __attribute__((export_name("boxBorderChanged")))

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -14,6 +14,7 @@ long canvas_height = 0;
 struct twr_window_widget box_color_menu;
 struct twr_window_widget test_two_menu;
 struct twr_window_widget extra_menu;
+struct twr_window_widget prop_menu;
 unsigned long box_color = 0xFF0000FF;
 int box_border = 0;
 
@@ -160,6 +161,15 @@ void init() {
    setup_box_options_menu(&box_color_menu);
    setup_test_two_menu(&test_two_menu);
    setup_extra_menu(&extra_menu);
+
+   long prop_len;
+   struct twr_widget_prop_details* props = twr_window_menu_widget_list_props(&box_color_menu, &prop_len);
+   printf("C alloc: %d\nC Length: %ld\n", (int)props, prop_len);
+   for (long i = 0; i < prop_len; i++) {
+      printf("prop list: %s\n", props[i].name);
+   }
+   free(props);
+   
 }
 
 
@@ -257,10 +267,22 @@ void spawn_button_pressed(int event_id, void* ptr) {
 
    printf("spawned new button: %d\n", button.widget_id);
 
+   char name[30] = "";
+   sprintf(name, "Delete Button: %d", button.widget_id);
+   twr_window_menu_widget_set_string(&button, "text", name);
+
    twr_window_menu_widget_add_callback(&button, delete_button_callback, (void*)heap_button);
 }
 __attribute__((export_name("deleteButtonPressed")))
 void delete_button_pressed(int event_id, struct twr_window_widget* button) {
+   char name[30] = "";
+   sprintf(name, "Delete Button: %d", button->widget_id);
+
+   char* real_name;
+   assert(twr_window_menu_widget_get_prop_string(button, "text", &real_name));
+   assert(strcmp(name, real_name) == 0);
+
+   free(real_name);
    twr_window_menu_delete_widget(button);
    free(button);
 }
@@ -512,5 +534,4 @@ void mouse_move_handler(int id, int x, int y, int button) {
       return;
    square_x = x - SQUARE_WIDTH/2.0;
    square_y = y - SQUARE_HEIGHT/2.0;
-   
 }

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -136,6 +136,8 @@ void init() {
    canvas_width = io_get_prop(canvas_con, "canvasWidth");
    canvas_height = io_get_prop(canvas_con, "canvasHeight");
 
+   printf("canvas size: %ld, %ld\n", canvas_width, canvas_height);
+
    int ANIMATION_EVENT = twr_register_callback("animationFrame");
    d2d_register_event(D2D_ANIMATION_FRAME, ANIMATION_EVENT);
 
@@ -152,6 +154,9 @@ void init() {
    int MOUSE_DBL_CLICK_EVENT = twr_register_callback("mouseMoveHandler");
    d2d_register_event(D2D_MOUSE_DBLCLICK, MOUSE_DBL_CLICK_EVENT);
    mouse_event_ids[MOUSE_EVENT_DOUBLE_CLICK] = MOUSE_DBL_CLICK_EVENT;
+
+   int KEY_PRESS_EVENT = twr_register_callback("keyEventHandler");
+   d2d_register_event(D2D_KEY_DOWN, KEY_PRESS_EVENT);
 
 
 
@@ -177,14 +182,32 @@ enum prop_menu_state {
    PROP_MENU_SET,
    PROP_MENU_GET
 };
+enum prop_menu_selected {
+   PROP_MENU_SELECTED_NONE,
+   PROP_MENU_SELECTED_TRUE,
+   PROP_MENU_SELECTED_FALSE,
+   PROP_MENU_SELECTED_UNDEFINED,
+   PROP_MENU_SELECTED_NUMBER,
+   PROP_MENU_SELECTED_STRING
+};
+struct text_fill_buffer {
+   char text[100];
+   int length;
+};
 struct prop_menu_popup {
    const char* prop_name;
    enum prop_menu_state state;
-   const char text_buffer[100];
-   enum WindowWidgetPropVal accepted_types;
-   int selected;
+   struct text_fill_buffer text_buffer;
+   struct text_fill_buffer number_buffer;
+   enum WindowWidgetPropVal accepted_types[4];
+   int accepted_types_len;
+   enum prop_menu_selected selected;
    struct twr_window_widget* widget;
+   long width, height;
 };
+const int BASE_PROP_MENU_HEIGHT = 25;
+const int PROP_MENU_HEIGHT_PER_FIELD = 25;
+const int POPUP_TITLE_HEIGHT = 20;
 struct prop_menu_popup prop_menu_popup_data = {
    .state = PROP_MENU_UNOPENED
 };
@@ -193,34 +216,50 @@ void window_prop_menu_get_event(int event_id, struct prop_menu_data* prop_data) 
    struct twr_widget_prop_value* val = twr_window_menu_widget_get_prop(prop_data->widget, prop_data->prop_details->name);
 
    prop_menu_popup_data.state = PROP_MENU_GET;
-   prop_menu_popup_data.selected = 0;
+   prop_menu_popup_data.selected = PROP_MENU_SELECTED_NONE;
    prop_menu_popup_data.prop_name = prop_data->prop_details->name;
+   prop_menu_popup_data.width = 200;
+   prop_menu_popup_data.height = BASE_PROP_MENU_HEIGHT + PROP_MENU_HEIGHT_PER_FIELD;
    switch (val->type) {
       case WINDOW_WIDGET_PROP_BOOLEAN:
-         sprintf(prop_menu_popup_data.text_buffer, "%s", val->boolean ? "true" : "false");
+         sprintf(prop_menu_popup_data.text_buffer.text, "%s", val->boolean ? "true" : "false");
       break;
       case WINDOW_WIDGET_PROP_NUMBER:
-         sprintf(prop_menu_popup_data.text_buffer, "%f", val->number);
+         sprintf(prop_menu_popup_data.text_buffer.text, "%f", val->number);
       break;
       case WINDOW_WIDGET_PROP_STRING:
-         sprintf(prop_menu_popup_data.text_buffer, "%s", val->string);
+         sprintf(prop_menu_popup_data.text_buffer.text, "%s", val->string);
       break;
       case WINDOW_WIDGET_PROP_UNDEFINED:
-         sprintf(prop_menu_popup_data.text_buffer, "undefined");
+         sprintf(prop_menu_popup_data.text_buffer.text, "undefined");
       break;
    }
 
    free(val);
+}
+unsigned int count_ones(unsigned int n) {
+   int i = 0;
+   for (; n > 0; n &= (n - 1), i++);
+   return i;
 }
 __attribute__((export_name("windowPropMenuSetEvent")))
 void window_prop_menu_set_event(int event_id, struct prop_menu_data* prop_data) {
    prop_menu_popup_data = (struct prop_menu_popup){
       .prop_name = prop_data->prop_details->name,
       .state = PROP_MENU_SET,
-      .text_buffer = "",
+      .text_buffer = (struct text_fill_buffer){
+         .text = "",
+         .length = 0
+      },
+      .number_buffer = (struct text_fill_buffer){
+         .text = "",
+         .length = 0
+      },
       .accepted_types = prop_data->prop_details->type,
-      .selected = 0,
-      .widget = prop_data->widget
+      .selected = PROP_MENU_SELECTED_NONE,
+      .widget = prop_data->widget,
+      .width = 200,
+      .height = BASE_PROP_MENU_HEIGHT + PROP_MENU_HEIGHT_PER_FIELD * count_ones((unsigned int)prop_data->prop_details->type),
    };
 }
 void setup_prop_menu(struct twr_window_widget *prop_menu) {
@@ -612,6 +651,8 @@ int square_y = 75;
 int SQUARE_WIDTH = 50;
 int SQUARE_HEIGHT = 50;
 
+
+
 __attribute__((export_name("animationFrame")))
 void animation_frame(int id, int delta) {
    struct d2d_draw_seq* ds = d2d_start_draw_sequence(100);
@@ -635,15 +676,219 @@ void animation_frame(int id, int delta) {
       d2d_fillrect(ds, square_x + SQUARE_WIDTH/2.0 - 5.0, square_y + SQUARE_HEIGHT/2.0 - 5.0, 10.0, 10.0);
    }
 
+   if (prop_menu_popup_data.state != PROP_MENU_UNOPENED) {
+      int m_x = (canvas_width - prop_menu_popup_data.width)/2;
+      int m_y = (canvas_height - prop_menu_popup_data.height)/2;
+
+      // printf("((%ld, %ld) + (%d, %d))/2 = (%d, %d)\n", canvas_width, canvas_height, prop_menu_popup_data.width, prop_menu_popup_data.height, m_x, m_y);
+      d2d_setfillstylergba(ds, 0xC0C0C0FF);
+      d2d_fillrect(ds, m_x, m_y, prop_menu_popup_data.width, prop_menu_popup_data.height);
+
+      d2d_setfillstylergba(ds, 0x808080FF);
+      d2d_fillrect(ds, m_x, m_y, prop_menu_popup_data.width, POPUP_TITLE_HEIGHT);
+
+      const int text_offset = 5;
+      d2d_setfont(ds, "16px Seriph");
+      d2d_setfillstylergba(ds, 0xFFFFFFFF);
+      d2d_filltext(ds, prop_menu_popup_data.prop_name, m_x, m_y+text_offset);
+
+      d2d_setfont(ds, "12px Seriph");
+      d2d_setfillstylergba(ds, 0x000000FF);
+      const int x_offset = 5;
+      if (prop_menu_popup_data.state == PROP_MENU_GET) {
+         char buffer[110];
+         sprintf(buffer, "value: %s", prop_menu_popup_data.text_buffer);
+         d2d_filltext(
+            ds, 
+            buffer, 
+            m_x + x_offset, 
+            m_y + (prop_menu_popup_data.height + POPUP_TITLE_HEIGHT)/2
+         );
+      } else {
+         int row = 0;
+         int n = prop_menu_popup_data.accepted_types;
+         const int num_types = 4;
+         const enum WindowWidgetPropVal types[] = {
+            WINDOW_WIDGET_PROP_STRING,
+            WINDOW_WIDGET_PROP_BOOLEAN,
+            WINDOW_WIDGET_PROP_NUMBER,
+            WINDOW_WIDGET_PROP_UNDEFINED
+         };
+         int height_per_row = (prop_menu_popup_data.height - POPUP_TITLE_HEIGHT)/count_ones((unsigned int)prop_menu_popup_data.accepted_types);
+         int height_offset = m_y + POPUP_TITLE_HEIGHT;
+         for (int i = 0; i < num_types; i++) {
+            if (prop_menu_popup_data.accepted_types & types[i]) {
+               if (prop_menu_popup_data.selected == PROP_MENU_SELECTED_NONE) {
+                  switch (types[i]) {
+                     case WINDOW_WIDGET_PROP_BOOLEAN:
+                        prop_menu_popup_data.selected = PROP_MENU_SELECTED_TRUE;
+                     break;
+                     case WINDOW_WIDGET_PROP_STRING:
+                        prop_menu_popup_data.selected = PROP_MENU_SELECTED_STRING;
+                     break;
+                     case WINDOW_WIDGET_PROP_NUMBER:
+                        prop_menu_popup_data.selected = PROP_MENU_SELECTED_NUMBER;
+                     break;
+                     case WINDOW_WIDGET_PROP_UNDEFINED:
+                        prop_menu_popup_data.selected = PROP_MENU_SELECTED_UNDEFINED;
+                     break;
+                  }
+                  printf("selected: %d\n", prop_menu_popup_data.selected);
+               }
+               switch (types[i]) {
+                  case WINDOW_WIDGET_PROP_BOOLEAN:
+                  {
+                     char buffer[30];
+                     sprintf(
+                        buffer,
+                        "%s true\t%s false",
+                        prop_menu_popup_data.selected == PROP_MENU_SELECTED_TRUE ? "*" : "  ",
+                        prop_menu_popup_data.selected == PROP_MENU_SELECTED_FALSE ? "*" : "  "
+                     );
+                     
+                     d2d_filltext(
+                        ds, 
+                        buffer, 
+                        m_x + x_offset,
+                        height_offset + height_per_row*row + text_offset
+                     );
+                  }
+                  break;
+                  case WINDOW_WIDGET_PROP_UNDEFINED:
+                  {
+                     char buffer[30];
+                     sprintf(
+                        buffer,
+                        "%s undefined",
+                        prop_menu_popup_data.selected == PROP_MENU_SELECTED_UNDEFINED ? "*" : "  "
+                     );
+                     
+                     d2d_filltext(
+                        ds, 
+                        buffer, 
+                        m_x + x_offset,
+                        height_offset + height_per_row*row + text_offset
+                     );
+                  }
+                  break;
+                  case WINDOW_WIDGET_PROP_NUMBER:
+                  {
+                     d2d_filltext(
+                        ds, 
+                        prop_menu_popup_data.selected == PROP_MENU_SELECTED_NUMBER ? "* number: " : "  number: ", 
+                        m_x + x_offset,
+                        height_offset + height_per_row*row + text_offset
+                     );
+                     const int text_box_offset = 60;
+                     const int inner_text_offset = 5;
+                     d2d_setfillstylergba(ds, 0xFFFFFFFF);
+                     d2d_fillrect(
+                        ds,
+                        m_x + x_offset + text_box_offset,
+                        height_offset + height_per_row*row + 2,
+                        prop_menu_popup_data.width - x_offset*2 - text_box_offset,
+                        height_per_row - 2
+                     );
+                     d2d_setfillstylergba(ds, 0x000000FF);
+                     d2d_filltext(
+                        ds,
+                        prop_menu_popup_data.number_buffer.text,
+                        m_x + x_offset + text_box_offset + inner_text_offset,
+                        height_offset + height_per_row*row + text_offset
+                     );
+                  }
+                  break;
+
+                  case WINDOW_WIDGET_PROP_STRING:
+                  {
+                     d2d_filltext(
+                        ds, 
+                        prop_menu_popup_data.selected == PROP_MENU_SELECTED_STRING ? "* string: " : "   string: ", 
+                        m_x + x_offset,
+                        height_offset + height_per_row*row + text_offset
+                     );
+
+                     const int text_box_offset = 60;
+                     const int inner_text_offset = 5;
+                     d2d_setfillstylergba(ds, 0xFFFFFFFF);
+                     d2d_fillrect(
+                        ds,
+                        m_x + x_offset + text_box_offset,
+                        height_offset + height_per_row*row + 2,
+                        prop_menu_popup_data.width - x_offset*2 - text_box_offset,
+                        height_per_row - 2
+                     );
+                     d2d_setfillstylergba(ds, 0x000000FF);
+                     d2d_filltext(
+                        ds,
+                        prop_menu_popup_data.text_buffer.text,
+                        m_x + x_offset + text_box_offset + inner_text_offset,
+                        height_offset + height_per_row*row + text_offset
+                     );
+                  }
+                  break;
+               }
+               row += 1;
+            }
+         }
+      }
+   }
+
    d2d_end_draw_sequence(ds);
 }
 
 __attribute__((export_name("mouseMoveHandler")))
 void mouse_move_handler(int id, int x, int y, int button) {
+   int m_x = (canvas_width - prop_menu_popup_data.width)/2;
+   int m_y = (canvas_height - prop_menu_popup_data.height)/2;
+
+   if (
+      prop_menu_popup_data.state != PROP_MENU_UNOPENED
+      && (
+         m_x < x && x < m_x + prop_menu_popup_data.width
+         && m_y < y && y < m_y + prop_menu_popup_data.height
+      )
+   ) {
+      return;
+   }
+   if (mouse_event_ids[MOUSE_EVENT_MOVE] != id) {
+      prop_menu_popup_data.state = PROP_MENU_UNOPENED;
+   }
    if (mouse_event_ids[box_move_event_type] != id)
       return;
    if (box_move_event_type == MOUSE_EVENT_LEFT_CLICK && button != 0)
       return;
    square_x = x - SQUARE_WIDTH/2.0;
    square_y = y - SQUARE_HEIGHT/2.0;
+}
+__attribute__((export_name("keyEventHandler")))
+void key_event_handler(int id, int key) {
+   // printf("key pressed: %d\n", key);
+   if (prop_menu_popup_data.state == PROP_MENU_UNOPENED)
+      return;
+   if (key == 27) { //escape
+      prop_menu_popup_data.state = PROP_MENU_UNOPENED;
+      return;
+   }
+   if (prop_menu_popup_data.state == PROP_MENU_GET)
+      return;
+   
+   enum prop_menu_selected selected = prop_menu_popup_data.selected;
+   switch (key) {
+      case 8592: //left arrow
+      case 8594: //right arrow
+      {
+         if (selected == PROP_MENU_SELECTED_FALSE)
+            selected = PROP_MENU_SELECTED_TRUE;
+         else if (selected == PROP_MENU_SELECTED_TRUE)
+            selected = PROP_MENU_SELECTED_FALSE;
+      }
+      break;
+
+      case 8593: //up arrow
+      {
+
+      }
+      break;
+   }
 }

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -3,6 +3,7 @@
 #include "twr-crt.h"
 #include "stdlib.h"
 #include "string.h"
+#include <ctype.h>
 
 twr_ioconsole_t* window_con = NULL;
 twr_ioconsole_t* canvas_con = NULL;
@@ -183,7 +184,6 @@ enum prop_menu_state {
    PROP_MENU_GET
 };
 enum prop_menu_selected {
-   PROP_MENU_SELECTED_NONE,
    PROP_MENU_SELECTED_TRUE,
    PROP_MENU_SELECTED_FALSE,
    PROP_MENU_SELECTED_UNDEFINED,
@@ -194,44 +194,63 @@ struct text_fill_buffer {
    char text[100];
    int length;
 };
+void append_to_text_fill_buffer(struct text_fill_buffer* buffer, char ch) {
+   assert(buffer->length < 99);
+   if (buffer->length < 99) {
+      buffer->text[buffer->length] = ch;
+      buffer->length++;
+      buffer->text[buffer->length] = '\0';
+   }
+}
+bool try_pop_from_text_fill_buffer(struct text_fill_buffer* buffer, char* ret_ch) {
+   if (buffer->length > 0) {
+      *ret_ch = buffer->text[buffer->length-1];
+      buffer->length--;
+      buffer->text[buffer->length] = '\0';
+      return TRUE;
+   } else {
+      return FALSE;
+   }
+}
 struct prop_menu_popup {
    const char* prop_name;
    enum prop_menu_state state;
    struct text_fill_buffer text_buffer;
    struct text_fill_buffer number_buffer;
-   enum WindowWidgetPropVal accepted_types[4];
+   bool number_buffer_has_dot;
+   enum prop_menu_selected accepted_types[5];
    int accepted_types_len;
-   enum prop_menu_selected selected;
+   int selected_type;
    struct twr_window_widget* widget;
    long width, height;
 };
 const int BASE_PROP_MENU_HEIGHT = 25;
 const int PROP_MENU_HEIGHT_PER_FIELD = 25;
 const int POPUP_TITLE_HEIGHT = 20;
-struct prop_menu_popup prop_menu_popup_data = {
+struct prop_menu_popup prop_menu_data = {
    .state = PROP_MENU_UNOPENED
 };
 __attribute__((export_name("windowPropMenuGetEvent")))
 void window_prop_menu_get_event(int event_id, struct prop_menu_data* prop_data) {
    struct twr_widget_prop_value* val = twr_window_menu_widget_get_prop(prop_data->widget, prop_data->prop_details->name);
 
-   prop_menu_popup_data.state = PROP_MENU_GET;
-   prop_menu_popup_data.selected = PROP_MENU_SELECTED_NONE;
-   prop_menu_popup_data.prop_name = prop_data->prop_details->name;
-   prop_menu_popup_data.width = 200;
-   prop_menu_popup_data.height = BASE_PROP_MENU_HEIGHT + PROP_MENU_HEIGHT_PER_FIELD;
+   prop_menu_data.state = PROP_MENU_GET;
+   // prop_menu_data.selected = PROP_MENU_SELECTED_NONE;
+   prop_menu_data.prop_name = prop_data->prop_details->name;
+   prop_menu_data.width = 200;
+   prop_menu_data.height = BASE_PROP_MENU_HEIGHT + PROP_MENU_HEIGHT_PER_FIELD;
    switch (val->type) {
       case WINDOW_WIDGET_PROP_BOOLEAN:
-         sprintf(prop_menu_popup_data.text_buffer.text, "%s", val->boolean ? "true" : "false");
+         sprintf(prop_menu_data.text_buffer.text, "%s", val->boolean ? "true" : "false");
       break;
       case WINDOW_WIDGET_PROP_NUMBER:
-         sprintf(prop_menu_popup_data.text_buffer.text, "%f", val->number);
+         sprintf(prop_menu_data.text_buffer.text, "%f", val->number);
       break;
       case WINDOW_WIDGET_PROP_STRING:
-         sprintf(prop_menu_popup_data.text_buffer.text, "%s", val->string);
+         sprintf(prop_menu_data.text_buffer.text, "%s", val->string);
       break;
       case WINDOW_WIDGET_PROP_UNDEFINED:
-         sprintf(prop_menu_popup_data.text_buffer.text, "undefined");
+         sprintf(prop_menu_data.text_buffer.text, "undefined");
       break;
    }
 
@@ -244,7 +263,7 @@ unsigned int count_ones(unsigned int n) {
 }
 __attribute__((export_name("windowPropMenuSetEvent")))
 void window_prop_menu_set_event(int event_id, struct prop_menu_data* prop_data) {
-   prop_menu_popup_data = (struct prop_menu_popup){
+   prop_menu_data = (struct prop_menu_popup){
       .prop_name = prop_data->prop_details->name,
       .state = PROP_MENU_SET,
       .text_buffer = (struct text_fill_buffer){
@@ -255,12 +274,45 @@ void window_prop_menu_set_event(int event_id, struct prop_menu_data* prop_data) 
          .text = "",
          .length = 0
       },
-      .accepted_types = prop_data->prop_details->type,
-      .selected = PROP_MENU_SELECTED_NONE,
+      .number_buffer_has_dot = FALSE,
+      // .accepted_types = accepted_types,
+      // .accepted_types_len = accepted_types_length,
+      .accepted_types_len = 0,
+      .selected_type = 0,
       .widget = prop_data->widget,
       .width = 200,
       .height = BASE_PROP_MENU_HEIGHT + PROP_MENU_HEIGHT_PER_FIELD * count_ones((unsigned int)prop_data->prop_details->type),
    };
+   const int num_types = 4;
+   const enum WindowWidgetPropVal types[] = {
+      WINDOW_WIDGET_PROP_STRING,
+      WINDOW_WIDGET_PROP_BOOLEAN,
+      WINDOW_WIDGET_PROP_NUMBER,
+      WINDOW_WIDGET_PROP_UNDEFINED
+   };
+   for (int i = 0; i < num_types; i++) {
+      if (prop_data->prop_details->type & types[i]) {
+         enum prop_menu_selected to_add;
+         switch (types[i]) {
+            case WINDOW_WIDGET_PROP_STRING:
+               to_add = PROP_MENU_SELECTED_STRING;
+            break;
+            case WINDOW_WIDGET_PROP_BOOLEAN:
+            prop_menu_data.accepted_types[prop_menu_data.accepted_types_len] = PROP_MENU_SELECTED_TRUE;
+               prop_menu_data.accepted_types_len++;
+               to_add = PROP_MENU_SELECTED_FALSE;
+            break;
+            case WINDOW_WIDGET_PROP_NUMBER:
+               to_add = PROP_MENU_SELECTED_NUMBER;
+            break;
+            case WINDOW_WIDGET_PROP_UNDEFINED:
+               to_add = PROP_MENU_SELECTED_UNDEFINED;
+            break;
+         }
+         prop_menu_data.accepted_types[prop_menu_data.accepted_types_len] = to_add;
+         prop_menu_data.accepted_types_len++;
+      }
+   }
 }
 void setup_prop_menu(struct twr_window_widget *prop_menu) {
    struct twr_widget_check_box_constructor modified_prop_cons = {
@@ -676,160 +728,138 @@ void animation_frame(int id, int delta) {
       d2d_fillrect(ds, square_x + SQUARE_WIDTH/2.0 - 5.0, square_y + SQUARE_HEIGHT/2.0 - 5.0, 10.0, 10.0);
    }
 
-   if (prop_menu_popup_data.state != PROP_MENU_UNOPENED) {
-      int m_x = (canvas_width - prop_menu_popup_data.width)/2;
-      int m_y = (canvas_height - prop_menu_popup_data.height)/2;
+   if (prop_menu_data.state != PROP_MENU_UNOPENED) {
+      int m_x = (canvas_width - prop_menu_data.width)/2;
+      int m_y = (canvas_height - prop_menu_data.height)/2;
 
-      // printf("((%ld, %ld) + (%d, %d))/2 = (%d, %d)\n", canvas_width, canvas_height, prop_menu_popup_data.width, prop_menu_popup_data.height, m_x, m_y);
+      // printf("((%ld, %ld) + (%d, %d))/2 = (%d, %d)\n", canvas_width, canvas_height, prop_menu_data.width, prop_menu_data.height, m_x, m_y);
       d2d_setfillstylergba(ds, 0xC0C0C0FF);
-      d2d_fillrect(ds, m_x, m_y, prop_menu_popup_data.width, prop_menu_popup_data.height);
+      d2d_fillrect(ds, m_x, m_y, prop_menu_data.width, prop_menu_data.height);
 
       d2d_setfillstylergba(ds, 0x808080FF);
-      d2d_fillrect(ds, m_x, m_y, prop_menu_popup_data.width, POPUP_TITLE_HEIGHT);
+      d2d_fillrect(ds, m_x, m_y, prop_menu_data.width, POPUP_TITLE_HEIGHT);
 
       const int text_offset = 5;
       d2d_setfont(ds, "16px Seriph");
       d2d_setfillstylergba(ds, 0xFFFFFFFF);
-      d2d_filltext(ds, prop_menu_popup_data.prop_name, m_x, m_y+text_offset);
+      d2d_filltext(ds, prop_menu_data.prop_name, m_x, m_y+text_offset);
 
       d2d_setfont(ds, "12px Seriph");
       d2d_setfillstylergba(ds, 0x000000FF);
       const int x_offset = 5;
-      if (prop_menu_popup_data.state == PROP_MENU_GET) {
+      if (prop_menu_data.state == PROP_MENU_GET) {
          char buffer[110];
-         sprintf(buffer, "value: %s", prop_menu_popup_data.text_buffer);
+         sprintf(buffer, "value: %s", prop_menu_data.text_buffer.text);
          d2d_filltext(
             ds, 
             buffer, 
             m_x + x_offset, 
-            m_y + (prop_menu_popup_data.height + POPUP_TITLE_HEIGHT)/2
+            m_y + (prop_menu_data.height + POPUP_TITLE_HEIGHT)/2
          );
       } else {
          int row = 0;
-         int n = prop_menu_popup_data.accepted_types;
-         const int num_types = 4;
-         const enum WindowWidgetPropVal types[] = {
-            WINDOW_WIDGET_PROP_STRING,
-            WINDOW_WIDGET_PROP_BOOLEAN,
-            WINDOW_WIDGET_PROP_NUMBER,
-            WINDOW_WIDGET_PROP_UNDEFINED
-         };
-         int height_per_row = (prop_menu_popup_data.height - POPUP_TITLE_HEIGHT)/count_ones((unsigned int)prop_menu_popup_data.accepted_types);
+         
+         int height_per_row = (prop_menu_data.height - POPUP_TITLE_HEIGHT)/prop_menu_data.accepted_types_len;
          int height_offset = m_y + POPUP_TITLE_HEIGHT;
-         for (int i = 0; i < num_types; i++) {
-            if (prop_menu_popup_data.accepted_types & types[i]) {
-               if (prop_menu_popup_data.selected == PROP_MENU_SELECTED_NONE) {
-                  switch (types[i]) {
-                     case WINDOW_WIDGET_PROP_BOOLEAN:
-                        prop_menu_popup_data.selected = PROP_MENU_SELECTED_TRUE;
-                     break;
-                     case WINDOW_WIDGET_PROP_STRING:
-                        prop_menu_popup_data.selected = PROP_MENU_SELECTED_STRING;
-                     break;
-                     case WINDOW_WIDGET_PROP_NUMBER:
-                        prop_menu_popup_data.selected = PROP_MENU_SELECTED_NUMBER;
-                     break;
-                     case WINDOW_WIDGET_PROP_UNDEFINED:
-                        prop_menu_popup_data.selected = PROP_MENU_SELECTED_UNDEFINED;
-                     break;
-                  }
-                  printf("selected: %d\n", prop_menu_popup_data.selected);
+         for (int i = 0; i < prop_menu_data.accepted_types_len; i++) {
+            enum prop_menu_selected selected_type = prop_menu_data.accepted_types[prop_menu_data.selected_type];
+            switch (prop_menu_data.accepted_types[i]) {
+               case PROP_MENU_SELECTED_TRUE:
+               //don't run for true, only false since it renders both
+               break;
+               case PROP_MENU_SELECTED_FALSE:
+               {
+                  char buffer[30];
+                  sprintf(
+                     buffer,
+                     "%s true\t%s false",
+                     selected_type == PROP_MENU_SELECTED_TRUE ? "*" : "  ",
+                     selected_type == PROP_MENU_SELECTED_FALSE ? "*" : "  "
+                  );
+                  
+                  d2d_filltext(
+                     ds, 
+                     buffer, 
+                     m_x + x_offset,
+                     height_offset + height_per_row*row + text_offset
+                  );
                }
-               switch (types[i]) {
-                  case WINDOW_WIDGET_PROP_BOOLEAN:
-                  {
-                     char buffer[30];
-                     sprintf(
-                        buffer,
-                        "%s true\t%s false",
-                        prop_menu_popup_data.selected == PROP_MENU_SELECTED_TRUE ? "*" : "  ",
-                        prop_menu_popup_data.selected == PROP_MENU_SELECTED_FALSE ? "*" : "  "
-                     );
-                     
-                     d2d_filltext(
-                        ds, 
-                        buffer, 
-                        m_x + x_offset,
-                        height_offset + height_per_row*row + text_offset
-                     );
-                  }
-                  break;
-                  case WINDOW_WIDGET_PROP_UNDEFINED:
-                  {
-                     char buffer[30];
-                     sprintf(
-                        buffer,
-                        "%s undefined",
-                        prop_menu_popup_data.selected == PROP_MENU_SELECTED_UNDEFINED ? "*" : "  "
-                     );
-                     
-                     d2d_filltext(
-                        ds, 
-                        buffer, 
-                        m_x + x_offset,
-                        height_offset + height_per_row*row + text_offset
-                     );
-                  }
-                  break;
-                  case WINDOW_WIDGET_PROP_NUMBER:
-                  {
-                     d2d_filltext(
-                        ds, 
-                        prop_menu_popup_data.selected == PROP_MENU_SELECTED_NUMBER ? "* number: " : "  number: ", 
-                        m_x + x_offset,
-                        height_offset + height_per_row*row + text_offset
-                     );
-                     const int text_box_offset = 60;
-                     const int inner_text_offset = 5;
-                     d2d_setfillstylergba(ds, 0xFFFFFFFF);
-                     d2d_fillrect(
-                        ds,
-                        m_x + x_offset + text_box_offset,
-                        height_offset + height_per_row*row + 2,
-                        prop_menu_popup_data.width - x_offset*2 - text_box_offset,
-                        height_per_row - 2
-                     );
-                     d2d_setfillstylergba(ds, 0x000000FF);
-                     d2d_filltext(
-                        ds,
-                        prop_menu_popup_data.number_buffer.text,
-                        m_x + x_offset + text_box_offset + inner_text_offset,
-                        height_offset + height_per_row*row + text_offset
-                     );
-                  }
-                  break;
-
-                  case WINDOW_WIDGET_PROP_STRING:
-                  {
-                     d2d_filltext(
-                        ds, 
-                        prop_menu_popup_data.selected == PROP_MENU_SELECTED_STRING ? "* string: " : "   string: ", 
-                        m_x + x_offset,
-                        height_offset + height_per_row*row + text_offset
-                     );
-
-                     const int text_box_offset = 60;
-                     const int inner_text_offset = 5;
-                     d2d_setfillstylergba(ds, 0xFFFFFFFF);
-                     d2d_fillrect(
-                        ds,
-                        m_x + x_offset + text_box_offset,
-                        height_offset + height_per_row*row + 2,
-                        prop_menu_popup_data.width - x_offset*2 - text_box_offset,
-                        height_per_row - 2
-                     );
-                     d2d_setfillstylergba(ds, 0x000000FF);
-                     d2d_filltext(
-                        ds,
-                        prop_menu_popup_data.text_buffer.text,
-                        m_x + x_offset + text_box_offset + inner_text_offset,
-                        height_offset + height_per_row*row + text_offset
-                     );
-                  }
-                  break;
+               break;
+               case PROP_MENU_SELECTED_UNDEFINED:
+               {
+                  char buffer[30];
+                  sprintf(
+                     buffer,
+                     "%s undefined",
+                     selected_type == PROP_MENU_SELECTED_UNDEFINED ? "*" : "  "
+                  );
+                  
+                  d2d_filltext(
+                     ds, 
+                     buffer, 
+                     m_x + x_offset,
+                     height_offset + height_per_row*row + text_offset
+                  );
                }
-               row += 1;
+               break;
+               case PROP_MENU_SELECTED_NUMBER:
+               {
+                  d2d_filltext(
+                     ds, 
+                     selected_type == PROP_MENU_SELECTED_NUMBER ? "* number: " : "  number: ", 
+                     m_x + x_offset,
+                     height_offset + height_per_row*row + text_offset
+                  );
+                  const int text_box_offset = 60;
+                  const int inner_text_offset = 5;
+                  d2d_setfillstylergba(ds, 0xFFFFFFFF);
+                  d2d_fillrect(
+                     ds,
+                     m_x + x_offset + text_box_offset,
+                     height_offset + height_per_row*row + 2,
+                     prop_menu_data.width - x_offset*2 - text_box_offset,
+                     height_per_row - 2
+                  );
+                  d2d_setfillstylergba(ds, 0x000000FF);
+                  d2d_filltext(
+                     ds,
+                     prop_menu_data.number_buffer.text,
+                     m_x + x_offset + text_box_offset + inner_text_offset,
+                     height_offset + height_per_row*row + text_offset
+                  );
+               }
+               break;
+
+               case PROP_MENU_SELECTED_STRING:
+               {
+                  d2d_filltext(
+                     ds, 
+                     selected_type == PROP_MENU_SELECTED_STRING ? "* string: " : "   string: ", 
+                     m_x + x_offset,
+                     height_offset + height_per_row*row + text_offset
+                  );
+
+                  const int text_box_offset = 60;
+                  const int inner_text_offset = 5;
+                  d2d_setfillstylergba(ds, 0xFFFFFFFF);
+                  d2d_fillrect(
+                     ds,
+                     m_x + x_offset + text_box_offset,
+                     height_offset + height_per_row*row + 2,
+                     prop_menu_data.width - x_offset*2 - text_box_offset,
+                     height_per_row - 2
+                  );
+                  d2d_setfillstylergba(ds, 0x000000FF);
+                  d2d_filltext(
+                     ds,
+                     prop_menu_data.text_buffer.text,
+                     m_x + x_offset + text_box_offset + inner_text_offset,
+                     height_offset + height_per_row*row + text_offset
+                  );
+               }
+               break;
             }
+            row += 1;
          }
       }
    }
@@ -839,20 +869,20 @@ void animation_frame(int id, int delta) {
 
 __attribute__((export_name("mouseMoveHandler")))
 void mouse_move_handler(int id, int x, int y, int button) {
-   int m_x = (canvas_width - prop_menu_popup_data.width)/2;
-   int m_y = (canvas_height - prop_menu_popup_data.height)/2;
+   int m_x = (canvas_width - prop_menu_data.width)/2;
+   int m_y = (canvas_height - prop_menu_data.height)/2;
 
    if (
-      prop_menu_popup_data.state != PROP_MENU_UNOPENED
+      prop_menu_data.state != PROP_MENU_UNOPENED
       && (
-         m_x < x && x < m_x + prop_menu_popup_data.width
-         && m_y < y && y < m_y + prop_menu_popup_data.height
+         m_x < x && x < m_x + prop_menu_data.width
+         && m_y < y && y < m_y + prop_menu_data.height
       )
    ) {
       return;
    }
    if (mouse_event_ids[MOUSE_EVENT_MOVE] != id) {
-      prop_menu_popup_data.state = PROP_MENU_UNOPENED;
+      prop_menu_data.state = PROP_MENU_UNOPENED;
    }
    if (mouse_event_ids[box_move_event_type] != id)
       return;
@@ -863,31 +893,144 @@ void mouse_move_handler(int id, int x, int y, int button) {
 }
 __attribute__((export_name("keyEventHandler")))
 void key_event_handler(int id, int key) {
-   // printf("key pressed: %d\n", key);
-   if (prop_menu_popup_data.state == PROP_MENU_UNOPENED)
+   printf("pressed key: %d\n", key);
+   if (prop_menu_data.state == PROP_MENU_UNOPENED)
       return;
    if (key == 27) { //escape
-      prop_menu_popup_data.state = PROP_MENU_UNOPENED;
+      prop_menu_data.state = PROP_MENU_UNOPENED;
       return;
    }
-   if (prop_menu_popup_data.state == PROP_MENU_GET)
+   if (prop_menu_data.state == PROP_MENU_GET)
       return;
    
-   enum prop_menu_selected selected = prop_menu_popup_data.selected;
+   enum prop_menu_selected selected = prop_menu_data.accepted_types[prop_menu_data.selected_type];
+
+   struct text_fill_buffer* text_buffer = &prop_menu_data.text_buffer;
+   struct text_fill_buffer* number_buffer = &prop_menu_data.number_buffer;
    switch (key) {
-      case 8592: //left arrow
-      case 8594: //right arrow
-      {
-         if (selected == PROP_MENU_SELECTED_FALSE)
-            selected = PROP_MENU_SELECTED_TRUE;
-         else if (selected == PROP_MENU_SELECTED_TRUE)
-            selected = PROP_MENU_SELECTED_FALSE;
-      }
-      break;
 
       case 8593: //up arrow
       {
+         if (prop_menu_data.selected_type > 0) {
+            prop_menu_data.selected_type--;
+         }
+      }
+      break;
 
+      case 8595: //down arrow
+      {
+         if (prop_menu_data.selected_type < prop_menu_data.accepted_types_len-1) {
+            prop_menu_data.selected_type++;
+         }
+      }
+      break;
+
+      case 8: //backspace
+      {
+         char deleted;
+         if (selected == PROP_MENU_SELECTED_STRING) {
+            try_pop_from_text_fill_buffer(text_buffer, &deleted);
+         } else if (selected == PROP_MENU_SELECTED_NUMBER) {
+            if (try_pop_from_text_fill_buffer(number_buffer, &deleted)) {
+               if (deleted == '.') {
+                  prop_menu_data.number_buffer_has_dot = FALSE;        
+               }
+            }
+         }
+      }
+      break;
+      case 127: //delete
+      {
+         if (selected == PROP_MENU_SELECTED_STRING) {
+            text_buffer->text[0] = '\0';
+            text_buffer->length = 0;
+         } else if (selected == PROP_MENU_SELECTED_NUMBER) {
+            number_buffer->text[0] = '\0';
+            number_buffer->length = 0;
+            prop_menu_data.number_buffer_has_dot = FALSE;
+         }
+      }
+      break;
+
+      case 10: //enter
+      {
+         switch (selected) {
+            case PROP_MENU_SELECTED_TRUE:
+            case PROP_MENU_SELECTED_FALSE:
+               twr_window_menu_widget_set_bool(
+                  prop_menu_data.widget, 
+                  prop_menu_data.prop_name, 
+                  selected == PROP_MENU_SELECTED_TRUE ? TRUE : FALSE
+               );
+            break;
+            case PROP_MENU_SELECTED_UNDEFINED:
+               twr_window_menu_widget_set_undefined(
+                  prop_menu_data.widget,
+                  prop_menu_data.prop_name
+               );
+            break;
+            case PROP_MENU_SELECTED_STRING:
+               twr_window_menu_widget_set_string(
+                  prop_menu_data.widget,
+                  prop_menu_data.prop_name,
+                  prop_menu_data.text_buffer.text
+               );
+            break;
+            case PROP_MENU_SELECTED_NUMBER:
+            {
+               assert(prop_menu_data.number_buffer.length > 0);
+               double res = strtod(prop_menu_data.number_buffer.text, NULL);
+               twr_window_menu_widget_set_number(
+                  prop_menu_data.widget,
+                  prop_menu_data.prop_name,
+                  res
+               );
+            }
+            break;
+            default:
+            assert(FALSE);
+         }
+         prop_menu_data.state = PROP_MENU_UNOPENED;
+      }
+      break;
+
+      case '-':
+      if (selected == PROP_MENU_SELECTED_NUMBER) {
+         if (number_buffer->length == 0) {
+            append_to_text_fill_buffer(number_buffer, '-');
+         }
+         break; //only break if it was a number, otherwise propogates down to default
+      }
+
+      case '0':
+      case '1':
+      case '2':
+      case '3':
+      case '4':
+      case '5':
+      case '6':
+      case '7':
+      case '9':
+      if (selected == PROP_MENU_SELECTED_NUMBER) {
+         append_to_text_fill_buffer(number_buffer, key);
+         break;
+      }
+
+      case '.':
+      if (selected == PROP_MENU_SELECTED_NUMBER) {
+         if (!prop_menu_data.number_buffer_has_dot) {
+            prop_menu_data.number_buffer_has_dot = TRUE;
+
+            append_to_text_fill_buffer(number_buffer, key);
+         }
+
+         break;
+      }
+      
+      default:
+      if (selected == PROP_MENU_SELECTED_STRING) {
+         if (key <= 0xFF && isprint(key))
+            append_to_text_fill_buffer(text_buffer, key);
       }
       break;
    }

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -16,6 +16,7 @@ struct twr_window_widget box_color_menu;
 struct twr_window_widget test_two_menu;
 struct twr_window_widget extra_menu;
 struct twr_window_widget prop_menu;
+struct twr_window_widget menu_prop_menu;
 unsigned long box_color = 0xFF0000FF;
 int box_border = 0;
 
@@ -121,6 +122,7 @@ void setup_box_options_menu(struct twr_window_widget *box_options_menu);
 void setup_test_two_menu(struct twr_window_widget *test_two_menu);
 void setup_extra_menu(struct twr_window_widget *extra_menu);
 void setup_prop_menu(struct twr_window_widget *prop_menu);
+void setup_menu_prop_menu(struct twr_window_widget *menu_prop_menu);
 __attribute__((export_name("init")))
 void init() {
    if (window_con)
@@ -165,11 +167,13 @@ void init() {
    test_two_menu = twr_window_add_menu(window_con, "test_two");
    extra_menu = twr_window_add_menu(window_con, "extra");
    prop_menu = twr_window_add_menu(window_con, "prop_modifiers");
+   menu_prop_menu = twr_window_add_menu(window_con, "Menu_Prop_Menu");
 
    setup_box_options_menu(&box_color_menu);
    setup_test_two_menu(&test_two_menu);
    setup_extra_menu(&extra_menu);
    setup_prop_menu(&prop_menu);
+   setup_menu_prop_menu(&menu_prop_menu);
 }
 
 struct prop_menu_data {
@@ -189,6 +193,10 @@ enum prop_menu_selected {
    PROP_MENU_SELECTED_UNDEFINED,
    PROP_MENU_SELECTED_NUMBER,
    PROP_MENU_SELECTED_STRING
+};
+enum prop_menu_target {
+   PROP_MENU_TARGET_WIDGET,
+   PROP_MENU_TARGET_MENU
 };
 struct text_fill_buffer {
    char text[100];
@@ -215,6 +223,7 @@ bool try_pop_from_text_fill_buffer(struct text_fill_buffer* buffer, char* ret_ch
 struct prop_menu_popup {
    const char* prop_name;
    enum prop_menu_state state;
+   enum prop_menu_target target;
    struct text_fill_buffer text_buffer;
    struct text_fill_buffer number_buffer;
    bool number_buffer_has_dot;
@@ -235,6 +244,7 @@ void window_prop_menu_get_event(int event_id, struct prop_menu_data* prop_data) 
    struct twr_widget_prop_value* val = twr_window_menu_widget_get_prop(prop_data->widget, prop_data->prop_details->name);
 
    prop_menu_data.state = PROP_MENU_GET;
+   prop_menu_data.target = PROP_MENU_TARGET_WIDGET;
    // prop_menu_data.selected = PROP_MENU_SELECTED_NONE;
    prop_menu_data.prop_name = prop_data->prop_details->name;
    prop_menu_data.width = 200;
@@ -266,6 +276,7 @@ void window_prop_menu_set_event(int event_id, struct prop_menu_data* prop_data) 
    prop_menu_data = (struct prop_menu_popup){
       .prop_name = prop_data->prop_details->name,
       .state = PROP_MENU_SET,
+      .target = PROP_MENU_TARGET_WIDGET,
       .text_buffer = (struct text_fill_buffer){
          .text = "",
          .length = 0
@@ -315,33 +326,12 @@ void window_prop_menu_set_event(int event_id, struct prop_menu_data* prop_data) 
    }
 }
 void setup_prop_menu(struct twr_window_widget *prop_menu) {
-   struct twr_widget_check_box_constructor modified_prop_cons = {
-      .base = {
-         .height = 10,
-         .width = -1,
-         .type = WINDOW_WIDGET_CHECK_BOX
-      },
-      .text = "Test Widget"
-   };
-
-   struct twr_window_widget modified_prop = twr_window_menu_add_widget(prop_menu, &modified_prop_cons.base);
+   struct twr_window_widget modified_prop = twr_window_menu_add_check_box_widget(prop_menu, -1, 10, "Test Widget");
    struct twr_window_widget* modified_prop_heap = (struct twr_window_widget*)malloc(sizeof(struct twr_window_widget));
    *modified_prop_heap = modified_prop;
 
-   struct twr_widget_sub_menu_constructor get_set_fields = {
-      .base = {
-         .height = 10,
-         .width = -1,
-         .type = WINDOW_WIDGET_SUB_MENU
-      },
-      .button_text = "Setters",
-      .minimum_child_height = -1,
-      .minimum_menu_height = -1,
-      .minimum_menu_width = -1,
-   };
-   struct twr_window_widget setter_menu = twr_window_menu_add_widget(prop_menu, &get_set_fields.base);
-   get_set_fields.button_text = "Getters";
-   struct twr_window_widget getter_menu = twr_window_menu_add_widget(prop_menu, &get_set_fields.base);
+   struct twr_window_widget setter_menu = twr_window_menu_add_sub_menu_widget_reduced(prop_menu, -1, 10, "Setters");
+   struct twr_window_widget getter_menu = twr_window_menu_add_sub_menu_widget_reduced(prop_menu, -1, 10, "Getters");
 
    
    long prop_len;
@@ -356,32 +346,14 @@ void setup_prop_menu(struct twr_window_widget *prop_menu) {
          .widget = modified_prop_heap,
       };
       if (prop_data->prop_details->access & WINDOW_WIDGET_PROP_GET) {
-         // struct twr_widget_button_constructor get_button_cons = {
-         //    .base = {
-         //       .height = 10,
-         //       .width = -1,
-         //       .type = WINDOW_WIDGET_BUTTON
-         //    },
-         //    .text = prop_data->prop_details->name
-         // };
          struct twr_window_widget get_button = twr_window_menu_add_button_widget(
             &getter_menu, 
             -1, 10, 
             prop_data->prop_details->name
          );
-         // struct twr_window_widget get_button = twr_window_menu_add_widget(&getter_menu, &get_button_cons.base);
          twr_window_menu_widget_add_callback(&get_button, getter_event_id, (void*)prop_data);
       }
       if (prop_data->prop_details->access & WINDOW_WIDGET_PROP_SET) {
-         // struct twr_widget_button_constructor set_button_cons = {
-         //    .base = {
-         //       .height = 10,
-         //       .width = -1,
-         //       .type = WINDOW_WIDGET_BUTTON
-         //    },
-         //    .text = prop_data->prop_details->name
-         // };
-         // struct twr_window_widget set_button = twr_window_menu_add_widget(&setter_menu, &set_button_cons.base);
          struct twr_window_widget set_button = twr_window_menu_add_button_widget(
             &setter_menu,
             -1, 10,
@@ -420,15 +392,7 @@ void setup_box_color_sub_menu(struct twr_window_widget* box_color_sub_menu) {
    int box_color_event = twr_register_callback("boxColorChanged");
    struct twr_window_widget root_radio_item;
    for (int i = 0; i < 6; i++) {
-      struct twr_widget_radio_item_constructor radio_item_constructor = {
-         .base = {
-            .type = WINDOW_WIDGET_RADIO_ITEM,
-            .width = -1,
-            .height = 10,
-         },
-         .text = BOX_COLOR_NAMES[i],
-      };
-      struct twr_window_widget radioItem = twr_window_menu_add_widget(box_color_sub_menu, &radio_item_constructor.base);
+      struct twr_window_widget radioItem = twr_window_menu_add_radio_item_widget(box_color_sub_menu, -1, 10, BOX_COLOR_NAMES[i]);
       twr_window_menu_widget_add_callback(&radioItem, box_color_event, (void*)(BOX_COLOR_VALUES[i]));
 
       if (i == 0) {
@@ -439,32 +403,10 @@ void setup_box_color_sub_menu(struct twr_window_widget* box_color_sub_menu) {
    }
 }
 void setup_box_options_menu(struct twr_window_widget* box_options_menu) {
-   struct twr_widget_sub_menu_constructor sub_menu = {
-      .base = {
-         .type = WINDOW_WIDGET_SUB_MENU,
-         .width = 20,
-         .height = -1,
-      },
-      .button_text = "Box Color",
-      
-      .minimum_child_height = -1,
-      .minimum_menu_height = -1,
-      .minimum_menu_width = -1,
-      
-   };
-   struct twr_window_widget box_color_sub_menu = twr_window_menu_add_widget(box_options_menu, &sub_menu.base);
+   struct twr_window_widget box_color_sub_menu = twr_window_menu_add_sub_menu_widget_reduced(box_options_menu, -1, 20, "Box Color");
    setup_box_color_sub_menu(&box_color_sub_menu);
 
-   struct twr_widget_check_box_constructor check_box_constructor = {
-      .base = {
-         .type = WINDOW_WIDGET_CHECK_BOX,
-         .width = -1,
-         .height = 20
-      },
-      .text = "Box Outline",
-   };
-
-   struct twr_window_widget check_box = twr_window_menu_add_widget(box_options_menu, &check_box_constructor.base);
+   struct twr_window_widget check_box = twr_window_menu_add_check_box_widget(box_options_menu, -1, 20, "Box Outline");
    int check_box_event = twr_register_callback("boxBorderChanged");
    twr_window_menu_widget_add_callback(&check_box, check_box_event, (void*)0);
 }
@@ -472,14 +414,6 @@ void setup_box_options_menu(struct twr_window_widget* box_options_menu) {
 
 __attribute__((export_name("spawnButtonPressed")))
 void spawn_button_pressed(int event_id, void* ptr) {
-   // struct twr_widget_button_constructor new_button_con = {
-   //    .base = {
-   //       .width = -1,
-   //       .height = 20,
-   //    },
-   //    .text = "Delete!",
-   // };
-   // struct twr_window_widget button = twr_window_menu_add_widget(&test_two_menu, &new_button_con.base);
    struct twr_window_widget button = twr_window_menu_add_button_widget(
       &test_two_menu,
       -1, 10,
@@ -511,15 +445,6 @@ void delete_button_pressed(int event_id, struct twr_window_widget* button) {
 }
 
 void setup_test_two_menu(struct twr_window_widget *test_two_menu) {
-   // struct twr_widget_button_constructor spawn_button_constructor = {
-   //    .base = {
-   //       .type = WINDOW_WIDGET_BUTTON,
-   //       .width = -1,
-   //       .height = 20
-   //    },
-   //    .text = "Spawn New Button",
-   // };
-   // spawn_button = twr_window_menu_add_widget(test_two_menu, &spawn_button_constructor.base);
    spawn_button = twr_window_menu_add_button_widget(
       test_two_menu,
       -1, 10,
@@ -530,17 +455,7 @@ void setup_test_two_menu(struct twr_window_widget *test_two_menu) {
    twr_window_menu_widget_add_callback(&spawn_button, spawn_button_callback, (void*)0);
    delete_button_callback = twr_register_callback("deleteButtonPressed");
 
-   struct twr_widget_seperator_constructor seperator_cons = {
-      .base = {
-         .type = WINDOW_WIDGET_SEPERATOR,
-         .width = -1,
-         .height = 10
-      },
-      .seperator_text = "-",
-      .seperator_font = NULL,
-   };
-
-   twr_window_menu_add_widget(test_two_menu, &seperator_cons.base);
+   twr_window_menu_add_seperator_widget(test_two_menu, -1, 10, "-", NULL);
 }
 
 void set_widget_visibility(struct twr_window_widget* widget, int visibility) {
@@ -552,27 +467,9 @@ void setup_extra_box_movement_sub_menu(struct twr_window_widget* box_movement_me
    extra_box_movement_items->len = 4;
    extra_box_movement_items->arr = (struct twr_window_widget*)malloc(sizeof(struct twr_window_widget) * extra_box_movement_items->len);
 
-   struct twr_widget_check_box_constructor extra_box_movement_show_box_cons = {
-      .base = {
-         .type = WINDOW_WIDGET_CHECK_BOX,
-         .width = -1,
-         .height = 20
-      },
-      .text = "Show"
-   };
-   struct twr_window_widget extra_box_movement_show_box = twr_window_menu_add_widget(box_movement_menu, &extra_box_movement_show_box_cons.base);
-   
-   struct twr_widget_seperator_constructor seperator_cons = {
-      .base = {
-         .type = WINDOW_WIDGET_SEPERATOR,
-         .width = -1,
-         .height = 10
-      },
-      .seperator_text = "-",
-      .seperator_font = NULL,
-   };
+   struct twr_window_widget extra_box_movement_show_box = twr_window_menu_add_check_box_widget(box_movement_menu, -1, 20, "Show");
 
-   extra_box_movement_items->arr[0] = twr_window_menu_add_widget(box_movement_menu, &seperator_cons.base);
+   extra_box_movement_items->arr[0] = twr_window_menu_add_seperator_widget(box_movement_menu, -1, 10, "-", NULL);
 
    const char* MOUSE_MOVE_METHOD_NAMES[3] = {
       "On Mouse Movement",
@@ -587,15 +484,7 @@ void setup_extra_box_movement_sub_menu(struct twr_window_widget* box_movement_me
    struct twr_window_widget root_radio_item;
    int extra_box_movement_options_event_id = twr_register_callback("extraBoxMovementOptionCallback");
    for (int i = 0; i < 3; i++) {
-      struct twr_widget_radio_item_constructor radio_item_cons = {
-         .base = {
-            .type = WINDOW_WIDGET_RADIO_ITEM,
-            .height = 10,
-            .width = -1
-         },
-         .text = MOUSE_MOVE_METHOD_NAMES[i]
-      };
-      struct twr_window_widget radio_item = twr_window_menu_add_widget(box_movement_menu, &radio_item_cons.base);
+      struct twr_window_widget radio_item = twr_window_menu_add_radio_item_widget(box_movement_menu, -1, 10, MOUSE_MOVE_METHOD_NAMES[i]);
       twr_window_menu_widget_add_callback(&radio_item, extra_box_movement_options_event_id, (void*)MOUSE_MOVE_METHOD_TYPES[i]);
       if (i == 0) {
          root_radio_item = radio_item;
@@ -615,54 +504,20 @@ void setup_extra_box_movement_sub_menu(struct twr_window_widget* box_movement_me
 }
 
 void setup_extra_menu(struct twr_window_widget *extra_menu) {
-   struct twr_widget_check_box_constructor extra_checkbox_constructor = {
-      .base = {
-         .type = WINDOW_WIDGET_CHECK_BOX,
-         .width = -1,
-         .height = 20,
-      },
-      .text = "Show Extra Options"
-   };
-   struct twr_window_widget extra_check_box = twr_window_menu_add_widget(extra_menu, &extra_checkbox_constructor.base);
+   struct twr_window_widget extra_check_box = twr_window_menu_add_check_box_widget(extra_menu, -1, 20, "Show Extra Options");
    int extra_checkbox_event_id = twr_register_callback("extraCheckBoxCallback");
 
    struct DynamicWidgetArray* extra_widget_array = (struct DynamicWidgetArray*)malloc(sizeof(struct DynamicWidgetArray));
    extra_widget_array->len = 4;
    extra_widget_array->arr = (struct twr_window_widget*)malloc(sizeof(struct twr_window_widget) * extra_widget_array->len);
 
-   struct twr_widget_seperator_constructor seperator_cons = {
-      .base = {
-         .type = WINDOW_WIDGET_SEPERATOR,
-         .width = -1,
-         .height = 10
-      },
-      .seperator_text = "-",
-      .seperator_font = NULL,
-   };
-   extra_widget_array->arr[0] = twr_window_menu_add_widget(extra_menu, &seperator_cons.base);
+   extra_widget_array->arr[0] = twr_window_menu_add_seperator_widget(extra_menu, -1, 10, "-", NULL);
 
-   struct twr_widget_check_box_constructor extra_center_dot_checkbox_cons = {
-      .base = {
-         .type = WINDOW_WIDGET_CHECK_BOX,
-         .width = -1,
-         .height = 20,
-      },
-      .text = "Centered Dot"
-   };
-   struct twr_window_widget extra_center_dot_checkbox = twr_window_menu_add_widget(extra_menu, &extra_center_dot_checkbox_cons.base);
+   struct twr_window_widget extra_center_dot_checkbox = twr_window_menu_add_check_box_widget(extra_menu, -1, 20, "Centered Dot");
    int extra_center_dot_event_id = twr_register_callback("extraCenterDotCallback");
    twr_window_menu_widget_add_callback(&extra_center_dot_checkbox, extra_center_dot_event_id, (void*)0);
    extra_widget_array->arr[1] = extra_center_dot_checkbox;
 
-   // struct twr_widget_button_constructor randomize_center_dot_color_cons = {
-   //    .base = {
-   //       .type = WINDOW_WIDGET_BUTTON,
-   //       .width = -1,
-   //       .height = 20,
-   //    },
-   //    .text = "Randomize Center Dot Color"
-   // };
-   // struct twr_window_widget randomize_center_dot_color = twr_window_menu_add_widget(extra_menu, &randomize_center_dot_color_cons.base);
    struct twr_window_widget randomize_center_dot_color = twr_window_menu_add_button_widget(
       extra_menu,
       -1, 20,
@@ -672,18 +527,7 @@ void setup_extra_menu(struct twr_window_widget *extra_menu) {
    twr_window_menu_widget_add_callback(&randomize_center_dot_color, randomize_center_dot_color_event_id, (void*)0);
    extra_widget_array->arr[2] = randomize_center_dot_color;
 
-   struct twr_widget_sub_menu_constructor extra_box_movement_menu_cons = {
-      .base = {
-         .type = WINDOW_WIDGET_SUB_MENU,
-         .height = 20,
-         .width = -1,
-      },
-      .minimum_child_height = -1,
-      .minimum_menu_height = -1,
-      .minimum_menu_width = -1,
-      .button_text = "Box Movement"
-   };
-   struct twr_window_widget extra_box_movement_menu = twr_window_menu_add_widget(extra_menu, &extra_box_movement_menu_cons.base);
+   struct twr_window_widget extra_box_movement_menu = twr_window_menu_add_sub_menu_widget_reduced(extra_menu, -1, 20, "Box Movement");
    setup_extra_box_movement_sub_menu(&extra_box_movement_menu);
    extra_widget_array->arr[3] = extra_box_movement_menu;
 
@@ -691,6 +535,19 @@ void setup_extra_menu(struct twr_window_widget *extra_menu) {
 
    for (int i = 0; i < extra_widget_array->len; i++) {
       set_widget_visibility(&extra_widget_array->arr[i], 0);
+   }
+}
+
+void setup_menu_prop_menu(struct twr_window_widget *menu_prop_menu) {
+   struct twr_window_widget getters = twr_window_menu_add_sub_menu_widget_reduced(menu_prop_menu, -1, 10, "Getters");
+   struct twr_window_widget setters = twr_window_menu_add_sub_menu_widget_reduced(menu_prop_menu, -1, 10, "Setters");
+
+   long length = 0;
+   struct twr_menu_prop_details* prop_list =  twr_window_menu_list_props(window_con, &length);
+   
+   for (long i = 0; i < length; i++) {
+      struct twr_window_widget getter = twr_window_menu_add_button_widget(&getters, -1, 10, prop_list[i].name);
+      struct twr_window_widget setter = twr_window_menu_add_button_widget(&setters, -1, 10, prop_list[i].name);
    }
 }
 

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -185,14 +185,15 @@ void init() {
    struct twr_widget_sub_menu_constructor sub_menu = {
       .base = {
          .type = WINDOW_WIDGET_SUB_MENU,
-         .width = 30,
-         .height = 20,
+         .width = 20,
+         .height = -1,
       },
       .button_text = "Box Color",
       
-      .min_child_height = 10,
-      .minimum_menu_height = 10,
-      .minimum_menu_width = 10,
+      .min_child_height = -1,
+      .minimum_menu_height = -1,
+      .minimum_menu_width = -1,
+      
    };
    struct twr_window_widget box_color_sub_menu = twr_window_menu_add_widget(&box_color_menu, &sub_menu.base);
 
@@ -225,7 +226,7 @@ void init() {
       "Cyan",
       "Teal"
    };
-   const int* BOX_COLOR_VALUES = {
+   const int BOX_COLOR_VALUES[] = {
       0xFF0000FF,
       0x0000FFFF,
       0xFF00FFFF,
@@ -234,7 +235,7 @@ void init() {
       0x008080FF
    };
    int box_color_event = twr_register_callback("boxColorChanged");
-   struct twr_window_widget main_widget;
+   struct twr_window_widget root_radio_item;
    for (int i = 0; i < 6; i++) {
       struct twr_widget_radio_item_constructor radio_item_constructor = {
          .base = {
@@ -245,7 +246,13 @@ void init() {
          .text = BOX_COLOR_NAMES[i],
       };
       struct twr_window_widget radioItem = twr_window_menu_add_widget(&box_color_sub_menu, &radio_item_constructor.base);
-      twr_window_menu_widget_add_callback(&radioItem, box_color_event, (void*)(BOX_COLOR_VALUES[i])
+      twr_window_menu_widget_add_callback(&radioItem, box_color_event, (void*)(BOX_COLOR_VALUES[i]));
+
+      if (i == 0) {
+         root_radio_item = radioItem;
+      } else {
+         twr_window_menu_radio_item_merge(&root_radio_item, &radioItem);
+      }
    }
 
    
@@ -331,7 +338,7 @@ void init() {
    struct twr_window_widget extra_box_movement_menu = twr_window_menu_add_widget(&extra_menu, &extra_box_movement_menu_cons.base);
 
    struct DynamicWidgetArray* extra_box_movement_items = (struct DynamicWidgetArray*)malloc(sizeof(struct DynamicWidgetArray));
-   extra_box_movement_items->len = 2;
+   extra_box_movement_items->len = 1;
    extra_box_movement_items->arr = (struct twr_window_widget*)malloc(sizeof(struct twr_window_widget) * extra_box_movement_items->len);
 
    struct twr_widget_check_box_constructor extra_box_movement_show_box_cons = {
@@ -348,51 +355,82 @@ void init() {
 
    extra_box_movement_items->arr[0] = twr_window_menu_add_widget(&extra_box_movement_menu, &seperator_cons.base);
 
-   struct twr_widget_radio_menu_constructor extra_box_movement_options_cons = {
-      .base = {
-         .type = WINDOW_WIDGET_RADIO_MENU,
-         .width = -1,
-         .height = -1
-      },
-      .minimum_height = -1,
-      .minimum_width = -1,
-      .option_height = 20,
-      .selected_symbol = "*",
+   // struct twr_widget_radio_menu_constructor extra_box_movement_options_cons = {
+   //    .base = {
+   //       .type = WINDOW_WIDGET_RADIO_MENU,
+   //       .width = -1,
+   //       .height = -1
+   //    },
+   //    .minimum_height = -1,
+   //    .minimum_width = -1,
+   //    .option_height = 20,
+   //    .selected_symbol = "*",
+   // };
+   // struct twr_window_widget extra_box_movement_options = twr_window_menu_add_widget(&extra_box_movement_menu, &extra_box_movement_options_cons.base);
+   // twr_window_menu_radio_menu_add_option(&extra_box_movement_options, "On Mouse Movement");
+   // twr_window_menu_radio_menu_add_option(&extra_box_movement_options, "On Left Click");
+   // twr_window_menu_radio_menu_add_option(&extra_box_movement_options, "On Double Click");
+   // int extra_box_movement_options_event_id = twr_register_callback("extraBoxMovementOptionCallback");
+   // twr_window_menu_widget_add_callback(&extra_box_movement_options, extra_box_movement_options_event_id, (void*)0);
+   // extra_box_movement_items->arr[1] = extra_box_movement_options;
+   // twr_window_menu_widget_add_callback(&extra_box_movement_show_box, extra_checkbox_event_id, (void*)extra_box_movement_items);
+   // for (int i = 0; i < extra_box_movement_items->len; i++) {
+   //    twr_window_menu_widget_set_visibility(&extra_box_movement_items->arr[i], 0);
+   // }
+   // extra_widget_array->arr[3] = extra_box_movement_menu;
+
+   const char* MOUSE_MOVE_METHOD_NAMES[20] = {
+      "On Mouse Movement",
+      "On Left Click",
+      "On Double Click"
    };
-   struct twr_window_widget extra_box_movement_options = twr_window_menu_add_widget(&extra_box_movement_menu, &extra_box_movement_options_cons.base);
-   twr_window_menu_radio_menu_add_option(&extra_box_movement_options, "On Mouse Movement");
-   twr_window_menu_radio_menu_add_option(&extra_box_movement_options, "On Left Click");
-   twr_window_menu_radio_menu_add_option(&extra_box_movement_options, "On Double Click");
+   const enum MOUSE_EVENT_TYPE MOUSE_MOVE_METHOD_TYPES[] = {
+      MOUSE_EVENT_MOVE,
+      MOUSE_EVENT_LEFT_CLICK,
+      MOUSE_EVENT_DOUBLE_CLICK
+   };
    int extra_box_movement_options_event_id = twr_register_callback("extraBoxMovementOptionCallback");
-   twr_window_menu_widget_add_callback(&extra_box_movement_options, extra_box_movement_options_event_id, (void*)0);
-   extra_box_movement_items->arr[1] = extra_box_movement_options;
-   twr_window_menu_widget_add_callback(&extra_box_movement_show_box, extra_checkbox_event_id, (void*)extra_box_movement_items);
-   for (int i = 0; i < extra_box_movement_items->len; i++) {
-      twr_window_menu_widget_set_visibility(&extra_box_movement_items->arr[i], 0);
+   for (int i = 0; i < 3; i++) {
+      struct twr_widget_radio_item_constructor radio_item_cons = {
+         .base = {
+            .type = WINDOW_WIDGET_RADIO_ITEM,
+            .height = 10,
+            .width = -1
+         },
+         .text = MOUSE_MOVE_METHOD_NAMES[i]
+      };
+      struct twr_window_widget radio_item = twr_window_menu_add_widget(&extra_box_movement_menu, &radio_item_cons);
+      twr_window_menu_widget_add_callback(&radio_item, extra_box_movement_options_event_id, (void*)MOUSE_MOVE_METHOD_TYPES[i]);
+      if (i == 0) {
+         root_radio_item = radio_item;
+      } else {
+         twr_window_menu_radio_item_merge(&root_radio_item, &radio_item);
+      }
    }
-   extra_widget_array->arr[3] = extra_box_movement_menu;
 
 
 
 
 
-   for (int i = 0; i < extra_widget_array->len; i++) {
-      twr_window_menu_widget_set_visibility(&extra_widget_array->arr[i], 0);
-   }
+   // for (int i = 0; i < extra_widget_array->len; i++) {
+   //    twr_window_menu_widget_set_visibility(&extra_widget_array->arr[i], 0);
+   // }
 
    
    twr_window_menu_widget_add_callback(&extra_check_box, extra_checkbox_event_id, (void*)extra_widget_array);
    
 }
 __attribute__((export_name("extraBoxMovementOptionCallback")))
-void extra_box_movement_option_callback(int event_id, void* _, char* option) {
-   if (strcmp("On Mouse Movement", option) == 0) {
-      box_move_event_type = MOUSE_EVENT_MOVE;
-   } else if (strcmp("On Left Click", option) == 0) {
-      box_move_event_type = MOUSE_EVENT_LEFT_CLICK;
-   } else if (strcmp("On Double Click", option) == 0) {
-      box_move_event_type = MOUSE_EVENT_DOUBLE_CLICK;
-   }
+void extra_box_movement_option_callback(int event_id, void* extra, int selected/*, char* option*/) {
+   // if (strcmp("On Mouse Movement", option) == 0) {
+   //    box_move_event_type = MOUSE_EVENT_MOVE;
+   // } else if (strcmp("On Left Click", option) == 0) {
+   //    box_move_event_type = MOUSE_EVENT_LEFT_CLICK;
+   // } else if (strcmp("On Double Click", option) == 0) {
+   //    box_move_event_type = MOUSE_EVENT_DOUBLE_CLICK;
+   // }
+   if (selected)
+      box_move_event_type = (enum MOUSE_EVENT_TYPE)extra;
 }
 __attribute__((export_name("randomizeCenterDotColorCallback")))
 void randomize_center_dot_color_callback(int event_id, void* _) {
@@ -439,21 +477,23 @@ void delete_button_pressed(int event_id, struct twr_window_widget* button) {
    free(button);
 }
 __attribute__((export_name("boxColorChanged")))
-void box_color_changed(int event_id, void* extra, char* opt) {
-   if (strcmp(opt, "Red") == 0) {
-      box_color = 0xFF0000FF;
-   } else if (strcmp(opt, "Blue") == 0) {
-      box_color = 0x0000FFFF;
-   } else if (strcmp(opt, "Magenta") == 0) {
-      box_color = 0xFF00FFFF;
-   } else if (strcmp(opt, "Yellow") == 0) {
-      box_color = 0xFFFF00FF;
-   } else if (strcmp(opt, "Cyan") == 0) {
-      box_color = 0x00FFFFFF;
-   } else if (strcmp(opt, "Teal") == 0) {
-      box_color = 0x008080FF;
-   }
-   free(opt);
+void box_color_changed(int event_id, void* extra, int selected/*, char* opt*/) {
+   // if (strcmp(opt, "Red") == 0) {
+   //    box_color = 0xFF0000FF;
+   // } else if (strcmp(opt, "Blue") == 0) {
+   //    box_color = 0x0000FFFF;
+   // } else if (strcmp(opt, "Magenta") == 0) {
+   //    box_color = 0xFF00FFFF;
+   // } else if (strcmp(opt, "Yellow") == 0) {
+   //    box_color = 0xFFFF00FF;
+   // } else if (strcmp(opt, "Cyan") == 0) {
+   //    box_color = 0x00FFFFFF;
+   // } else if (strcmp(opt, "Teal") == 0) {
+   //    box_color = 0x008080FF;
+   // }
+   // free(opt);
+   if (selected)
+      box_color = (int)extra;
 }
 
 

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -15,6 +15,7 @@ struct twr_window_widget box_color_menu;
 struct twr_window_widget test_two_menu;
 
 unsigned long box_color = 0xFF0000FF;
+int box_border = 0;
 
 struct twr_window_widget spawn_button;
 int delete_button_callback;
@@ -136,15 +137,24 @@ void init() {
       },
       .button_color = NULL,
       .checked_symbol = "[*]",
-      .unchecked_symbol = "[ ]",
+      .unchecked_symbol = "[  ]",
       .reserved_prefix_space = -1,
       .selected_button_color = NULL,
       .text = "Box Outline",
       .text_color = NULL,
       .text_font = NULL,
    };
+
+   struct twr_window_widget check_box = twr_window_menu_add_widget(&box_color_menu, &check_box_constructor.base);
+   int check_box_event = twr_register_callback("boxBorderChanged");
+   twr_window_menu_widget_add_callback(&check_box, check_box_event, (void*)0);
 }
 
+__attribute__((export_name("boxBorderChanged")))
+void box_border_changed(int event_id, void* _, int new_state) {
+   printf("new box border update! %d\n", new_state);
+   box_border = new_state;
+}
 __attribute__((export_name("spawnButtonPressed")))
 void spawn_button_pressed(int event_id, void* ptr) {
    struct twr_widget_button_constructor new_button_con = {
@@ -207,6 +217,12 @@ void animation_frame(int id, int delta) {
 
    d2d_setfillstylergba(ds, box_color);
    d2d_fillrect(ds, square_x, square_y, SQUARE_WIDTH, SQUARE_HEIGHT);
+
+   d2d_setstrokestylergba(ds, 0x000000FF);
+   d2d_setlinewidth(ds, 4.0);
+   if (box_border) {
+      d2d_strokerect(ds, square_x, square_y, SQUARE_WIDTH, SQUARE_HEIGHT);
+   }
 
    d2d_end_draw_sequence(ds);
 }

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -115,6 +115,9 @@ enum MOUSE_EVENT_TYPE {
 int mouse_event_ids[3] = {};
 enum MOUSE_EVENT_TYPE box_move_event_type = MOUSE_EVENT_MOVE;
 
+void setup_box_options_menu(struct twr_window_widget *box_options_menu);
+void setup_test_two_menu(struct twr_window_widget *test_two_menu);
+void setup_extra_menu(struct twr_window_widget *extra_menu);
 __attribute__((export_name("init")))
 void init() {
    if (window_con)
@@ -154,70 +157,19 @@ void init() {
    test_two_menu = twr_window_add_menu(window_con, "test_two");
    extra_menu = twr_window_add_menu(window_con, "extra");
 
-   struct twr_widget_button_constructor spawn_button_constructor = {
-      .base = {
-         .type = WINDOW_WIDGET_BUTTON,
-         .width = -1,
-         .height = 20
-      },
-      .text = "Spawn New Button",
-   };
-   spawn_button = twr_window_menu_add_widget(&test_two_menu, &spawn_button_constructor.base);
-   
-   int spawn_button_callback = twr_register_callback("spawnButtonPressed");
-   twr_window_menu_widget_add_callback(&spawn_button, spawn_button_callback, (void*)0);
-   delete_button_callback = twr_register_callback("deleteButtonPressed");
+   setup_box_options_menu(&box_color_menu);
+   setup_test_two_menu(&test_two_menu);
+   setup_extra_menu(&extra_menu);
+}
 
-   struct twr_widget_seperator_constructor seperator_cons = {
-      .base = {
-         .type = WINDOW_WIDGET_SEPERATOR,
-         .width = -1,
-         .height = 10
-      },
-      .seperator_text = "-",
-      .seperator_font = NULL,
-   };
 
-   twr_window_menu_add_widget(&test_two_menu, &seperator_cons.base);
-   
+__attribute__((export_name("boxColorChanged")))
+void box_color_changed(int event_id, void* extra, int selected) {
+   if (selected)
+      box_color = (int)extra;
+}
 
-   // struct twr_window_menu radio_menu_header = twr_window_add_menu(window_con, "Radio_Menu");
-   struct twr_widget_sub_menu_constructor sub_menu = {
-      .base = {
-         .type = WINDOW_WIDGET_SUB_MENU,
-         .width = 20,
-         .height = -1,
-      },
-      .button_text = "Box Color",
-      
-      .min_child_height = -1,
-      .minimum_menu_height = -1,
-      .minimum_menu_width = -1,
-      
-   };
-   struct twr_window_widget box_color_sub_menu = twr_window_menu_add_widget(&box_color_menu, &sub_menu.base);
-
-   // struct twr_widget_radio_menu_constructor radio_menu_constructor = {
-   //    .base = {
-   //       .type = WINDOW_WIDGET_RADIO_MENU,
-   //       .width = -1,
-   //       .height = -1,
-   //    },
-   //    .minimum_height = 10,
-   //    .minimum_width = 10,
-   //    .option_height = 20,
-   //    .selected_symbol = "*",
-   // };
-   // struct twr_window_widget radio_menu = twr_window_menu_add_widget(&box_color_sub_menu, &radio_menu_constructor.base);
-   // twr_window_menu_radio_menu_add_option(&radio_menu, "Red");
-   // twr_window_menu_radio_menu_add_option(&radio_menu, "Blue");
-   // twr_window_menu_radio_menu_add_option(&radio_menu, "Magenta");
-   // twr_window_menu_radio_menu_add_option(&radio_menu, "Yellow");
-   // twr_window_menu_radio_menu_add_option(&radio_menu, "Cyan");
-   // twr_window_menu_radio_menu_add_option(&radio_menu, "Teal");
-
-   // int box_color_event = twr_register_callback("boxColorChanged");
-   // twr_window_menu_widget_add_callback(&radio_menu, box_color_event, (void*)0);
+void setup_box_color_sub_menu(struct twr_window_widget* box_color_sub_menu) {
    const char* BOX_COLOR_NAMES[20] = {
       "Red",
       "Blue",
@@ -245,7 +197,7 @@ void init() {
          },
          .text = BOX_COLOR_NAMES[i],
       };
-      struct twr_window_widget radioItem = twr_window_menu_add_widget(&box_color_sub_menu, &radio_item_constructor.base);
+      struct twr_window_widget radioItem = twr_window_menu_add_widget(box_color_sub_menu, &radio_item_constructor.base);
       twr_window_menu_widget_add_callback(&radioItem, box_color_event, (void*)(BOX_COLOR_VALUES[i]));
 
       if (i == 0) {
@@ -254,8 +206,23 @@ void init() {
          twr_window_menu_radio_item_merge(&root_radio_item, &radioItem);
       }
    }
-
-   
+}
+void setup_box_options_menu(struct twr_window_widget* box_options_menu) {
+   struct twr_widget_sub_menu_constructor sub_menu = {
+      .base = {
+         .type = WINDOW_WIDGET_SUB_MENU,
+         .width = 20,
+         .height = -1,
+      },
+      .button_text = "Box Color",
+      
+      .min_child_height = -1,
+      .minimum_menu_height = -1,
+      .minimum_menu_width = -1,
+      
+   };
+   struct twr_window_widget box_color_sub_menu = twr_window_menu_add_widget(box_options_menu, &sub_menu.base);
+   setup_box_color_sub_menu(&box_color_sub_menu);
 
    struct twr_widget_check_box_constructor check_box_constructor = {
       .base = {
@@ -268,191 +235,12 @@ void init() {
       .text = "Box Outline",
    };
 
-   struct twr_window_widget check_box = twr_window_menu_add_widget(&box_color_menu, &check_box_constructor.base);
+   struct twr_window_widget check_box = twr_window_menu_add_widget(box_options_menu, &check_box_constructor.base);
    int check_box_event = twr_register_callback("boxBorderChanged");
    twr_window_menu_widget_add_callback(&check_box, check_box_event, (void*)0);
-
-   struct twr_widget_check_box_constructor extra_checkbox_constructor = {
-      .base = {
-         .type = WINDOW_WIDGET_CHECK_BOX,
-         .width = -1,
-         .height = 20,
-      },
-      .checked_symbol = "[*]",
-      .unchecked_symbol = "[  ]",
-      .text = "Show Extra Options"
-   };
-   struct twr_window_widget extra_check_box = twr_window_menu_add_widget(&extra_menu, &extra_checkbox_constructor.base);
-   int extra_checkbox_event_id = twr_register_callback("extraCheckBoxCallback");
-
-   struct DynamicWidgetArray* extra_widget_array = (struct DynamicWidgetArray*)malloc(sizeof(struct DynamicWidgetArray));
-   extra_widget_array->len = 4;
-   extra_widget_array->arr = (struct twr_window_widget*)malloc(sizeof(struct twr_window_widget) * extra_widget_array->len);
-
-   extra_widget_array->arr[0] = twr_window_menu_add_widget(&extra_menu, &seperator_cons.base);
-
-   struct twr_widget_check_box_constructor extra_center_dot_checkbox_cons = {
-      .base = {
-         .type = WINDOW_WIDGET_CHECK_BOX,
-         .width = -1,
-         .height = 20,
-      },
-      .checked_symbol = "[*]",
-      .unchecked_symbol ="[  ]",
-      .text = "Centered Dot"
-   };
-   struct twr_window_widget extra_center_dot_checkbox = twr_window_menu_add_widget(&extra_menu, &extra_center_dot_checkbox_cons.base);
-   int extra_center_dot_event_id = twr_register_callback("extraCenterDotCallback");
-   twr_window_menu_widget_add_callback(&extra_center_dot_checkbox, extra_center_dot_event_id, (void*)0);
-   extra_widget_array->arr[1] = extra_center_dot_checkbox;
-
-   struct twr_widget_button_constructor randomize_center_dot_color_cons = {
-      .base = {
-         .type = WINDOW_WIDGET_BUTTON,
-         .width = -1,
-         .height = 20,
-      },
-      .text = "Randomize Center Dot Color"
-   };
-   struct twr_window_widget randomize_center_dot_color = twr_window_menu_add_widget(&extra_menu, &randomize_center_dot_color_cons.base);
-   int randomize_center_dot_color_event_id = twr_register_callback("randomizeCenterDotColorCallback");
-   twr_window_menu_widget_add_callback(&randomize_center_dot_color, randomize_center_dot_color_event_id, (void*)0);
-   extra_widget_array->arr[2] = randomize_center_dot_color;
-
-
-
-
-
-
-   struct twr_widget_sub_menu_constructor extra_box_movement_menu_cons = {
-      .base = {
-         .type = WINDOW_WIDGET_SUB_MENU,
-         .height = 20,
-         .width = -1,
-      },
-      .min_child_height = -1,
-      .minimum_menu_height = -1,
-      .minimum_menu_width = -1,
-      .button_text = "Box Movement"
-   };
-   struct twr_window_widget extra_box_movement_menu = twr_window_menu_add_widget(&extra_menu, &extra_box_movement_menu_cons.base);
-
-   struct DynamicWidgetArray* extra_box_movement_items = (struct DynamicWidgetArray*)malloc(sizeof(struct DynamicWidgetArray));
-   extra_box_movement_items->len = 1;
-   extra_box_movement_items->arr = (struct twr_window_widget*)malloc(sizeof(struct twr_window_widget) * extra_box_movement_items->len);
-
-   struct twr_widget_check_box_constructor extra_box_movement_show_box_cons = {
-      .base = {
-         .type = WINDOW_WIDGET_CHECK_BOX,
-         .width = -1,
-         .height = 20
-      },
-      .checked_symbol = "[*]",
-      .unchecked_symbol = "[  ]",
-      .text = "Show"
-   };
-   struct twr_window_widget extra_box_movement_show_box = twr_window_menu_add_widget(&extra_box_movement_menu, &extra_box_movement_show_box_cons.base);
-
-   extra_box_movement_items->arr[0] = twr_window_menu_add_widget(&extra_box_movement_menu, &seperator_cons.base);
-
-   // struct twr_widget_radio_menu_constructor extra_box_movement_options_cons = {
-   //    .base = {
-   //       .type = WINDOW_WIDGET_RADIO_MENU,
-   //       .width = -1,
-   //       .height = -1
-   //    },
-   //    .minimum_height = -1,
-   //    .minimum_width = -1,
-   //    .option_height = 20,
-   //    .selected_symbol = "*",
-   // };
-   // struct twr_window_widget extra_box_movement_options = twr_window_menu_add_widget(&extra_box_movement_menu, &extra_box_movement_options_cons.base);
-   // twr_window_menu_radio_menu_add_option(&extra_box_movement_options, "On Mouse Movement");
-   // twr_window_menu_radio_menu_add_option(&extra_box_movement_options, "On Left Click");
-   // twr_window_menu_radio_menu_add_option(&extra_box_movement_options, "On Double Click");
-   // int extra_box_movement_options_event_id = twr_register_callback("extraBoxMovementOptionCallback");
-   // twr_window_menu_widget_add_callback(&extra_box_movement_options, extra_box_movement_options_event_id, (void*)0);
-   // extra_box_movement_items->arr[1] = extra_box_movement_options;
-   // twr_window_menu_widget_add_callback(&extra_box_movement_show_box, extra_checkbox_event_id, (void*)extra_box_movement_items);
-   // for (int i = 0; i < extra_box_movement_items->len; i++) {
-   //    twr_window_menu_widget_set_visibility(&extra_box_movement_items->arr[i], 0);
-   // }
-   // extra_widget_array->arr[3] = extra_box_movement_menu;
-
-   const char* MOUSE_MOVE_METHOD_NAMES[20] = {
-      "On Mouse Movement",
-      "On Left Click",
-      "On Double Click"
-   };
-   const enum MOUSE_EVENT_TYPE MOUSE_MOVE_METHOD_TYPES[] = {
-      MOUSE_EVENT_MOVE,
-      MOUSE_EVENT_LEFT_CLICK,
-      MOUSE_EVENT_DOUBLE_CLICK
-   };
-   int extra_box_movement_options_event_id = twr_register_callback("extraBoxMovementOptionCallback");
-   for (int i = 0; i < 3; i++) {
-      struct twr_widget_radio_item_constructor radio_item_cons = {
-         .base = {
-            .type = WINDOW_WIDGET_RADIO_ITEM,
-            .height = 10,
-            .width = -1
-         },
-         .text = MOUSE_MOVE_METHOD_NAMES[i]
-      };
-      struct twr_window_widget radio_item = twr_window_menu_add_widget(&extra_box_movement_menu, &radio_item_cons);
-      twr_window_menu_widget_add_callback(&radio_item, extra_box_movement_options_event_id, (void*)MOUSE_MOVE_METHOD_TYPES[i]);
-      if (i == 0) {
-         root_radio_item = radio_item;
-      } else {
-         twr_window_menu_radio_item_merge(&root_radio_item, &radio_item);
-      }
-   }
-
-
-
-
-
-   // for (int i = 0; i < extra_widget_array->len; i++) {
-   //    twr_window_menu_widget_set_visibility(&extra_widget_array->arr[i], 0);
-   // }
-
-   
-   twr_window_menu_widget_add_callback(&extra_check_box, extra_checkbox_event_id, (void*)extra_widget_array);
-   
-}
-__attribute__((export_name("extraBoxMovementOptionCallback")))
-void extra_box_movement_option_callback(int event_id, void* extra, int selected/*, char* option*/) {
-   // if (strcmp("On Mouse Movement", option) == 0) {
-   //    box_move_event_type = MOUSE_EVENT_MOVE;
-   // } else if (strcmp("On Left Click", option) == 0) {
-   //    box_move_event_type = MOUSE_EVENT_LEFT_CLICK;
-   // } else if (strcmp("On Double Click", option) == 0) {
-   //    box_move_event_type = MOUSE_EVENT_DOUBLE_CLICK;
-   // }
-   if (selected)
-      box_move_event_type = (enum MOUSE_EVENT_TYPE)extra;
-}
-__attribute__((export_name("randomizeCenterDotColorCallback")))
-void randomize_center_dot_color_callback(int event_id, void* _) {
-   box_center_dot_color_index = rand()%COLORS_LEN;
-}
-__attribute__((export_name("extraCenterDotCallback")))
-void extra_center_dot_callback(int event_id, void* _, int new_state) {
-   printf("center box change! %d\n", new_state);
-   box_center_dot = new_state;
 }
 
-__attribute__((export_name("extraCheckBoxCallback")))
-void extra_check_box_callback(int event_id, struct DynamicWidgetArray* arr, int new_state) {
-   for (int i = 0; i < arr->len; i++) {
-      twr_window_menu_widget_set_visibility(&arr->arr[i], new_state);
-   }
-}
-__attribute__((export_name("boxBorderChanged")))
-void box_border_changed(int event_id, void* _, int new_state) {
-   printf("new box border update! %d\n", new_state);
-   box_border = new_state;
-}
+
 __attribute__((export_name("spawnButtonPressed")))
 void spawn_button_pressed(int event_id, void* ptr) {
    struct twr_widget_button_constructor new_button_con = {
@@ -476,24 +264,208 @@ void delete_button_pressed(int event_id, struct twr_window_widget* button) {
    twr_window_menu_delete_widget(button);
    free(button);
 }
-__attribute__((export_name("boxColorChanged")))
-void box_color_changed(int event_id, void* extra, int selected/*, char* opt*/) {
-   // if (strcmp(opt, "Red") == 0) {
-   //    box_color = 0xFF0000FF;
-   // } else if (strcmp(opt, "Blue") == 0) {
-   //    box_color = 0x0000FFFF;
-   // } else if (strcmp(opt, "Magenta") == 0) {
-   //    box_color = 0xFF00FFFF;
-   // } else if (strcmp(opt, "Yellow") == 0) {
-   //    box_color = 0xFFFF00FF;
-   // } else if (strcmp(opt, "Cyan") == 0) {
-   //    box_color = 0x00FFFFFF;
-   // } else if (strcmp(opt, "Teal") == 0) {
-   //    box_color = 0x008080FF;
-   // }
-   // free(opt);
+
+void setup_test_two_menu(struct twr_window_widget *test_two_menu) {
+   struct twr_widget_button_constructor spawn_button_constructor = {
+      .base = {
+         .type = WINDOW_WIDGET_BUTTON,
+         .width = -1,
+         .height = 20
+      },
+      .text = "Spawn New Button",
+   };
+   spawn_button = twr_window_menu_add_widget(test_two_menu, &spawn_button_constructor.base);
+   
+   int spawn_button_callback = twr_register_callback("spawnButtonPressed");
+   twr_window_menu_widget_add_callback(&spawn_button, spawn_button_callback, (void*)0);
+   delete_button_callback = twr_register_callback("deleteButtonPressed");
+
+   struct twr_widget_seperator_constructor seperator_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_SEPERATOR,
+         .width = -1,
+         .height = 10
+      },
+      .seperator_text = "-",
+      .seperator_font = NULL,
+   };
+
+   twr_window_menu_add_widget(test_two_menu, &seperator_cons.base);
+}
+
+void setup_extra_box_movement_sub_menu(struct twr_window_widget* box_movement_menu) {
+   struct DynamicWidgetArray* extra_box_movement_items = (struct DynamicWidgetArray*)malloc(sizeof(struct DynamicWidgetArray));
+   extra_box_movement_items->len = 4;
+   extra_box_movement_items->arr = (struct twr_window_widget*)malloc(sizeof(struct twr_window_widget) * extra_box_movement_items->len);
+
+   struct twr_widget_check_box_constructor extra_box_movement_show_box_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_CHECK_BOX,
+         .width = -1,
+         .height = 20
+      },
+      .checked_symbol = "[*]",
+      .unchecked_symbol = "[  ]",
+      .text = "Show"
+   };
+   struct twr_window_widget extra_box_movement_show_box = twr_window_menu_add_widget(box_movement_menu, &extra_box_movement_show_box_cons.base);
+   
+   struct twr_widget_seperator_constructor seperator_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_SEPERATOR,
+         .width = -1,
+         .height = 10
+      },
+      .seperator_text = "-",
+      .seperator_font = NULL,
+   };
+
+   extra_box_movement_items->arr[0] = twr_window_menu_add_widget(box_movement_menu, &seperator_cons.base);
+
+   const char* MOUSE_MOVE_METHOD_NAMES[3] = {
+      "On Mouse Movement",
+      "On Left Click",
+      "On Double Click"
+   };
+   const enum MOUSE_EVENT_TYPE MOUSE_MOVE_METHOD_TYPES[] = {
+      MOUSE_EVENT_MOVE,
+      MOUSE_EVENT_LEFT_CLICK,
+      MOUSE_EVENT_DOUBLE_CLICK
+   };
+   struct twr_window_widget root_radio_item;
+   int extra_box_movement_options_event_id = twr_register_callback("extraBoxMovementOptionCallback");
+   for (int i = 0; i < 3; i++) {
+      struct twr_widget_radio_item_constructor radio_item_cons = {
+         .base = {
+            .type = WINDOW_WIDGET_RADIO_ITEM,
+            .height = 10,
+            .width = -1
+         },
+         .text = MOUSE_MOVE_METHOD_NAMES[i]
+      };
+      struct twr_window_widget radio_item = twr_window_menu_add_widget(box_movement_menu, &radio_item_cons.base);
+      twr_window_menu_widget_add_callback(&radio_item, extra_box_movement_options_event_id, (void*)MOUSE_MOVE_METHOD_TYPES[i]);
+      if (i == 0) {
+         root_radio_item = radio_item;
+      } else {
+         twr_window_menu_radio_item_merge(&root_radio_item, &radio_item);
+      }
+      extra_box_movement_items->arr[i+1] = radio_item;
+   }
+
+   for (int i = 0; i < extra_box_movement_items->len; i++) {
+      twr_window_menu_widget_set_visibility(&extra_box_movement_items->arr[i], 0);
+   }
+
+   int visibility_event_id = twr_register_callback("extraCheckBoxCallback");
+   twr_window_menu_widget_add_callback(&extra_box_movement_show_box, visibility_event_id, (void*)extra_box_movement_items);
+
+}
+
+void setup_extra_menu(struct twr_window_widget *extra_menu) {
+   struct twr_widget_check_box_constructor extra_checkbox_constructor = {
+      .base = {
+         .type = WINDOW_WIDGET_CHECK_BOX,
+         .width = -1,
+         .height = 20,
+      },
+      .checked_symbol = "[*]",
+      .unchecked_symbol = "[  ]",
+      .text = "Show Extra Options"
+   };
+   struct twr_window_widget extra_check_box = twr_window_menu_add_widget(extra_menu, &extra_checkbox_constructor.base);
+   int extra_checkbox_event_id = twr_register_callback("extraCheckBoxCallback");
+
+   struct DynamicWidgetArray* extra_widget_array = (struct DynamicWidgetArray*)malloc(sizeof(struct DynamicWidgetArray));
+   extra_widget_array->len = 4;
+   extra_widget_array->arr = (struct twr_window_widget*)malloc(sizeof(struct twr_window_widget) * extra_widget_array->len);
+
+   struct twr_widget_seperator_constructor seperator_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_SEPERATOR,
+         .width = -1,
+         .height = 10
+      },
+      .seperator_text = "-",
+      .seperator_font = NULL,
+   };
+   extra_widget_array->arr[0] = twr_window_menu_add_widget(extra_menu, &seperator_cons.base);
+
+   struct twr_widget_check_box_constructor extra_center_dot_checkbox_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_CHECK_BOX,
+         .width = -1,
+         .height = 20,
+      },
+      .checked_symbol = "[*]",
+      .unchecked_symbol ="[  ]",
+      .text = "Centered Dot"
+   };
+   struct twr_window_widget extra_center_dot_checkbox = twr_window_menu_add_widget(extra_menu, &extra_center_dot_checkbox_cons.base);
+   int extra_center_dot_event_id = twr_register_callback("extraCenterDotCallback");
+   twr_window_menu_widget_add_callback(&extra_center_dot_checkbox, extra_center_dot_event_id, (void*)0);
+   extra_widget_array->arr[1] = extra_center_dot_checkbox;
+
+   struct twr_widget_button_constructor randomize_center_dot_color_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_BUTTON,
+         .width = -1,
+         .height = 20,
+      },
+      .text = "Randomize Center Dot Color"
+   };
+   struct twr_window_widget randomize_center_dot_color = twr_window_menu_add_widget(extra_menu, &randomize_center_dot_color_cons.base);
+   int randomize_center_dot_color_event_id = twr_register_callback("randomizeCenterDotColorCallback");
+   twr_window_menu_widget_add_callback(&randomize_center_dot_color, randomize_center_dot_color_event_id, (void*)0);
+   extra_widget_array->arr[2] = randomize_center_dot_color;
+
+   struct twr_widget_sub_menu_constructor extra_box_movement_menu_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_SUB_MENU,
+         .height = 20,
+         .width = -1,
+      },
+      .min_child_height = -1,
+      .minimum_menu_height = -1,
+      .minimum_menu_width = -1,
+      .button_text = "Box Movement"
+   };
+   struct twr_window_widget extra_box_movement_menu = twr_window_menu_add_widget(extra_menu, &extra_box_movement_menu_cons.base);
+   setup_extra_box_movement_sub_menu(&extra_box_movement_menu);
+   extra_widget_array->arr[3] = extra_box_movement_menu;
+
+   twr_window_menu_widget_add_callback(&extra_check_box, extra_checkbox_event_id, (void*)extra_widget_array);
+
+   for (int i = 0; i < extra_widget_array->len; i++) {
+      twr_window_menu_widget_set_visibility(&extra_widget_array->arr[i], 0);
+   }
+}
+
+__attribute__((export_name("extraBoxMovementOptionCallback")))
+void extra_box_movement_option_callback(int event_id, void* extra, int selected) {
    if (selected)
-      box_color = (int)extra;
+      box_move_event_type = (enum MOUSE_EVENT_TYPE)extra;
+}
+__attribute__((export_name("randomizeCenterDotColorCallback")))
+void randomize_center_dot_color_callback(int event_id, void* _) {
+   box_center_dot_color_index = rand()%COLORS_LEN;
+}
+__attribute__((export_name("extraCenterDotCallback")))
+void extra_center_dot_callback(int event_id, void* _, int new_state) {
+   printf("center box change! %d\n", new_state);
+   box_center_dot = new_state;
+}
+
+__attribute__((export_name("extraCheckBoxCallback")))
+void extra_check_box_callback(int event_id, struct DynamicWidgetArray* arr, int new_state) {
+   for (int i = 0; i < arr->len; i++) {
+      twr_window_menu_widget_set_visibility(&arr->arr[i], new_state);
+   }
+}
+__attribute__((export_name("boxBorderChanged")))
+void box_border_changed(int event_id, void* _, int new_state) {
+   printf("new box border update! %d\n", new_state);
+   box_border = new_state;
 }
 
 

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -52,10 +52,6 @@ void init() {
          .height = 20
       },
       .text = "Spawn New Button",
-      .text_font = "14px Seriph",
-      .text_color = NULL,
-      .button_color = NULL,
-      .selected_button_color = NULL
    };
    spawn_button = twr_window_menu_add_widget(&test_two_menu, &spawn_button_constructor.base);
    
@@ -71,7 +67,6 @@ void init() {
       },
       .seperator_text = "-",
       .seperator_font = NULL,
-      .seperator_color = NULL,
    };
 
    twr_window_menu_add_widget(&test_two_menu, &seperator_cons.base);
@@ -84,17 +79,8 @@ void init() {
          .width = 30,
          .height = 20,
       },
-      .button_color = NULL,
-      .selected_button_color = NULL,
       .button_text = "Box Color",
-      .button_text_font = NULL,
-      .button_text_color = NULL,
       
-      .menu_border_color = "Black",
-      .menu_border_width = 1.0,
-      .menu_color = NULL,
-      .menu_open_offset = 2.0,
-      .menu_y_padding = 0.0,
       .min_child_height = 10,
       .minimum_menu_height = 10,
       .minimum_menu_width = 10,
@@ -107,16 +93,10 @@ void init() {
          .width = -1,
          .height = -1,
       },
-      .hovered_background_color = "#D0D0D0",
-      .menu_color = "#B0B0B0",
       .minimum_height = 10,
       .minimum_width = 10,
       .option_height = 20,
-      .option_text_color = "black",
-      .option_text_font = "14px Seriph",
       .selected_symbol = "*",
-      .reserved_prefix_length = -1,
-      .y_padding = 5,
    };
    struct twr_window_widget radio_menu = twr_window_menu_add_widget(&box_color_sub_menu, &radio_menu_constructor.base);
    twr_window_menu_radio_menu_add_option(&radio_menu, "Red");
@@ -135,14 +115,9 @@ void init() {
          .width = -1,
          .height = 20
       },
-      .button_color = NULL,
       .checked_symbol = "[*]",
       .unchecked_symbol = "[  ]",
-      .reserved_prefix_space = -1,
-      .selected_button_color = NULL,
       .text = "Box Outline",
-      .text_color = NULL,
-      .text_font = NULL,
    };
 
    struct twr_window_widget check_box = twr_window_menu_add_widget(&box_color_menu, &check_box_constructor.base);
@@ -163,10 +138,6 @@ void spawn_button_pressed(int event_id, void* ptr) {
          .height = 20,
       },
       .text = "Delete!",
-      .text_font = "14px Seriph",
-      .text_color = NULL,
-      .button_color = NULL,
-      .selected_button_color = NULL
    };
    struct twr_window_widget button = twr_window_menu_add_widget(&test_two_menu, &new_button_con.base);
 

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -548,9 +548,91 @@ void setup_menu_prop_menu(struct twr_window_widget *menu_prop_menu) {
    for (long i = 0; i < length; i++) {
       struct twr_window_widget getter = twr_window_menu_add_button_widget(&getters, -1, 10, prop_list[i].name);
       struct twr_window_widget setter = twr_window_menu_add_button_widget(&setters, -1, 10, prop_list[i].name);
+
+
    }
 }
 
+__attribute__((export_name("menuPropMenuGetterCallback")))
+void menu_prop_menu_getter_callback(int event_id, struct twr_menu_prop_details* details) {
+   prop_menu_data = (struct prop_menu_popup){
+      .prop_name = details->name,
+      .state = PROP_MENU_SET,
+      .target = PROP_MENU_TARGET_MENU,
+      .text_buffer = (struct text_fill_buffer){
+         .text = "",
+         .length = 0
+      },
+      .number_buffer = (struct text_fill_buffer){
+         .text = "",
+         .length = 0
+      },
+      .number_buffer_has_dot = FALSE,
+      // .accepted_types = accepted_types,
+      // .accepted_types_len = accepted_types_length,
+      .accepted_types_len = 0,
+      .selected_type = 0,
+      .width = 200,
+      .height = BASE_PROP_MENU_HEIGHT + PROP_MENU_HEIGHT_PER_FIELD * count_ones((unsigned int)details->type),
+   };
+   const int num_types = 4;
+   const enum WindowWidgetPropVal types[] = {
+      WINDOW_WIDGET_PROP_STRING,
+      WINDOW_WIDGET_PROP_BOOLEAN,
+      WINDOW_WIDGET_PROP_NUMBER,
+      WINDOW_WIDGET_PROP_UNDEFINED
+   };
+   for (int i = 0; i < num_types; i++) {
+      if (details->type & types[i]) {
+         enum prop_menu_selected to_add;
+         switch (types[i]) {
+            case WINDOW_WIDGET_PROP_STRING:
+               to_add = PROP_MENU_SELECTED_STRING;
+            break;
+            case WINDOW_WIDGET_PROP_BOOLEAN:
+            prop_menu_data.accepted_types[prop_menu_data.accepted_types_len] = PROP_MENU_SELECTED_TRUE;
+               prop_menu_data.accepted_types_len++;
+               to_add = PROP_MENU_SELECTED_FALSE;
+            break;
+            case WINDOW_WIDGET_PROP_NUMBER:
+               to_add = PROP_MENU_SELECTED_NUMBER;
+            break;
+            case WINDOW_WIDGET_PROP_UNDEFINED:
+               to_add = PROP_MENU_SELECTED_UNDEFINED;
+            break;
+         }
+         prop_menu_data.accepted_types[prop_menu_data.accepted_types_len] = to_add;
+         prop_menu_data.accepted_types_len++;
+      }
+   }
+}
+__attribute__((export_name("menuPropMenuSetterCallback")))
+void menu_prop_menu_setter_callback(int event_id, struct twr_menu_prop_details* details) {
+   struct twr_widget_prop_value* val = twr_window_menu_get_prop(window_con, details->name);
+
+   prop_menu_data.state = PROP_MENU_GET;
+   prop_menu_data.target = PROP_MENU_TARGET_MENU;
+   // prop_menu_data.selected = PROP_MENU_SELECTED_NONE;
+   prop_menu_data.prop_name = details->name;
+   prop_menu_data.width = 200;
+   prop_menu_data.height = BASE_PROP_MENU_HEIGHT + PROP_MENU_HEIGHT_PER_FIELD;
+   switch (val->type) {
+      case WINDOW_WIDGET_PROP_BOOLEAN:
+         sprintf(prop_menu_data.text_buffer.text, "%s", val->boolean ? "true" : "false");
+      break;
+      case WINDOW_WIDGET_PROP_NUMBER:
+         sprintf(prop_menu_data.text_buffer.text, "%f", val->number);
+      break;
+      case WINDOW_WIDGET_PROP_STRING:
+         sprintf(prop_menu_data.text_buffer.text, "%s", val->string);
+      break;
+      case WINDOW_WIDGET_PROP_UNDEFINED:
+         sprintf(prop_menu_data.text_buffer.text, "undefined");
+      break;
+   }
+
+   free(val);
+}
 __attribute__((export_name("extraBoxMovementOptionCallback")))
 void extra_box_movement_option_callback(int event_id, void* extra, int selected) {
    if (selected)
@@ -785,6 +867,7 @@ void key_event_handler(int id, int key) {
       return;
    
    enum prop_menu_selected selected = prop_menu_data.accepted_types[prop_menu_data.selected_type];
+   enum prop_menu_target target = prop_menu_data.target;
 
    struct text_fill_buffer* text_buffer = &prop_menu_data.text_buffer;
    struct text_fill_buffer* number_buffer = &prop_menu_data.number_buffer;
@@ -838,34 +921,59 @@ void key_event_handler(int id, int key) {
          switch (selected) {
             case PROP_MENU_SELECTED_TRUE:
             case PROP_MENU_SELECTED_FALSE:
-               twr_window_menu_widget_set_bool(
-                  prop_menu_data.widget, 
-                  prop_menu_data.prop_name, 
-                  selected == PROP_MENU_SELECTED_TRUE ? TRUE : FALSE
-               );
+               if (target == PROP_MENU_TARGET_WIDGET) {
+                  twr_window_menu_widget_set_bool(
+                     prop_menu_data.widget, 
+                     prop_menu_data.prop_name, 
+                     selected == PROP_MENU_SELECTED_TRUE ? TRUE : FALSE
+                  );
+               } else if (target == PROP_MENU_TARGET_MENU) {
+                  twr_window_menu_set_prop_boolean(
+                     window_con,
+                     prop_menu_data.prop_name,
+                     selected == PROP_MENU_SELECTED_TRUE ? TRUE : FALSE
+                  );
+               }
             break;
             case PROP_MENU_SELECTED_UNDEFINED:
+               assert(target == PROP_MENU_TARGET_WIDGET);
                twr_window_menu_widget_set_undefined(
                   prop_menu_data.widget,
                   prop_menu_data.prop_name
                );
             break;
             case PROP_MENU_SELECTED_STRING:
-               twr_window_menu_widget_set_string(
-                  prop_menu_data.widget,
-                  prop_menu_data.prop_name,
-                  prop_menu_data.text_buffer.text
-               );
+               if (target == PROP_MENU_TARGET_WIDGET) {
+                  twr_window_menu_widget_set_string(
+                     prop_menu_data.widget,
+                     prop_menu_data.prop_name,
+                     prop_menu_data.text_buffer.text
+                  );
+               } else if (target == PROP_MENU_TARGET_MENU) {
+                  twr_window_menu_set_string(
+                     window_con,
+                     prop_menu_data.prop_name,
+                     prop_menu_data.text_buffer.text
+                  );
+               }
             break;
             case PROP_MENU_SELECTED_NUMBER:
             {
                assert(prop_menu_data.number_buffer.length > 0);
                double res = strtod(prop_menu_data.number_buffer.text, NULL);
-               twr_window_menu_widget_set_number(
-                  prop_menu_data.widget,
-                  prop_menu_data.prop_name,
-                  res
-               );
+               if (target == PROP_MENU_TARGET_WIDGET) {
+                  twr_window_menu_widget_set_number(
+                     prop_menu_data.widget,
+                     prop_menu_data.prop_name,
+                     res
+                  );
+               } else {
+                  twr_window_menu_set_number(
+                     window_con,
+                     prop_menu_data.prop_name,
+                     res
+                  );
+               }
             }
             break;
             default:

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -119,6 +119,7 @@ enum MOUSE_EVENT_TYPE box_move_event_type = MOUSE_EVENT_MOVE;
 void setup_box_options_menu(struct twr_window_widget *box_options_menu);
 void setup_test_two_menu(struct twr_window_widget *test_two_menu);
 void setup_extra_menu(struct twr_window_widget *extra_menu);
+void setup_prop_menu(struct twr_window_widget *prop_menu);
 __attribute__((export_name("init")))
 void init() {
    if (window_con)
@@ -157,19 +158,138 @@ void init() {
    box_color_menu = twr_window_add_menu(window_con, "Box Options");
    test_two_menu = twr_window_add_menu(window_con, "test_two");
    extra_menu = twr_window_add_menu(window_con, "extra");
+   prop_menu = twr_window_add_menu(window_con, "prop_modifiers");
 
    setup_box_options_menu(&box_color_menu);
    setup_test_two_menu(&test_two_menu);
    setup_extra_menu(&extra_menu);
+   setup_prop_menu(&prop_menu);
+}
 
-   long prop_len;
-   struct twr_widget_prop_details* props = twr_window_menu_widget_list_props(&box_color_menu, &prop_len);
-   printf("C alloc: %d\nC Length: %ld\n", (int)props, prop_len);
-   for (long i = 0; i < prop_len; i++) {
-      printf("prop list: %s\n", props[i].name);
+struct prop_menu_data {
+   struct twr_window_widget* widget;
+   struct twr_widget_prop_details* prop_details;
+};
+
+
+enum prop_menu_state {
+   PROP_MENU_UNOPENED,
+   PROP_MENU_SET,
+   PROP_MENU_GET
+};
+struct prop_menu_popup {
+   const char* prop_name;
+   enum prop_menu_state state;
+   const char text_buffer[100];
+   enum WindowWidgetPropVal accepted_types;
+   int selected;
+   struct twr_window_widget* widget;
+};
+struct prop_menu_popup prop_menu_popup_data = {
+   .state = PROP_MENU_UNOPENED
+};
+__attribute__((export_name("windowPropMenuGetEvent")))
+void window_prop_menu_get_event(int event_id, struct prop_menu_data* prop_data) {
+   struct twr_widget_prop_value* val = twr_window_menu_widget_get_prop(prop_data->widget, prop_data->prop_details->name);
+
+   prop_menu_popup_data.state = PROP_MENU_GET;
+   prop_menu_popup_data.selected = 0;
+   prop_menu_popup_data.prop_name = prop_data->prop_details->name;
+   switch (val->type) {
+      case WINDOW_WIDGET_PROP_BOOLEAN:
+         sprintf(prop_menu_popup_data.text_buffer, "%s", val->boolean ? "true" : "false");
+      break;
+      case WINDOW_WIDGET_PROP_NUMBER:
+         sprintf(prop_menu_popup_data.text_buffer, "%f", val->number);
+      break;
+      case WINDOW_WIDGET_PROP_STRING:
+         sprintf(prop_menu_popup_data.text_buffer, "%s", val->string);
+      break;
+      case WINDOW_WIDGET_PROP_UNDEFINED:
+         sprintf(prop_menu_popup_data.text_buffer, "undefined");
+      break;
    }
-   free(props);
+
+   free(val);
+}
+__attribute__((export_name("windowPropMenuSetEvent")))
+void window_prop_menu_set_event(int event_id, struct prop_menu_data* prop_data) {
+   prop_menu_popup_data = (struct prop_menu_popup){
+      .prop_name = prop_data->prop_details->name,
+      .state = PROP_MENU_SET,
+      .text_buffer = "",
+      .accepted_types = prop_data->prop_details->type,
+      .selected = 0,
+      .widget = prop_data->widget
+   };
+}
+void setup_prop_menu(struct twr_window_widget *prop_menu) {
+   struct twr_widget_check_box_constructor modified_prop_cons = {
+      .base = {
+         .height = 10,
+         .width = -1,
+         .type = WINDOW_WIDGET_CHECK_BOX
+      },
+      .text = "Test Widget"
+   };
+
+   struct twr_window_widget modified_prop = twr_window_menu_add_widget(prop_menu, &modified_prop_cons.base);
+   struct twr_window_widget* modified_prop_heap = (struct twr_window_widget*)malloc(sizeof(struct twr_window_widget));
+   *modified_prop_heap = modified_prop;
+
+   struct twr_widget_sub_menu_constructor get_set_fields = {
+      .base = {
+         .height = 10,
+         .width = -1,
+         .type = WINDOW_WIDGET_SUB_MENU
+      },
+      .button_text = "Setters",
+      .min_child_height = -1,
+      .minimum_menu_height = -1,
+      .minimum_menu_width = -1,
+   };
+   struct twr_window_widget setter_menu = twr_window_menu_add_widget(prop_menu, &get_set_fields.base);
+   get_set_fields.button_text = "Getters";
+   struct twr_window_widget getter_menu = twr_window_menu_add_widget(prop_menu, &get_set_fields.base);
+
    
+   long prop_len;
+   struct twr_widget_prop_details* props = twr_window_menu_widget_list_props(&modified_prop, &prop_len);
+   int getter_event_id = twr_register_callback("windowPropMenuGetEvent");
+   int setter_event_id = twr_register_callback("windowPropMenuSetEvent");
+   // printf("C alloc: %d\nC Length: %ld\n", (int)props, prop_len);
+   for (long i = 0; i < prop_len; i++) {
+      struct prop_menu_data* prop_data = (struct prop_menu_data*)malloc(sizeof(struct prop_menu_data));
+      *prop_data = (struct prop_menu_data){
+         .prop_details = &(props[i]),
+         .widget = modified_prop_heap,
+      };
+      if (prop_data->prop_details->access & WINDOW_WIDGET_PROP_GET) {
+         struct twr_widget_button_constructor get_button_cons = {
+            .base = {
+               .height = 10,
+               .width = -1,
+               .type = WINDOW_WIDGET_BUTTON
+            },
+            .text = prop_data->prop_details->name
+         };
+         struct twr_window_widget get_button = twr_window_menu_add_widget(&getter_menu, &get_button_cons.base);
+         twr_window_menu_widget_add_callback(&get_button, getter_event_id, (void*)prop_data);
+      }
+      if (prop_data->prop_details->access & WINDOW_WIDGET_PROP_SET) {
+         struct twr_widget_button_constructor set_button_cons = {
+            .base = {
+               .height = 10,
+               .width = -1,
+               .type = WINDOW_WIDGET_BUTTON
+            },
+            .text = prop_data->prop_details->name
+         };
+         struct twr_window_widget set_button = twr_window_menu_add_widget(&setter_menu, &set_button_cons.base);
+         twr_window_menu_widget_add_callback(&set_button, setter_event_id, (void*)prop_data);
+      }
+   }
+   // free(props);
 }
 
 
@@ -240,8 +360,6 @@ void setup_box_options_menu(struct twr_window_widget* box_options_menu) {
          .width = -1,
          .height = 20
       },
-      .checked_symbol = "[*]",
-      .unchecked_symbol = "[  ]",
       .text = "Box Outline",
    };
 
@@ -330,8 +448,6 @@ void setup_extra_box_movement_sub_menu(struct twr_window_widget* box_movement_me
          .width = -1,
          .height = 20
       },
-      .checked_symbol = "[*]",
-      .unchecked_symbol = "[  ]",
       .text = "Show"
    };
    struct twr_window_widget extra_box_movement_show_box = twr_window_menu_add_widget(box_movement_menu, &extra_box_movement_show_box_cons.base);
@@ -395,8 +511,6 @@ void setup_extra_menu(struct twr_window_widget *extra_menu) {
          .width = -1,
          .height = 20,
       },
-      .checked_symbol = "[*]",
-      .unchecked_symbol = "[  ]",
       .text = "Show Extra Options"
    };
    struct twr_window_widget extra_check_box = twr_window_menu_add_widget(extra_menu, &extra_checkbox_constructor.base);
@@ -423,8 +537,6 @@ void setup_extra_menu(struct twr_window_widget *extra_menu) {
          .width = -1,
          .height = 20,
       },
-      .checked_symbol = "[*]",
-      .unchecked_symbol ="[  ]",
       .text = "Centered Dot"
    };
    struct twr_window_widget extra_center_dot_checkbox = twr_window_menu_add_widget(extra_menu, &extra_center_dot_checkbox_cons.base);

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -13,12 +13,107 @@ long canvas_height = 0;
 
 struct twr_window_widget box_color_menu;
 struct twr_window_widget test_two_menu;
-
+struct twr_window_widget extra_menu;
 unsigned long box_color = 0xFF0000FF;
 int box_border = 0;
 
+#define COLORS_LEN 76
+const char* COLORS[COLORS_LEN] = {
+   "Salmon",
+   "Red",
+   "DarkRed",
+   "Pink",
+   "DeepPink",
+   "MediumVioletRed",
+   "Coral",
+   "Tomato",
+   "OrangeRed",
+   "Orange",
+   "Gold",
+   "Yellow",
+   "LightYellow",
+   "DarkKhaki",
+   "Lavender",
+   "Thistle",
+   "Violet",
+   "Fuchsia",
+   "Magenta",
+   "MediumOrchid",
+   "MediumPurple",
+   "RebeccaPurple",
+   "DarkMagenta",
+   "Purple",
+   "Indigo",
+   "SlateBlue",
+   "DarkSlateBlue",
+   "GreenYellow",
+   "LimeGreen",
+   "LightGreen",
+   "MediumSpringGreen",
+   "MediumSeaGreen",
+   "Green",
+   "OliveDrab",
+   "Olive",
+   "MediumAquamarine",
+   "LightSeaGreen",
+   "DarkCyan",
+   "Aqua",
+   "PaleTurquiose",
+   "Aquamarine",
+   "CadetBlue",
+   "SteelBlue",
+   "LightSteelBlue",
+   "DeepSkyBlue",
+   "DodgetBlue",
+   "MediumSlateBlue",
+   "RoyalBlue",
+   "Blue",
+   "Navy",
+   "BurlyWood",
+   "RosyBrown",
+   "SandyBrown",
+   "Goldenrod",
+   "DarkGoldenrod",
+   "Peru",
+   "Chocolate",
+   "SaddleBrown",
+   "Sienna",
+   "Brown",
+   "Maroon",
+   "White",
+   "GhostWhite",
+   "SeaShell",
+   "Biege",
+   "Ivory",
+   "MistyRose",
+   "Gainsboro",
+   "LightGray",
+   "Silver",
+   "Gray",
+   "DimGray",
+   "LightSlateGray",
+   "SlateGray",
+   "DarkSlateGray",
+   "Black"
+}; 
+unsigned long box_center_dot_color_index = 0;
+int box_center_dot = 0;
+
 struct twr_window_widget spawn_button;
 int delete_button_callback;
+
+struct DynamicWidgetArray {
+   struct twr_window_widget* arr;
+   unsigned long len;
+};
+
+enum MOUSE_EVENT_TYPE {
+   MOUSE_EVENT_MOVE,
+   MOUSE_EVENT_LEFT_CLICK,
+   MOUSE_EVENT_DOUBLE_CLICK,
+};
+int mouse_event_ids[3] = {};
+enum MOUSE_EVENT_TYPE box_move_event_type = MOUSE_EVENT_MOVE;
 
 __attribute__((export_name("init")))
 void init() {
@@ -39,11 +134,25 @@ void init() {
    int ANIMATION_EVENT = twr_register_callback("animationFrame");
    d2d_register_event(D2D_ANIMATION_FRAME, ANIMATION_EVENT);
 
+
+
    int MOUSE_MOVE_EVENT = twr_register_callback("mouseMoveHandler");
    d2d_register_event(D2D_MOUSE_MOVE, MOUSE_MOVE_EVENT);
+   mouse_event_ids[MOUSE_EVENT_MOVE] = MOUSE_MOVE_EVENT;
+
+   int MOUSE_LEFT_CLICK_EVENT = twr_register_callback("mouseMoveHandler");
+   d2d_register_event(D2D_MOUSE_CLICK, MOUSE_LEFT_CLICK_EVENT);
+   mouse_event_ids[MOUSE_EVENT_LEFT_CLICK] = MOUSE_LEFT_CLICK_EVENT;
+
+   int MOUSE_DBL_CLICK_EVENT = twr_register_callback("mouseMoveHandler");
+   d2d_register_event(D2D_MOUSE_DBLCLICK, MOUSE_DBL_CLICK_EVENT);
+   mouse_event_ids[MOUSE_EVENT_DOUBLE_CLICK] = MOUSE_DBL_CLICK_EVENT;
+
+
 
    box_color_menu = twr_window_add_menu(window_con, "Box Options");
    test_two_menu = twr_window_add_menu(window_con, "test_two");
+   extra_menu = twr_window_add_menu(window_con, "extra");
 
    struct twr_widget_button_constructor spawn_button_constructor = {
       .base = {
@@ -123,8 +232,152 @@ void init() {
    struct twr_window_widget check_box = twr_window_menu_add_widget(&box_color_menu, &check_box_constructor.base);
    int check_box_event = twr_register_callback("boxBorderChanged");
    twr_window_menu_widget_add_callback(&check_box, check_box_event, (void*)0);
+
+   struct twr_widget_check_box_constructor extra_checkbox_constructor = {
+      .base = {
+         .type = WINDOW_WIDGET_CHECK_BOX,
+         .width = -1,
+         .height = 20,
+      },
+      .checked_symbol = "[*]",
+      .unchecked_symbol = "[  ]",
+      .text = "Show Extra Options"
+   };
+   struct twr_window_widget extra_check_box = twr_window_menu_add_widget(&extra_menu, &extra_checkbox_constructor.base);
+   int extra_checkbox_event_id = twr_register_callback("extraCheckBoxCallback");
+
+   struct DynamicWidgetArray* extra_widget_array = (struct DynamicWidgetArray*)malloc(sizeof(struct DynamicWidgetArray));
+   extra_widget_array->len = 4;
+   extra_widget_array->arr = (struct twr_window_widget*)malloc(sizeof(struct twr_window_widget) * extra_widget_array->len);
+
+   extra_widget_array->arr[0] = twr_window_menu_add_widget(&extra_menu, &seperator_cons.base);
+
+   struct twr_widget_check_box_constructor extra_center_dot_checkbox_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_CHECK_BOX,
+         .width = -1,
+         .height = 20,
+      },
+      .checked_symbol = "[*]",
+      .unchecked_symbol ="[  ]",
+      .text = "Centered Dot"
+   };
+   struct twr_window_widget extra_center_dot_checkbox = twr_window_menu_add_widget(&extra_menu, &extra_center_dot_checkbox_cons.base);
+   int extra_center_dot_event_id = twr_register_callback("extraCenterDotCallback");
+   twr_window_menu_widget_add_callback(&extra_center_dot_checkbox, extra_center_dot_event_id, (void*)0);
+   extra_widget_array->arr[1] = extra_center_dot_checkbox;
+
+   struct twr_widget_button_constructor randomize_center_dot_color_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_BUTTON,
+         .width = -1,
+         .height = 20,
+      },
+      .text = "Randomize Center Dot Color"
+   };
+   struct twr_window_widget randomize_center_dot_color = twr_window_menu_add_widget(&extra_menu, &randomize_center_dot_color_cons.base);
+   int randomize_center_dot_color_event_id = twr_register_callback("randomizeCenterDotColorCallback");
+   twr_window_menu_widget_add_callback(&randomize_center_dot_color, randomize_center_dot_color_event_id, (void*)0);
+   extra_widget_array->arr[2] = randomize_center_dot_color;
+
+
+
+
+
+
+   struct twr_widget_sub_menu_constructor extra_box_movement_menu_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_SUB_MENU,
+         .height = 20,
+         .width = -1,
+      },
+      .min_child_height = -1,
+      .minimum_menu_height = -1,
+      .minimum_menu_width = -1,
+      .button_text = "Box Movement"
+   };
+   struct twr_window_widget extra_box_movement_menu = twr_window_menu_add_widget(&extra_menu, &extra_box_movement_menu_cons.base);
+
+   struct DynamicWidgetArray* extra_box_movement_items = (struct DynamicWidgetArray*)malloc(sizeof(struct DynamicWidgetArray));
+   extra_box_movement_items->len = 2;
+   extra_box_movement_items->arr = (struct twr_window_widget*)malloc(sizeof(struct twr_window_widget) * extra_box_movement_items->len);
+
+   struct twr_widget_check_box_constructor extra_box_movement_show_box_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_CHECK_BOX,
+         .width = -1,
+         .height = 20
+      },
+      .checked_symbol = "[*]",
+      .unchecked_symbol = "[  ]",
+      .text = "Show"
+   };
+   struct twr_window_widget extra_box_movement_show_box = twr_window_menu_add_widget(&extra_box_movement_menu, &extra_box_movement_show_box_cons.base);
+
+   extra_box_movement_items->arr[0] = twr_window_menu_add_widget(&extra_box_movement_menu, &seperator_cons.base);
+
+   struct twr_widget_radio_menu_constructor extra_box_movement_options_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_RADIO_MENU,
+         .width = -1,
+         .height = -1
+      },
+      .minimum_height = -1,
+      .minimum_width = -1,
+      .option_height = 20,
+      .selected_symbol = "*",
+   };
+   struct twr_window_widget extra_box_movement_options = twr_window_menu_add_widget(&extra_box_movement_menu, &extra_box_movement_options_cons.base);
+   twr_window_menu_radio_menu_add_option(&extra_box_movement_options, "On Mouse Movement");
+   twr_window_menu_radio_menu_add_option(&extra_box_movement_options, "On Left Click");
+   twr_window_menu_radio_menu_add_option(&extra_box_movement_options, "On Double Click");
+   int extra_box_movement_options_event_id = twr_register_callback("extraBoxMovementOptionCallback");
+   twr_window_menu_widget_add_callback(&extra_box_movement_options, extra_box_movement_options_event_id, (void*)0);
+   extra_box_movement_items->arr[1] = extra_box_movement_options;
+   twr_window_menu_widget_add_callback(&extra_box_movement_show_box, extra_checkbox_event_id, (void*)extra_box_movement_items);
+   for (int i = 0; i < extra_box_movement_items->len; i++) {
+      twr_window_menu_widget_set_visibility(&extra_box_movement_items->arr[i], 0);
+   }
+   extra_widget_array->arr[3] = extra_box_movement_menu;
+
+
+
+
+
+   for (int i = 0; i < extra_widget_array->len; i++) {
+      twr_window_menu_widget_set_visibility(&extra_widget_array->arr[i], 0);
+   }
+
+   
+   twr_window_menu_widget_add_callback(&extra_check_box, extra_checkbox_event_id, (void*)extra_widget_array);
+   
+}
+__attribute__((export_name("extraBoxMovementOptionCallback")))
+void extra_box_movement_option_callback(int event_id, void* _, char* option) {
+   if (strcmp("On Mouse Movement", option) == 0) {
+      box_move_event_type = MOUSE_EVENT_MOVE;
+   } else if (strcmp("On Left Click", option) == 0) {
+      box_move_event_type = MOUSE_EVENT_LEFT_CLICK;
+   } else if (strcmp("On Double Click", option) == 0) {
+      box_move_event_type = MOUSE_EVENT_DOUBLE_CLICK;
+   }
+}
+__attribute__((export_name("randomizeCenterDotColorCallback")))
+void randomize_center_dot_color_callback(int event_id, void* _) {
+   box_center_dot_color_index = rand()%COLORS_LEN;
+}
+__attribute__((export_name("extraCenterDotCallback")))
+void extra_center_dot_callback(int event_id, void* _, int new_state) {
+   printf("center box change! %d\n", new_state);
+   box_center_dot = new_state;
 }
 
+__attribute__((export_name("extraCheckBoxCallback")))
+void extra_check_box_callback(int event_id, struct DynamicWidgetArray* arr, int new_state) {
+   for (int i = 0; i < arr->len; i++) {
+      twr_window_menu_widget_set_visibility(&arr->arr[i], new_state);
+   }
+}
 __attribute__((export_name("boxBorderChanged")))
 void box_border_changed(int event_id, void* _, int new_state) {
    printf("new box border update! %d\n", new_state);
@@ -195,11 +448,21 @@ void animation_frame(int id, int delta) {
       d2d_strokerect(ds, square_x, square_y, SQUARE_WIDTH, SQUARE_HEIGHT);
    }
 
+   d2d_setfillstyle(ds, COLORS[box_center_dot_color_index]);
+   if (box_center_dot) {
+      d2d_fillrect(ds, square_x + SQUARE_WIDTH/2.0 - 5.0, square_y + SQUARE_HEIGHT/2.0 - 5.0, 10.0, 10.0);
+   }
+
    d2d_end_draw_sequence(ds);
 }
 
 __attribute__((export_name("mouseMoveHandler")))
-void mouse_move_handler(int id, int x, int y) {
+void mouse_move_handler(int id, int x, int y, int button) {
+   if (mouse_event_ids[box_move_event_type] != id)
+      return;
+   if (box_move_event_type == MOUSE_EVENT_LEFT_CLICK && button != 0)
+      return;
    square_x = x - SQUARE_WIDTH/2.0;
    square_y = y - SQUARE_HEIGHT/2.0;
+   
 }

--- a/examples/window/window.c
+++ b/examples/window/window.c
@@ -14,8 +14,6 @@ long canvas_height = 0;
 struct twr_window_menu box_color_menu;
 struct twr_window_menu test_two_menu;
 
-struct twr_window_widget red_box_button;
-struct twr_window_widget blue_box_button;
 unsigned long box_color = 0xFF0000FF;
 
 struct twr_window_widget spawn_button;
@@ -46,56 +44,6 @@ void init() {
    box_color_menu = twr_window_add_menu(window_con, "Box Color");
    test_two_menu = twr_window_add_menu(window_con, "test_two");
 
-   struct twr_widget_button_constructor red_box_button_cons = {
-      .base = {
-         .type = WINDOW_WIDGET_BUTTON,
-         .x = 0,
-         .y = 0,
-         .width = -1,
-         .height = 20
-      },
-      .text = "Red",
-      .text_font = "14px Seriph",
-      .text_color = NULL,
-      .button_color = NULL,
-      .selected_button_color = NULL
-   };
-   red_box_button = twr_window_menu_add_widget(&box_color_menu, &red_box_button_cons.base);
-   
-   struct twr_widget_seperator_constructor seperator_cons = {
-      .base = {
-         .type = WINDOW_WIDGET_SEPERATOR,
-         .x = 0,
-         .y = 0,
-         .width = -1,
-         .height = 10
-      },
-      .seperator_text = "-",
-      .seperator_font = NULL,
-      .seperator_color = NULL,
-   };
-   twr_window_menu_add_widget(&box_color_menu, &seperator_cons.base);
-
-   struct twr_widget_button_constructor blue_box_button_cons = {
-      .base = {
-         .type = WINDOW_WIDGET_BUTTON,
-         .x = 0,
-         .y = 0,
-         .width = -1,
-         .height = 20
-      },
-      .text = "Blue",
-      .text_font = "14px Seriph",
-      .text_color = NULL,
-      .button_color = NULL,
-      .selected_button_color = NULL
-   };
-   blue_box_button = twr_window_menu_add_widget(&box_color_menu, &blue_box_button_cons.base);
-
-   int button_callback = twr_register_callback("buttonPressed");
-   twr_window_menu_button_add_callback(&red_box_button, button_callback, (void*)(&red_box_button));
-   twr_window_menu_button_add_callback(&blue_box_button, button_callback, (void*)(&blue_box_button));
-
    struct twr_widget_button_constructor spawn_button_constructor = {
       .base = {
          .type = WINDOW_WIDGET_BUTTON,
@@ -113,11 +61,55 @@ void init() {
    spawn_button = twr_window_menu_add_widget(&test_two_menu, &spawn_button_constructor.base);
    
    int spawn_button_callback = twr_register_callback("spawnButtonPressed");
-   twr_window_menu_button_add_callback(&spawn_button, spawn_button_callback, (void*)0);
+   twr_window_menu_widget_add_callback(&spawn_button, spawn_button_callback, (void*)0);
    delete_button_callback = twr_register_callback("deleteButtonPressed");
+
+   struct twr_widget_seperator_constructor seperator_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_SEPERATOR,
+         .x = 0,
+         .y = 0,
+         .width = -1,
+         .height = 10
+      },
+      .seperator_text = "-",
+      .seperator_font = NULL,
+      .seperator_color = NULL,
+   };
 
    twr_window_menu_add_widget(&test_two_menu, &seperator_cons.base);
    
+
+   // struct twr_window_menu radio_menu_header = twr_window_add_menu(window_con, "Radio_Menu");
+   
+   struct twr_widget_radio_menu_constructor radio_menu_constructor = {
+      .base = {
+         .type = WINDOW_WIDGET_RADIO_MENU,
+         .x = 0,
+         .y = 0,
+         .width = -1,
+         .height = -1,
+      },
+      .hovered_background_color = "#D0D0D0",
+      .menu_color = "#B0B0B0",
+      .minimum_height = 10,
+      .minimum_width = 10,
+      .option_height = 20,
+      .option_text_color = "black",
+      .option_text_font = "14px Seriph",
+      .selected_symbol = "*",
+      .y_padding = 5,
+   };
+   struct twr_window_widget radio_menu = twr_window_menu_add_widget(&box_color_menu, &radio_menu_constructor.base);
+   twr_window_menu_radio_menu_add_option(&radio_menu, "Red");
+   twr_window_menu_radio_menu_add_option(&radio_menu, "Blue");
+   twr_window_menu_radio_menu_add_option(&radio_menu, "Magenta");
+   twr_window_menu_radio_menu_add_option(&radio_menu, "Yellow");
+   twr_window_menu_radio_menu_add_option(&radio_menu, "Cyan");
+   twr_window_menu_radio_menu_add_option(&radio_menu, "Teal");
+
+   int box_color_event = twr_register_callback("boxColorChanged");
+   twr_window_menu_widget_add_callback(&radio_menu, box_color_event, (void*)0);
 }
 
 __attribute__((export_name("spawnButtonPressed")))
@@ -142,22 +134,31 @@ void spawn_button_pressed(int event_id, void* ptr) {
 
    printf("spawned new button: %d\n", button.widget_id);
 
-   twr_window_menu_button_add_callback(&button, delete_button_callback, (void*)heap_button);
+   twr_window_menu_widget_add_callback(&button, delete_button_callback, (void*)heap_button);
 }
 __attribute__((export_name("deleteButtonPressed")))
 void delete_button_pressed(int event_id, struct twr_window_widget* button) {
    twr_window_menu_delete_widget(button);
    free(button);
 }
-
-__attribute__((export_name("buttonPressed")))
-void button_pressed(int event_id, struct twr_window_widget* button) {
-   if (button->widget_id == red_box_button.widget_id) {
+__attribute__((export_name("boxColorChanged")))
+void box_color_changed(int event_id, void* extra, char* opt) {
+   if (strcmp(opt, "Red") == 0) {
       box_color = 0xFF0000FF;
-   } else if (button->widget_id == blue_box_button.widget_id) {
+   } else if (strcmp(opt, "Blue") == 0) {
       box_color = 0x0000FFFF;
+   } else if (strcmp(opt, "Magenta") == 0) {
+      box_color = 0xFF00FFFF;
+   } else if (strcmp(opt, "Yellow") == 0) {
+      box_color = 0xFFFF00FF;
+   } else if (strcmp(opt, "Cyan") == 0) {
+      box_color = 0x00FFFFFF;
+   } else if (strcmp(opt, "Teal") == 0) {
+      box_color = 0x008080FF;
    }
+   free(opt);
 }
+
 
 int square_x = 75;
 int square_y = 75;

--- a/source/twr-c/draw2d.c
+++ b/source/twr-c/draw2d.c
@@ -707,3 +707,24 @@ long d2d_doesidexist(struct d2d_draw_seq* ds, long id) {
 
    return exists;
 }
+
+
+void d2d_register_event(enum D2DEvent eventType, int eventID) {
+   d2d_register_event_with_con(eventType, eventID, twr_get_std2d_con());
+}
+void d2d_register_event_with_con(enum D2DEvent eventType, int eventID, twr_ioconsole_t * con) {
+   twrRegisterEvent(__twr_get_jsid(con), (int)eventType, eventID);
+}
+
+void d2d_unregister_event(enum D2DEvent eventType, int eventID) {
+   d2d_unregister_event_with_con(eventType, eventID, twr_get_std2d_con());
+}
+void d2d_unregister_event_with_con(enum D2DEvent eventType, int eventID, twr_ioconsole_t * con) {
+   twrUnregisterEvent(__twr_get_jsid(con), (int)eventType, eventID);
+}
+void d2d_unregister_all_events() {
+   d2d_unregister_all_events_with_con(twr_get_std2d_con());
+}
+void d2d_unregister_all_events_with_con(twr_ioconsole_t * con) {
+   twrUnregisterAllEvents(__twr_get_jsid(con));
+}

--- a/source/twr-c/twr-canvas-events.h
+++ b/source/twr-c/twr-canvas-events.h
@@ -1,0 +1,16 @@
+#ifndef __TWR_CANVAS_EVENTS_H__
+#define __TWR_CANVAS_EVENTS_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+__attribute__((import_name("twrRegisterEvent"))) void twrRegisterEvent(int jsid, int eventType, int eventID);
+__attribute__((import_name("twrUnregisterEvent"))) void twrUnregisterEvent(int jsid, int eventType, int eventID);
+__attribute__((import_name("twrUnregisterAllEvents"))) void twrUnregisterAllEvents(int jsid);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/source/twr-c/twr-draw2d.h
+++ b/source/twr-c/twr-draw2d.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include "twr-io.h"
+#include "twr-canvas-events.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -451,9 +452,6 @@ enum D2DEvent {
 
    D2D_ANIMATION_FRAME
 };
-__attribute__((import_name("twrRegisterEvent"))) void twrRegisterEvent(int jsid, int eventType, int eventID);
-__attribute__((import_name("twrUnregisterEvent"))) void twrUnregisterEvent(int jsid, int eventType, int eventID);
-__attribute__((import_name("twrUnregisterAllEvents"))) void twrUnregisterAllEvents(int jsid);
 
 struct d2d_draw_seq* d2d_start_draw_sequence(int flush_at_ins_count);
 struct d2d_draw_seq* d2d_start_draw_sequence_with_con(int flush_at_ins_count, twr_ioconsole_t * con);

--- a/source/twr-c/twr-draw2d.h
+++ b/source/twr-c/twr-draw2d.h
@@ -437,6 +437,22 @@ struct d2d_2d_matrix {
 __attribute__((import_name("twrConDrawSeq"))) void twrConDrawSeq(int jsid, struct d2d_draw_seq *);
 __attribute__((import_name("twrConLoadImage"))) bool twrConLoadImage(int jsid, const char* url, long id);
 
+enum D2DEvent {
+   D2D_KEY_DOWN,
+   D2D_KEY_UP,
+
+   D2D_MOUSE_DOWN,
+   D2D_MOUSE_UP,
+   D2D_MOUSE_CLICK,
+   D2D_MOUSE_DBLCLICK,
+   D2D_MOUSE_MOVE,
+
+   D2D_WHEEL
+};
+__attribute__((import_name("twrRegisterEvent"))) void twrRegisterEvent(int jsid, int eventType, int eventID);
+__attribute__((import_name("twrUnregisterEvent"))) void twrUnregisterEvent(int jsid, int eventType, int eventID);
+__attribute__((import_name("twrUnregisterAllEvents"))) void twrUnregisterAllEvents(int jsid);
+
 struct d2d_draw_seq* d2d_start_draw_sequence(int flush_at_ins_count);
 struct d2d_draw_seq* d2d_start_draw_sequence_with_con(int flush_at_ins_count, twr_ioconsole_t * con);
 void d2d_end_draw_sequence(struct d2d_draw_seq* ds);
@@ -517,6 +533,13 @@ void d2d_setcanvaspropdouble(struct d2d_draw_seq* ds, const char* prop_name, dou
 void d2d_setcanvaspropstring(struct d2d_draw_seq* ds, const char* prop_name, const char* val);
 
 long d2d_doesidexist(struct d2d_draw_seq* ds, long id);
+
+void d2d_register_event(enum D2DEvent eventType, int eventID);
+void d2d_register_event_with_con(enum D2DEvent eventType, int eventID, twr_ioconsole_t * con);
+void d2d_unregister_event(enum D2DEvent eventType, int eventID);
+void d2d_unregister_event_with_con(enum D2DEvent eventType, int eventID, twr_ioconsole_t * con);
+void d2d_unregister_all_events();
+void d2d_unregister_all_events_with_con(twr_ioconsole_t * con);
 
 #ifdef __cplusplus
 }

--- a/source/twr-c/twr-draw2d.h
+++ b/source/twr-c/twr-draw2d.h
@@ -447,7 +447,9 @@ enum D2DEvent {
    D2D_MOUSE_DBLCLICK,
    D2D_MOUSE_MOVE,
 
-   D2D_WHEEL
+   D2D_WHEEL,
+
+   D2D_ANIMATION_FRAME
 };
 __attribute__((import_name("twrRegisterEvent"))) void twrRegisterEvent(int jsid, int eventType, int eventID);
 __attribute__((import_name("twrUnregisterEvent"))) void twrUnregisterEvent(int jsid, int eventType, int eventID);

--- a/source/twr-c/twr-window.c
+++ b/source/twr-c/twr-window.c
@@ -1,6 +1,7 @@
 #include "twr-window.h"
 #include "twr-crt.h"
 #include <assert.h>
+#include <stdlib.h>
 
 twr_ioconsole_t* twr_window_get_app_canvas(twr_ioconsole_t* con) {
    int id = twrGetAppCanvasJSID(__twr_get_jsid(con));
@@ -41,6 +42,119 @@ void twr_window_menu_radio_item_merge(const struct twr_window_widget* widget1, c
    twrWindowMenuRadioItemMerge(widget1->jsid, widget1->widget_id, widget2->widget_id);
 }
 
-void twr_window_menu_widget_set_visibility(struct twr_window_widget* widget, int visibility) {
-   twrWindowMenuWidgetSetVisibility(widget->jsid, widget->widget_id, visibility);
+// void twr_window_menu_widget_set_visibility(struct twr_window_widget* widget, int visibility) {
+//    // twrWindowMenuWidgetSetVisibility(widget->jsid, widget->widget_id, visibility);
+//    twr_window_menu_widget_set_bool(widget, "isVisible", visibility);
+// }
+
+void twr_window_menu_widget_set_string(const struct twr_window_widget* widget, const char* prop_name, const char* val) {
+   // struct twr_widget_prop_value {
+   //    enum WindowWidgetPropVal type;
+   //    const void* val;
+   // };
+   struct twr_widget_prop_value prop_val = {
+      .string = val,
+      .type = WINDOW_WIDGET_PROP_STRING,
+   };
+   twrWindowMenuWidgetSetProp(widget->jsid, widget->widget_id, prop_name, &prop_val);
+}
+void twr_window_menu_widget_set_bool(const struct twr_window_widget* widget, const char* prop_name, int val) {
+   struct twr_widget_prop_value prop_val = {
+      .boolean = val,
+      .type = WINDOW_WIDGET_PROP_BOOLEAN,
+   };
+   twrWindowMenuWidgetSetProp(widget->jsid, widget->widget_id, prop_name, &prop_val);
+}
+void twr_window_menu_widget_set_number(const struct twr_window_widget* widget, const char* prop_name, double val) {
+   struct twr_widget_prop_value prop_val = {
+      .number = val,
+      .type = WINDOW_WIDGET_PROP_NUMBER,
+   };
+   twrWindowMenuWidgetSetProp(widget->jsid, widget->widget_id, prop_name, &prop_val);
+}
+void twr_window_menu_widget_set_undefined(const struct twr_window_widget* widget, const char* prop_name) {
+   struct twr_widget_prop_value prop_val = {
+      .type = WINDOW_WIDGET_PROP_UNDEFINED,
+   };
+   twrWindowMenuWidgetSetProp(widget->jsid, widget->widget_id, prop_name, &prop_val);
+}
+
+struct twr_widget_prop_value* twr_window_menu_widget_get_prop(const struct twr_window_widget* widget, const char* prop_name) {
+   return twrWindowMenuWidgetGetProp(widget->jsid, widget->widget_id, prop_name);
+}
+
+char* twr_window_menu_widget_get_prop_string(const struct twr_window_widget* widget, const char* prop_name, int* success) {
+   struct twr_widget_prop_value* val = twr_window_menu_widget_get_prop(widget, prop_name);
+   *success = true;
+   if (val->type == WINDOW_WIDGET_PROP_UNDEFINED) {
+      free(val);
+      return (char*)0;
+   } else if (val->type == WINDOW_WIDGET_PROP_STRING) {
+      char* str = (char*)val->string;
+      free(val);
+      return str;
+   } else {
+      free(val);
+      *success = false;
+      return (char*)0;
+   }
+}
+char* twr_window_menu_widget_get_prop_string_or_null(const struct twr_window_widget* widget, const char* prop_name) {
+   struct twr_widget_prop_value* val = twr_window_menu_widget_get_prop(widget, prop_name);
+   if (val->type == WINDOW_WIDGET_PROP_STRING) {
+      char* str = (char*)val->string;
+      free(val);
+      return str;
+   } else {
+      free(val);
+      return (char*)0;
+   }
+}
+int twr_window_menu_widget_get_prop_boolean(const struct twr_window_widget* widget, const char* prop_name, int* success) {
+   struct twr_widget_prop_value* val = twr_window_menu_widget_get_prop(widget, prop_name);
+   if (val->type == WINDOW_WIDGET_PROP_BOOLEAN) {
+      int boolean = val->boolean;
+      free(val);
+      *success = true;
+      return boolean;
+   } else {
+      free(val);
+      *success = false;
+      return -1;
+   }
+}
+int twr_window_menu_widget_get_prop_boolean_or_default(const struct twr_window_widget* widget, const char* prop_name, int default_val) {
+   struct twr_widget_prop_value* val = twr_window_menu_widget_get_prop(widget, prop_name);
+   if (val->type == WINDOW_WIDGET_PROP_BOOLEAN) {
+      int boolean = val->boolean;
+      free(val);
+      return boolean;
+   } else {
+      free(val);
+      return default_val;
+   }
+}
+double twr_window_menu_widget_get_prop_number(const struct twr_window_widget* widget, const char* prop_name, int *success) {
+   struct twr_widget_prop_value* val = twr_window_menu_widget_get_prop(widget, prop_name);
+   if (val->type == WINDOW_WIDGET_PROP_NUMBER) {
+      double number = val->number;
+      free(val);
+      *success = true;
+      return number;
+   } else {
+      free(val);
+      *success = false;
+      return -1.0;
+   }
+}
+double twr_window_menu_widget_get_prop_number_or_default(const struct twr_window_widget* widget, const char* prop_name, double default_val) {
+   struct twr_widget_prop_value* val = twr_window_menu_widget_get_prop(widget, prop_name);
+   if (val->type == WINDOW_WIDGET_PROP_NUMBER) {
+      double number = val->number;
+      free(val);
+      return number;
+   } else {
+      free(val);
+      return default_val;
+   }
 }

--- a/source/twr-c/twr-window.c
+++ b/source/twr-c/twr-window.c
@@ -4,8 +4,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-twr_ioconsole_t* twr_window_get_app_canvas(twr_ioconsole_t* con) {
-   int id = twrGetAppCanvasJSID(__twr_get_jsid(con));
+twr_ioconsole_t* twr_window_get_draw_canvas(twr_ioconsole_t* con) {
+   int id = twrGetDrawCanvasJSID(__twr_get_jsid(con));
    return twr_jscon(id);
 }
 
@@ -298,4 +298,15 @@ void twr_window_menu_set_prop_string(twr_ioconsole_t* window, const char* prop_n
       .string = (char*)val,
       .type = WINDOW_WIDGET_PROP_STRING,
    });
+}
+
+
+void twr_window_register_event(twr_ioconsole_t* window, enum TwrWindowEvents event, int event_id) {
+   twrRegisterEvent(__twr_get_jsid(window), event, event_id);
+}
+void twr_window_unregister_event(twr_ioconsole_t* window, enum TwrWindowEvents event, int event_id) {
+   twrUnregisterEvent(__twr_get_jsid(window), event, event_id);
+}
+void twr_window_unregiser_all_events(twr_ioconsole_t* window) {
+   twrUnregisterAllEvents(__twr_get_jsid(window));
 }

--- a/source/twr-c/twr-window.c
+++ b/source/twr-c/twr-window.c
@@ -1,5 +1,6 @@
 #include "twr-window.h"
 #include "twr-crt.h"
+#include <assert.h>
 
 twr_ioconsole_t* twr_window_get_app_canvas(twr_ioconsole_t* con) {
    int id = twrGetAppCanvasJSID(__twr_get_jsid(con));
@@ -31,8 +32,13 @@ void twr_window_menu_delete_widget(const struct twr_window_widget* widget) {
    twrWindowMenuDeleteWidget(widget->jsid, widget->widget_id);
 }
 
-void twr_window_menu_radio_menu_add_option(struct twr_window_widget* widget, const char* option) {
-   twrWindowMenuRadioMenuAddOption(widget->jsid, widget->widget_id, option);
+// void twr_window_menu_radio_menu_add_option(struct twr_window_widget* widget, const char* option) {
+//    twrWindowMenuRadioMenuAddOption(widget->jsid, widget->widget_id, option);
+// }
+
+void twr_window_menu_radio_item_merge(const struct twr_window_widget* widget1, const struct twr_window_widget* widget2) {
+   assert(widget1->jsid == widget2->jsid);
+   twrWindowMenuRadioItemMerge(widget1->jsid, widget1->widget_id, widget2->widget_id);
 }
 
 void twr_window_menu_widget_set_visibility(struct twr_window_widget* widget, int visibility) {

--- a/source/twr-c/twr-window.c
+++ b/source/twr-c/twr-window.c
@@ -83,78 +83,63 @@ struct twr_widget_prop_value* twr_window_menu_widget_get_prop(const struct twr_w
    return twrWindowMenuWidgetGetProp(widget->jsid, widget->widget_id, prop_name);
 }
 
-char* twr_window_menu_widget_get_prop_string(const struct twr_window_widget* widget, const char* prop_name, int* success) {
+int twr_window_menu_widget_get_prop_string(const struct twr_window_widget* widget, const char* prop_name, char** ret_str) {
    struct twr_widget_prop_value* val = twr_window_menu_widget_get_prop(widget, prop_name);
-   *success = true;
-   if (val->type == WINDOW_WIDGET_PROP_UNDEFINED) {
+   if (val->type == WINDOW_WIDGET_PROP_STRING) {
+      *ret_str = (char*)val->string;
       free(val);
-      return (char*)0;
-   } else if (val->type == WINDOW_WIDGET_PROP_STRING) {
-      char* str = (char*)val->string;
-      free(val);
-      return str;
+      return 1;
    } else {
       free(val);
-      *success = false;
-      return (char*)0;
+      *ret_str = NULL;
+      return 0;
    }
 }
 char* twr_window_menu_widget_get_prop_string_or_null(const struct twr_window_widget* widget, const char* prop_name) {
-   struct twr_widget_prop_value* val = twr_window_menu_widget_get_prop(widget, prop_name);
-   if (val->type == WINDOW_WIDGET_PROP_STRING) {
-      char* str = (char*)val->string;
-      free(val);
+   char* str;
+   if (twr_window_menu_widget_get_prop_string(widget, prop_name, &str)) {
       return str;
    } else {
-      free(val);
-      return (char*)0;
+      return NULL;
    }
 }
-int twr_window_menu_widget_get_prop_boolean(const struct twr_window_widget* widget, const char* prop_name, int* success) {
+int twr_window_menu_widget_get_prop_boolean(const struct twr_window_widget* widget, const char* prop_name, int* ret_bool) {
    struct twr_widget_prop_value* val = twr_window_menu_widget_get_prop(widget, prop_name);
    if (val->type == WINDOW_WIDGET_PROP_BOOLEAN) {
-      int boolean = val->boolean;
+      *ret_bool = val->boolean;
       free(val);
-      *success = true;
-      return boolean;
+      return 1;
    } else {
       free(val);
-      *success = false;
-      return -1;
+      *ret_bool = false;
+      return 0;
    }
 }
 int twr_window_menu_widget_get_prop_boolean_or_default(const struct twr_window_widget* widget, const char* prop_name, int default_val) {
-   struct twr_widget_prop_value* val = twr_window_menu_widget_get_prop(widget, prop_name);
-   if (val->type == WINDOW_WIDGET_PROP_BOOLEAN) {
-      int boolean = val->boolean;
-      free(val);
-      return boolean;
+   int ret = 0;
+   if (twr_window_menu_widget_get_prop_boolean(widget, prop_name, &ret)) {
+      return ret;
    } else {
-      free(val);
       return default_val;
    }
 }
-double twr_window_menu_widget_get_prop_number(const struct twr_window_widget* widget, const char* prop_name, int *success) {
+int twr_window_menu_widget_get_prop_number(const struct twr_window_widget* widget, const char* prop_name, double *ret_number) {
    struct twr_widget_prop_value* val = twr_window_menu_widget_get_prop(widget, prop_name);
    if (val->type == WINDOW_WIDGET_PROP_NUMBER) {
-      double number = val->number;
+      *ret_number = val->number;
       free(val);
-      *success = true;
-      return number;
+      return 1;
    } else {
       free(val);
-      *success = false;
-      return -1.0;
+      *ret_number = -1.0;
+      return 0;
    }
 }
 double twr_window_menu_widget_get_prop_number_or_default(const struct twr_window_widget* widget, const char* prop_name, double default_val) {
-   struct twr_widget_prop_value* val = twr_window_menu_widget_get_prop(widget, prop_name);
-   if (val->type == WINDOW_WIDGET_PROP_NUMBER) {
-      double number = val->number;
-      free(val);
-      return number;
+   double ret = 0;
+   if (twr_window_menu_widget_get_prop_number(widget, prop_name, &ret)) {
+      return ret;
    } else {
-      free(val);
       return default_val;
    }
 }

--- a/source/twr-c/twr-window.c
+++ b/source/twr-c/twr-window.c
@@ -1,0 +1,7 @@
+#include "twr-window.h"
+#include "twr-crt.h"
+
+twr_ioconsole_t* twr_window_get_app_canvas(twr_ioconsole_t* con) {
+   int id = twrGetAppCanvasJSID(__twr_get_jsid(con));
+   return twr_jscon(id);
+}

--- a/source/twr-c/twr-window.c
+++ b/source/twr-c/twr-window.c
@@ -137,7 +137,10 @@ double twr_window_menu_widget_get_prop_number_or_default(const struct twr_window
    }
 }
 
-
+void twr_window_menu_widget_fill_in_details(const struct twr_window_widget* widget, struct twr_widget_prop_details* details) {
+   assert(details->name != (void*)0);
+   twrWindowMenuWidgetGetPropDetails(widget->jsid, widget->widget_id, details);
+}
 struct twr_widget_prop_details* twr_window_menu_widget_list_props(const struct twr_window_widget* widget, long* length) {
    return twrWindowMenuWidgetListProps(widget->jsid, widget->widget_id, length);
 }

--- a/source/twr-c/twr-window.c
+++ b/source/twr-c/twr-window.c
@@ -2,6 +2,7 @@
 #include "twr-crt.h"
 #include <assert.h>
 #include <stdlib.h>
+#include <string.h>
 
 twr_ioconsole_t* twr_window_get_app_canvas(twr_ioconsole_t* con) {
    int id = twrGetAppCanvasJSID(__twr_get_jsid(con));
@@ -33,19 +34,10 @@ void twr_window_menu_delete_widget(const struct twr_window_widget* widget) {
    twrWindowMenuDeleteWidget(widget->jsid, widget->widget_id);
 }
 
-// void twr_window_menu_radio_menu_add_option(struct twr_window_widget* widget, const char* option) {
-//    twrWindowMenuRadioMenuAddOption(widget->jsid, widget->widget_id, option);
-// }
-
 void twr_window_menu_radio_item_merge(const struct twr_window_widget* widget1, const struct twr_window_widget* widget2) {
    assert(widget1->jsid == widget2->jsid);
    twrWindowMenuRadioItemMerge(widget1->jsid, widget1->widget_id, widget2->widget_id);
 }
-
-// void twr_window_menu_widget_set_visibility(struct twr_window_widget* widget, int visibility) {
-//    // twrWindowMenuWidgetSetVisibility(widget->jsid, widget->widget_id, visibility);
-//    twr_window_menu_widget_set_bool(widget, "isVisible", visibility);
-// }
 
 void twr_window_menu_widget_set_string(const struct twr_window_widget* widget, const char* prop_name, const char* val) {
    // struct twr_widget_prop_value {
@@ -86,7 +78,8 @@ struct twr_widget_prop_value* twr_window_menu_widget_get_prop(const struct twr_w
 int twr_window_menu_widget_get_prop_string(const struct twr_window_widget* widget, const char* prop_name, char** ret_str) {
    struct twr_widget_prop_value* val = twr_window_menu_widget_get_prop(widget, prop_name);
    if (val->type == WINDOW_WIDGET_PROP_STRING) {
-      *ret_str = (char*)val->string;
+      // *ret_str = (char*)val->string;
+      *ret_str = strdup(val->string);      
       free(val);
       return 1;
    } else {
@@ -142,4 +135,9 @@ double twr_window_menu_widget_get_prop_number_or_default(const struct twr_window
    } else {
       return default_val;
    }
+}
+
+
+struct twr_widget_prop_details* twr_window_menu_widget_list_props(const struct twr_window_widget* widget, long* length) {
+   return twrWindowMenuWidgetListProps(widget->jsid, widget->widget_id, length);
 }

--- a/source/twr-c/twr-window.c
+++ b/source/twr-c/twr-window.c
@@ -161,7 +161,7 @@ struct twr_window_widget twr_window_menu_add_button_widget(const struct twr_wind
       .text = text
    };
 
-   return twr_window_menu_add_widget(menu, &button_cons);
+   return twr_window_menu_add_widget(menu, &button_cons.base);
 }
 
 struct twr_window_widget twr_window_menu_add_seperator_widget(const struct twr_window_widget* menu, long width, long height, const char* seperator_text, const char* seperator_font) {
@@ -175,7 +175,7 @@ struct twr_window_widget twr_window_menu_add_seperator_widget(const struct twr_w
       .seperator_font = seperator_font
    };
 
-   return twr_window_menu_add_widget(menu, &seperator_cons);
+   return twr_window_menu_add_widget(menu, &seperator_cons.base);
 }
 
 struct twr_window_widget twr_window_menu_add_radio_item_widget(const struct twr_window_widget* menu, long width, long height, const char* text) {
@@ -188,10 +188,10 @@ struct twr_window_widget twr_window_menu_add_radio_item_widget(const struct twr_
       .text = text
    };
 
-   return twr_window_menu_add_widget(menu, &radio_item_cons);
+   return twr_window_menu_add_widget(menu, &radio_item_cons.base);
 }
 
-struct twr_window_widget twr_window_menu_add_sub_menu_widget(const struct twr_window_widget* menu, long width, long height, const char* button_text, long minimum_menu_width, long minimum_menu_height, long minimum_child_height) {
+struct twr_window_widget twr_window_menu_add_sub_menu_widget(const struct twr_window_widget* menu, long width, long height, const char* button_text, long minimum_menu_width, long minimum_menu_height) {
    struct twr_widget_sub_menu_constructor sub_menu_cons = {
       .base = {
          .type = WINDOW_WIDGET_SUB_MENU,
@@ -201,13 +201,12 @@ struct twr_window_widget twr_window_menu_add_sub_menu_widget(const struct twr_wi
       .button_text = button_text,
       .minimum_menu_width = minimum_menu_width,
       .minimum_menu_height = minimum_menu_height,
-      .minimum_child_height = minimum_child_height,
    };
 
-   return twr_window_menu_add_widget(menu, &sub_menu_cons);
+   return twr_window_menu_add_widget(menu, &sub_menu_cons.base);
 }
 struct twr_window_widget twr_window_menu_add_sub_menu_widget_reduced(const struct twr_window_widget* menu, long width, long height, const char* button_text) {
-   return twr_window_menu_add_sub_menu_widget(menu, width, height, button_text, -1, -1, -1);
+   return twr_window_menu_add_sub_menu_widget(menu, width, height, button_text, -1, -1);
 }
 
 struct twr_window_widget twr_window_menu_add_check_box_widget(const struct twr_window_widget* menu, long width, long height, const char* text) {
@@ -220,7 +219,7 @@ struct twr_window_widget twr_window_menu_add_check_box_widget(const struct twr_w
       .text = text,
    };
 
-   return twr_window_menu_add_widget(menu, &check_box_cons);
+   return twr_window_menu_add_widget(menu, &check_box_cons.base);
 }
 
 

--- a/source/twr-c/twr-window.c
+++ b/source/twr-c/twr-window.c
@@ -6,17 +6,17 @@ twr_ioconsole_t* twr_window_get_app_canvas(twr_ioconsole_t* con) {
    return twr_jscon(id);
 }
 
-struct twr_window_menu twr_window_add_menu(twr_ioconsole_t * con, const char* text) {
+struct twr_window_widget twr_window_add_menu(twr_ioconsole_t * con, const char* text) {
    int id = __twr_get_jsid(con);
    int menu_id = twrWindowAddMenu(id, text);
-   return (struct twr_window_menu){
+   return (struct twr_window_widget){
       .jsid = id,
-      .menu_id = menu_id,
+      .widget_id = menu_id,
    };
 }
 
-struct twr_window_widget twr_window_menu_add_widget(const struct twr_window_menu* menu, const struct twr_widget_constructor* widget) {
-   int widget_id = twrWindowMenuAddWidget(menu->jsid, menu->menu_id, widget);
+struct twr_window_widget twr_window_menu_add_widget(const struct twr_window_widget* menu, const struct twr_widget_constructor* widget) {
+   int widget_id = twrWindowMenuAddWidget(menu->jsid, menu->widget_id, widget);
    return (struct twr_window_widget){
       .jsid = menu->jsid,
       .widget_id = widget_id

--- a/source/twr-c/twr-window.c
+++ b/source/twr-c/twr-window.c
@@ -223,3 +223,80 @@ struct twr_window_widget twr_window_menu_add_check_box_widget(const struct twr_w
    return twr_window_menu_add_widget(menu, &check_box_cons);
 }
 
+
+struct twr_widget_prop_value* twr_window_menu_get_prop(twr_ioconsole_t* window, const char* prop_name) {
+   return twrWindowMenuGetProp(__twr_get_jsid(window), prop_name);
+}
+int twr_window_menu_get_prop_boolean(twr_ioconsole_t* window, const char* prop_name, int* ret_bool) {
+   struct twr_widget_prop_value* ret_val = twr_window_menu_get_prop(window, prop_name);
+   int success = ret_val->type == WINDOW_WIDGET_PROP_BOOLEAN;
+   if (success)
+      *ret_bool = ret_val->boolean;
+
+   free(ret_val);
+   return 0;
+}
+int twr_window_menu_get_prop_boolean_or_default(twr_ioconsole_t* window, const char* prop_name, int def) {
+   int ret;
+   if (twr_window_menu_get_prop_boolean(window, prop_name, &ret)) {
+      return ret;
+   } else {
+      return def;
+   }
+}
+int twr_window_menu_get_prop_number(twr_ioconsole_t* window, const char* prop_name, double* ret_number) {
+   struct twr_widget_prop_value* ret_val = twr_window_menu_get_prop(window, prop_name);
+   int success = ret_val->type == WINDOW_WIDGET_PROP_NUMBER;
+   if (success)
+      *ret_number = ret_val->number;
+   
+   free(ret_val);
+   return success;
+}
+double twr_window_menu_get_prop_number_or_default(twr_ioconsole_t* window, const char* prop_name, double def) {
+   double ret;
+   if (twr_window_menu_get_prop_number(window, prop_name, &ret)) {
+      return ret;
+   } else {
+      return def;
+   }
+}
+int twr_window_menu_get_prop_string(twr_ioconsole_t* window, const char* prop_name, char** ret_str) {
+   struct twr_widget_prop_value* ret_val = twr_window_menu_get_prop(window, prop_name);
+   int success = ret_val->type == WINDOW_WIDGET_PROP_STRING;
+   if (success)
+      *ret_str = strdup(ret_val->string);
+
+   free(ret_val);
+   return success;
+}
+char* twr_window_menu_get_prop_string_or_default(twr_ioconsole_t* window, const char* prop_name) {
+   char* ret;
+   if (twr_window_menu_get_prop_string(window, prop_name, &ret)) {
+      return ret;
+   } else {
+      return (char*)0;
+   }
+}
+
+void twr_window_menu_set_prop(twr_ioconsole_t* window, const char* prop_name, struct twr_widget_prop_value* val) {
+   twrWindowMenuSetProp(__twr_get_jsid(window), prop_name, val);
+}
+void twr_window_menu_set_prop_boolean(twr_ioconsole_t* window, const char* prop_name, int val) {
+   twr_window_menu_set_prop(window, prop_name, &(struct twr_widget_prop_value){
+      .boolean = val,
+      .type = WINDOW_WIDGET_PROP_BOOLEAN,
+   });
+}
+void twr_window_menu_set_prop_number(twr_ioconsole_t* window, const char* prop_name, double val) {
+   twr_window_menu_set_prop(window, prop_name, &(struct twr_widget_prop_value){
+      .number = val,
+      .type = WINDOW_WIDGET_PROP_NUMBER,
+   });
+}
+void twr_window_menu_set_prop_string(twr_ioconsole_t* window, const char* prop_name, const char* val) {
+   twr_window_menu_set_prop(window, prop_name, &(struct twr_widget_prop_value){
+      .string = (char*)val,
+      .type = WINDOW_WIDGET_PROP_STRING,
+   });
+}

--- a/source/twr-c/twr-window.c
+++ b/source/twr-c/twr-window.c
@@ -26,3 +26,7 @@ struct twr_window_widget twr_window_menu_add_widget(const struct twr_window_menu
 void twr_window_menu_button_add_callback(const struct twr_window_widget* widget, int event_id, void* extraPtr) {
    twrWindowMenuButtonAddCallback(widget->jsid, widget->widget_id, event_id, extraPtr);
 }
+
+void twr_window_menu_delete_widget(const struct twr_window_widget* widget) {
+   twrWindowMenuDeleteWidget(widget->jsid, widget->widget_id);
+}

--- a/source/twr-c/twr-window.c
+++ b/source/twr-c/twr-window.c
@@ -5,3 +5,12 @@ twr_ioconsole_t* twr_window_get_app_canvas(twr_ioconsole_t* con) {
    int id = twrGetAppCanvasJSID(__twr_get_jsid(con));
    return twr_jscon(id);
 }
+
+struct twr_window_menu twr_window_add_menu(twr_ioconsole_t * con, const char* text) {
+   int id = __twr_get_jsid(con);
+   
+   return (struct twr_window_menu){
+      .jsid = id,
+      .menu_id = twrWindowAddMenu(id, text)
+   };
+}

--- a/source/twr-c/twr-window.c
+++ b/source/twr-c/twr-window.c
@@ -144,3 +144,82 @@ void twr_window_menu_widget_fill_in_details(const struct twr_window_widget* widg
 struct twr_widget_prop_details* twr_window_menu_widget_list_props(const struct twr_window_widget* widget, long* length) {
    return twrWindowMenuWidgetListProps(widget->jsid, widget->widget_id, length);
 }
+
+
+struct twr_menu_prop_details* twr_window_menu_list_props(twr_ioconsole_t* window, long* length) {
+   return twrWindowMenuListProps(__twr_get_jsid(window), length);
+}
+
+
+struct twr_window_widget twr_window_menu_add_button_widget(const struct twr_window_widget* menu, long width, long height, const char* text) {
+   struct twr_widget_button_constructor button_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_BUTTON,
+         .width = width,
+         .height = height
+      },
+      .text = text
+   };
+
+   return twr_window_menu_add_widget(menu, &button_cons);
+}
+
+struct twr_window_widget twr_window_menu_add_seperator_widget(const struct twr_window_widget* menu, long width, long height, const char* seperator_text, const char* seperator_font) {
+   struct twr_widget_seperator_constructor seperator_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_SEPERATOR,
+         .height = height,
+         .width = width,
+      },
+      .seperator_text = seperator_text,
+      .seperator_font = seperator_font
+   };
+
+   return twr_window_menu_add_widget(menu, &seperator_cons);
+}
+
+struct twr_window_widget twr_window_menu_add_radio_item_widget(const struct twr_window_widget* menu, long width, long height, const char* text) {
+   struct twr_widget_radio_item_constructor radio_item_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_RADIO_ITEM,
+         .height = height,
+         .width = width,
+      },
+      .text = text
+   };
+
+   return twr_window_menu_add_widget(menu, &radio_item_cons);
+}
+
+struct twr_window_widget twr_window_menu_add_sub_menu_widget(const struct twr_window_widget* menu, long width, long height, const char* button_text, long minimum_menu_width, long minimum_menu_height, long minimum_child_height) {
+   struct twr_widget_sub_menu_constructor sub_menu_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_SUB_MENU,
+         .height = height,
+         .width = width
+      },
+      .button_text = button_text,
+      .minimum_menu_width = minimum_menu_width,
+      .minimum_menu_height = minimum_menu_height,
+      .minimum_child_height = minimum_child_height,
+   };
+
+   return twr_window_menu_add_widget(menu, &sub_menu_cons);
+}
+struct twr_window_widget twr_window_menu_add_sub_menu_widget_reduced(const struct twr_window_widget* menu, long width, long height, const char* button_text) {
+   return twr_window_menu_add_sub_menu_widget(menu, width, height, button_text, -1, -1, -1);
+}
+
+struct twr_window_widget twr_window_menu_add_check_box_widget(const struct twr_window_widget* menu, long width, long height, const char* text) {
+   struct twr_widget_check_box_constructor check_box_cons = {
+      .base = {
+         .type = WINDOW_WIDGET_CHECK_BOX,
+         .height = height,
+         .width = width,
+      },
+      .text = text,
+   };
+
+   return twr_window_menu_add_widget(menu, &check_box_cons);
+}
+

--- a/source/twr-c/twr-window.c
+++ b/source/twr-c/twr-window.c
@@ -8,9 +8,21 @@ twr_ioconsole_t* twr_window_get_app_canvas(twr_ioconsole_t* con) {
 
 struct twr_window_menu twr_window_add_menu(twr_ioconsole_t * con, const char* text) {
    int id = __twr_get_jsid(con);
-   
+   int menu_id = twrWindowAddMenu(id, text);
    return (struct twr_window_menu){
       .jsid = id,
-      .menu_id = twrWindowAddMenu(id, text)
+      .menu_id = menu_id,
    };
+}
+
+struct twr_window_widget twr_window_menu_add_widget(const struct twr_window_menu* menu, const struct twr_widget_constructor* widget) {
+   int widget_id = twrWindowMenuAddWidget(menu->jsid, menu->menu_id, widget);
+   return (struct twr_window_widget){
+      .jsid = menu->jsid,
+      .widget_id = widget_id
+   };
+}
+
+void twr_window_menu_button_add_callback(const struct twr_window_widget* widget, int event_id, void* extraPtr) {
+   twrWindowMenuButtonAddCallback(widget->jsid, widget->widget_id, event_id, extraPtr);
 }

--- a/source/twr-c/twr-window.c
+++ b/source/twr-c/twr-window.c
@@ -151,11 +151,11 @@ struct twr_menu_prop_details* twr_window_menu_list_props(twr_ioconsole_t* window
 }
 
 
-struct twr_window_widget twr_window_menu_add_button_widget(const struct twr_window_widget* menu, long width, long height, const char* text) {
+struct twr_window_widget twr_window_menu_add_button_widget(const struct twr_window_widget* menu, long height, const char* text) {
    struct twr_widget_button_constructor button_cons = {
       .base = {
          .type = WINDOW_WIDGET_BUTTON,
-         .width = width,
+         // .width = width,
          .height = height
       },
       .text = text
@@ -164,12 +164,12 @@ struct twr_window_widget twr_window_menu_add_button_widget(const struct twr_wind
    return twr_window_menu_add_widget(menu, &button_cons.base);
 }
 
-struct twr_window_widget twr_window_menu_add_seperator_widget(const struct twr_window_widget* menu, long width, long height, const char* seperator_text, const char* seperator_font) {
+struct twr_window_widget twr_window_menu_add_seperator_widget(const struct twr_window_widget* menu, long height, const char* seperator_text, const char* seperator_font) {
    struct twr_widget_seperator_constructor seperator_cons = {
       .base = {
          .type = WINDOW_WIDGET_SEPERATOR,
          .height = height,
-         .width = width,
+         // .width = width,
       },
       .seperator_text = seperator_text,
       .seperator_font = seperator_font
@@ -178,12 +178,12 @@ struct twr_window_widget twr_window_menu_add_seperator_widget(const struct twr_w
    return twr_window_menu_add_widget(menu, &seperator_cons.base);
 }
 
-struct twr_window_widget twr_window_menu_add_radio_item_widget(const struct twr_window_widget* menu, long width, long height, const char* text) {
+struct twr_window_widget twr_window_menu_add_radio_item_widget(const struct twr_window_widget* menu, long height, const char* text) {
    struct twr_widget_radio_item_constructor radio_item_cons = {
       .base = {
          .type = WINDOW_WIDGET_RADIO_ITEM,
          .height = height,
-         .width = width,
+         // .width = width,
       },
       .text = text
    };
@@ -191,12 +191,12 @@ struct twr_window_widget twr_window_menu_add_radio_item_widget(const struct twr_
    return twr_window_menu_add_widget(menu, &radio_item_cons.base);
 }
 
-struct twr_window_widget twr_window_menu_add_sub_menu_widget(const struct twr_window_widget* menu, long width, long height, const char* button_text, long minimum_menu_width, long minimum_menu_height) {
+struct twr_window_widget twr_window_menu_add_sub_menu_widget(const struct twr_window_widget* menu, long height, const char* button_text, long minimum_menu_width, long minimum_menu_height) {
    struct twr_widget_sub_menu_constructor sub_menu_cons = {
       .base = {
          .type = WINDOW_WIDGET_SUB_MENU,
          .height = height,
-         .width = width
+         // .width = width
       },
       .button_text = button_text,
       .minimum_menu_width = minimum_menu_width,
@@ -205,16 +205,16 @@ struct twr_window_widget twr_window_menu_add_sub_menu_widget(const struct twr_wi
 
    return twr_window_menu_add_widget(menu, &sub_menu_cons.base);
 }
-struct twr_window_widget twr_window_menu_add_sub_menu_widget_reduced(const struct twr_window_widget* menu, long width, long height, const char* button_text) {
-   return twr_window_menu_add_sub_menu_widget(menu, width, height, button_text, -1, -1);
+struct twr_window_widget twr_window_menu_add_sub_menu_widget_reduced(const struct twr_window_widget* menu, long height, const char* button_text) {
+   return twr_window_menu_add_sub_menu_widget(menu, height, button_text, -1, -1);
 }
 
-struct twr_window_widget twr_window_menu_add_check_box_widget(const struct twr_window_widget* menu, long width, long height, const char* text) {
+struct twr_window_widget twr_window_menu_add_check_box_widget(const struct twr_window_widget* menu, long height, const char* text) {
    struct twr_widget_check_box_constructor check_box_cons = {
       .base = {
          .type = WINDOW_WIDGET_CHECK_BOX,
          .height = height,
-         .width = width,
+         // .width = width,
       },
       .text = text,
    };

--- a/source/twr-c/twr-window.c
+++ b/source/twr-c/twr-window.c
@@ -34,3 +34,7 @@ void twr_window_menu_delete_widget(const struct twr_window_widget* widget) {
 void twr_window_menu_radio_menu_add_option(struct twr_window_widget* widget, const char* option) {
    twrWindowMenuRadioMenuAddOption(widget->jsid, widget->widget_id, option);
 }
+
+void twr_window_menu_widget_set_visibility(struct twr_window_widget* widget, int visibility) {
+   twrWindowMenuWidgetSetVisibility(widget->jsid, widget->widget_id, visibility);
+}

--- a/source/twr-c/twr-window.c
+++ b/source/twr-c/twr-window.c
@@ -23,10 +23,14 @@ struct twr_window_widget twr_window_menu_add_widget(const struct twr_window_menu
    };
 }
 
-void twr_window_menu_button_add_callback(const struct twr_window_widget* widget, int event_id, void* extraPtr) {
-   twrWindowMenuButtonAddCallback(widget->jsid, widget->widget_id, event_id, extraPtr);
+void twr_window_menu_widget_add_callback(const struct twr_window_widget* widget, int event_id, void* extraPtr) {
+   twrWindowMenuWidgetAddCallback(widget->jsid, widget->widget_id, event_id, extraPtr);
 }
 
 void twr_window_menu_delete_widget(const struct twr_window_widget* widget) {
    twrWindowMenuDeleteWidget(widget->jsid, widget->widget_id);
+}
+
+void twr_window_menu_radio_menu_add_option(struct twr_window_widget* widget, const char* option) {
+   twrWindowMenuRadioMenuAddOption(widget->jsid, widget->widget_id, option);
 }

--- a/source/twr-c/twr-window.h
+++ b/source/twr-c/twr-window.h
@@ -26,7 +26,8 @@ struct twr_window_widget {
 
 enum WindowWidget {
    WINDOW_WIDGET_BUTTON,
-   WINDOW_WIDGET_SEPERATOR
+   WINDOW_WIDGET_SEPERATOR,
+   WINDOW_WIDGET_RADIO_MENU,
 };
 
 
@@ -85,15 +86,46 @@ struct twr_widget_seperator_constructor {
    const char* seperator_color;
 };
 
+struct twr_widget_radio_menu_constructor {
+   /// @brief Base widget constructor
+   struct twr_widget_constructor base;
+   ///@brief defaults to 0
+   long minimum_width;
+   /// @brief defaults to 0
+   long minimum_height;
+   /// @brief defaults to 0
+   long y_padding;
+   /// @brief defaults to gray
+   const char* menu_color;
+   /**
+    * Color options change to when hovered over
+    * defaults to light gray
+    */
+   const char* hovered_background_color;
+   /**
+    * Symbol used to denote that the option is selected
+    * defaults to *
+    */
+   const char* selected_symbol;
+   /// @brief default to 20
+   long option_height;
+   /// @brief defaults to 16px Seriph
+   const char* option_text_font;
+   /// @brief defaults to black
+   const char* option_text_color;
+};
+
 __attribute__((import_name("twrWindowMenuAddWidget"))) int twrWindowMenuAddWidget(int jsid, int menu_id, const struct twr_widget_constructor* widget);
 struct twr_window_widget twr_window_menu_add_widget(const struct twr_window_menu* menu, const struct twr_widget_constructor* widget);
 
-__attribute__((import_name("twrWindowMenuButtonAddCallback"))) void twrWindowMenuButtonAddCallback(int jsid, int widget_id, int event_id, void* extraPtr);
-void twr_window_menu_button_add_callback(const struct twr_window_widget* widget, int event_id, void* extraPtr);
+__attribute__((import_name("twrWindowMenuWidgetAddCallback"))) void twrWindowMenuWidgetAddCallback(int jsid, int widget_id, int event_id, void* extraPtr);
+void twr_window_menu_widget_add_callback(const struct twr_window_widget* widget, int event_id, void* extraPtr);
 
 __attribute__((import_name("twrWindowMenuDeleteWidget"))) void twrWindowMenuDeleteWidget(int jsid, int widget_id);
 void twr_window_menu_delete_widget(const struct twr_window_widget* widget);
 
+__attribute__((import_name("twrWindowMenuRadioMenuAddOption"))) void twrWindowMenuRadioMenuAddOption(int jsid, int widget_id, const char* option);
+void twr_window_menu_radio_menu_add_option(struct twr_window_widget* widget, const char* option);
 #ifdef __cplusplus
 }
 #endif

--- a/source/twr-c/twr-window.h
+++ b/source/twr-c/twr-window.h
@@ -260,6 +260,24 @@ __attribute__((import_name("twrWindowMenuListProps"))) struct twr_menu_prop_deta
  */
 struct twr_menu_prop_details* twr_window_menu_list_props(twr_ioconsole_t* window, long* length);
 
+__attribute__((import_name("twrWindowMenuGetProp"))) struct twr_widget_prop_value* twrWindowMenuGetProp(int jsid, const char* prop_name);
+struct twr_widget_prop_value* twr_window_menu_get_prop(twr_ioconsole_t* window, const char* prop_name);
+int twr_window_menu_get_prop_boolean(twr_ioconsole_t* window, const char* prop_name, int* ret_bool);
+int twr_window_menu_get_prop_boolean_or_default(twr_ioconsole_t* window, const char* prop_name, int def);
+int twr_window_menu_get_prop_number(twr_ioconsole_t* window, const char* prop_name, double* ret_number);
+double twr_window_menu_get_prop_number_or_default(twr_ioconsole_t* window, const char* prop_name, double def);
+int twr_window_menu_get_prop_string(twr_ioconsole_t* window, const char* prop_name, char** ret_str);
+char* twr_window_menu_get_prop_string_or_default(twr_ioconsole_t* window, const char* prop_name);
+
+__attribute__((import_name("twrWindowMenuSetProp"))) void twrWindowMenuSetProp(int jsid, const char* prop_name, struct twr_widget_prop_value* val);
+void twr_window_menu_set_prop(twr_ioconsole_t* window, const char* prop_name, struct twr_widget_prop_value* val);
+void twr_window_menu_set_prop_boolean(twr_ioconsole_t* window, const char* prop_name, int val);
+void twr_window_menu_set_prop_number(twr_ioconsole_t* window, const char* prop_name, double val);
+void twr_window_menu_set_prop_string(twr_ioconsole_t* window, const char* prop_name, const char* val);
+
+
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/twr-c/twr-window.h
+++ b/source/twr-c/twr-window.h
@@ -114,16 +114,6 @@ struct twr_widget_check_box_constructor {
     * defaults to Lorem Ipsum
     */
    const char* text;
-   /**
-    * Text prefix used to indicate that the check box is clicked
-    * defaults to *
-    */
-   const char* checked_symbol;
-   /**
-    * text prefix used to indicate that the check box is not clicked
-    * defaults to ""
-    */
-   const char* unchecked_symbol;
 };
 
 
@@ -155,8 +145,8 @@ struct twr_widget_prop_value {
    enum WindowWidgetPropVal type;
 };
 enum WindowWidgetPropAccess {
-   WINDOW_WIDGET_PROP_GETONLY = 1,
-   WINDOW_WIDGET_PROP_SETONLY = 2,
+   WINDOW_WIDGET_PROP_GET = 1,
+   WINDOW_WIDGET_PROP_SET = 2,
    WINDOW_WIDGET_PROP_GETANDSET = 3,
 };
 struct twr_widget_prop_details {
@@ -186,6 +176,12 @@ int twr_window_menu_widget_get_prop_number(const struct twr_window_widget* widge
 /// @brief if type is not number, returns default value
 double twr_window_menu_widget_get_prop_number_or_default(const struct twr_window_widget* widget, const char* prop_name, double default_val);
 
+__attribute__((import_name("twrWindowMenuWidgetGetPropDetails"))) void twrWindowMenuWidgetGetPropDetails(int jsid, int widget_id, struct twr_widget_prop_details* details);
+/**
+ * Given a details struct with the name filled out,
+ * this function will fill in the type and access fields of the struct
+ */
+void twr_window_menu_widget_fill_in_details(const struct twr_window_widget* widget, struct twr_widget_prop_details* details);
 __attribute__((import_name("twrWindowMenuWidgetListProps"))) struct twr_widget_prop_details* twrWindowMenuWidgetListProps(int jsid, int widget_id, long* length);
 /**
  * Returns an array of twr_widget_prop_details representing the name, access, and types of each property

--- a/source/twr-c/twr-window.h
+++ b/source/twr-c/twr-window.h
@@ -127,8 +127,6 @@ struct twr_widget_sub_menu_constructor {
    long minimum_menu_width;
    /// @brief defaults to 10
    long minimum_menu_height;
-   /// @brief defaults to 10
-   long minimum_child_height;
 };
 /**
  * @brief Adds a sub menu button with the given properties to the given menu
@@ -138,10 +136,9 @@ struct twr_widget_sub_menu_constructor {
  * @param button_text: Text displayed on the button used to open the sub menu
  * @param minimum_menu_width: The minimum width of the menu when it's opened
  * @param minimum_menu_height: The minimum height of the menu when it's opened
- * @param minimum_child_height: The minimum height of the menu's child widgets
  * @retval Struct identifying the widget and it's linked window
  */
-struct twr_window_widget twr_window_menu_add_sub_menu_widget(const struct twr_window_widget* menu, long width, long height, const char* button_text, long minimum_menu_width, long minimum_menu_height, long minimum_child_height);
+struct twr_window_widget twr_window_menu_add_sub_menu_widget(const struct twr_window_widget* menu, long width, long height, const char* button_text, long minimum_menu_width, long minimum_menu_height);
 /**
  * @brief Adds a sub menu button with the given properties to the given menu
  * @param menu: The menu widget this sub menu should be added to

--- a/source/twr-c/twr-window.h
+++ b/source/twr-c/twr-window.h
@@ -11,6 +11,15 @@ __attribute__((import_name("twrGetAppCanvasJSID"))) int twrGetAppCanvasJSID(int 
 
 twr_ioconsole_t* twr_window_get_app_canvas(twr_ioconsole_t * con);
 
+__attribute__((import_name("twrWindowAddMenu"))) int twrWindowAddMenu(int jsid, const char* text);
+
+struct twr_window_menu {
+   int jsid;
+   int menu_id;
+};
+
+struct twr_window_menu twr_window_add_menu(twr_ioconsole_t * con, const char* text);
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/twr-c/twr-window.h
+++ b/source/twr-c/twr-window.h
@@ -18,8 +18,78 @@ struct twr_window_menu {
    int menu_id;
 };
 
+struct twr_window_widget {
+   int jsid;
+   int widget_id;
+};
+
+
+enum WindowWidget {
+   WINDOW_WIDGET_BUTTON,
+   WINDOW_WIDGET_SEPERATOR
+};
+
 
 struct twr_window_menu twr_window_add_menu(twr_ioconsole_t * con, const char* text);
+
+
+/**
+ * Base widget constructor for all widgets.
+ * Any Null or Negative values will be set to their defaults
+ */
+struct twr_widget_constructor {
+   /// @brief must be set and matched to the correct widget
+   enum WindowWidget type;
+   /// @brief Defaults to 0
+   long x;
+   /// @brief Defaults to 0
+   long y;
+   /// @brief Default depends on widget
+   long width;
+   /// @brief Default depends on widget
+   long height;
+};
+
+/** 
+ * Constructor for a button widget: Displays a button that can be clicked on for events.
+ * Event callbacks are added after construction
+ * Any Null or Negative values will be set to their defaults
+ */
+struct twr_widget_button_constructor {
+   /// @brief Base widget constructor
+   struct twr_widget_constructor base;
+   /// @brief defaults to "Lorem Ipsum"
+   const char* text;
+   /// @brief defaults to 16px Seriph
+   const char* text_font;
+   /// @brief defaults to Black
+   const char* text_color;
+   /// @brief defaults to #B0B0B0
+   const char* button_color;
+   /// @brief defaults to #D0D0D0
+   const char* selected_button_color;
+};
+
+/** 
+ * Constructor for a seperator widget: Displays a repeating segment of text to seperate sections
+ * Any Null or Negative values will be set to their defaults
+ */
+struct twr_widget_seperator_constructor {
+   /// @brief Base widget constructor
+   struct twr_widget_constructor base;
+   /// @brief defaults to "-"
+   const char* seperator_text;
+   /// @brief defaults to 16px Seriph
+   const char* seperator_font;
+   /// @brief defaults to black
+   const char* seperator_color;
+};
+
+__attribute__((import_name("twrWindowMenuAddWidget"))) int twrWindowMenuAddWidget(int jsid, int menu_id, const struct twr_widget_constructor* widget);
+struct twr_window_widget twr_window_menu_add_widget(const struct twr_window_menu* menu, const struct twr_widget_constructor* widget);
+
+__attribute__((import_name("twrWindowMenuButtonAddCallback"))) void twrWindowMenuButtonAddCallback(int jsid, int widget_id, int event_id, void* extraPtr);
+void twr_window_menu_button_add_callback(const struct twr_window_widget* widget, int event_id, void* extraPtr);
 
 #ifdef __cplusplus
 }

--- a/source/twr-c/twr-window.h
+++ b/source/twr-c/twr-window.h
@@ -13,10 +13,6 @@ twr_ioconsole_t* twr_window_get_app_canvas(twr_ioconsole_t * con);
 
 __attribute__((import_name("twrWindowAddMenu"))) int twrWindowAddMenu(int jsid, const char* text);
 
-struct twr_window_menu {
-   int jsid;
-   int menu_id;
-};
 
 struct twr_window_widget {
    int jsid;
@@ -28,10 +24,12 @@ enum WindowWidget {
    WINDOW_WIDGET_BUTTON,
    WINDOW_WIDGET_SEPERATOR,
    WINDOW_WIDGET_RADIO_MENU,
+   WINDOW_WIDGET_SUB_MENU,
+   WINDOW_WIDGET_CHECK_BOX,
 };
 
 
-struct twr_window_menu twr_window_add_menu(twr_ioconsole_t * con, const char* text);
+struct twr_window_widget twr_window_add_menu(twr_ioconsole_t * con, const char* text);
 
 
 /**
@@ -41,10 +39,6 @@ struct twr_window_menu twr_window_add_menu(twr_ioconsole_t * con, const char* te
 struct twr_widget_constructor {
    /// @brief must be set and matched to the correct widget
    enum WindowWidget type;
-   /// @brief Defaults to 0
-   long x;
-   /// @brief Defaults to 0
-   long y;
    /// @brief Default depends on widget
    long width;
    /// @brief Default depends on widget
@@ -86,6 +80,10 @@ struct twr_widget_seperator_constructor {
    const char* seperator_color;
 };
 
+/** 
+ * Constructor for a radio menu widget: Displays a list of mutually exclusive options that you can select from
+ * Any Null or Negative values will be set to their defaults
+ */
 struct twr_widget_radio_menu_constructor {
    /// @brief Base widget constructor
    struct twr_widget_constructor base;
@@ -107,6 +105,11 @@ struct twr_widget_radio_menu_constructor {
     * defaults to *
     */
    const char* selected_symbol;
+   /**
+    * Amount of space before option text reserved for the select symbol
+    * defaults to width of (selected_symbol + "  ")
+    */
+   long reserved_prefix_length;
    /// @brief default to 20
    long option_height;
    /// @brief defaults to 16px Seriph
@@ -115,8 +118,85 @@ struct twr_widget_radio_menu_constructor {
    const char* option_text_color;
 };
 
+/** 
+ * Constructor for a sub-menu widget: Holds a list of widgets
+ * Any Null or Negative values will be set to their defaults
+ */
+struct twr_widget_sub_menu_constructor {
+   /// @brief Base widget constructor
+   struct twr_widget_constructor base;
+   /**
+    * Text for the button that opens this menu
+    * defaults to Lorem Ipsum
+    */
+   const char* button_text;
+   /// @brief defaults to 16px Seriph
+   const char* button_text_font;
+   /// @brief defaults to "black"
+   const char* button_text_color;
+   /// @brief defaults to #B0B0B0
+   const char* button_color;
+   /// @brief defaults to #D0D0D0
+   const char* selected_button_color;
+
+   /// @brief defaults to 10
+   long minimum_menu_width;
+   /// @brief defaults to 10
+   long minimum_menu_height;
+   /// @brief defaults to #B0B0B0
+   const char* menu_color;
+   /// @brief defaults to 5
+   long menu_y_padding;
+   /// @brief defaults to 10
+   long min_child_height;
+   /// @brief defaults to black
+   const char* menu_border_color;
+   /// @brief defaults to 0
+   long menu_border_width;
+   ///@brief defaults to 0
+   long menu_open_offset;
+};
+
+/** 
+ * Constructor for a check box widget: Button with a checkbox that has an event for when it's state changes
+ * Any Null or Negative values will be set to their defaults
+ */
+struct twr_widget_check_box_constructor {
+   /// @brief Base widget constructor
+   struct twr_widget_constructor base;
+   /**
+    * Text for the check box
+    * defaults to Lorem Ipsum
+    */
+   const char* text;
+   /**
+    * Text prefix used to indicate that the check box is clicked
+    * defaults to *
+    */
+   const char* checked_symbol;
+   /**
+    * text prefix used to indicate that the check box is not clicked
+    * defaults to ""
+    */
+   const char* unchecked_symbol;
+   /**
+    * amount of space to reserve for the checked and unchecked symbol prefixes
+    * defaults to max(width(checked_symbol),width(unchecked_symbol)) + width(" ") * 2
+    */
+   long reserved_prefix_space;
+   /// @brief defaults to "16px Seriph"
+   const char* text_font;
+   /// @brief defaults to "Black"
+   const char* text_color;
+   /// @brief defaults to #B0B0B0
+   const char* button_color;
+   /// @brief defaults to #D0D0D0
+   const char* selected_button_color;
+};
+
+
 __attribute__((import_name("twrWindowMenuAddWidget"))) int twrWindowMenuAddWidget(int jsid, int menu_id, const struct twr_widget_constructor* widget);
-struct twr_window_widget twr_window_menu_add_widget(const struct twr_window_menu* menu, const struct twr_widget_constructor* widget);
+struct twr_window_widget twr_window_menu_add_widget(const struct twr_window_widget* menu, const struct twr_widget_constructor* widget);
 
 __attribute__((import_name("twrWindowMenuWidgetAddCallback"))) void twrWindowMenuWidgetAddCallback(int jsid, int widget_id, int event_id, void* extraPtr);
 void twr_window_menu_widget_add_callback(const struct twr_window_widget* widget, int event_id, void* extraPtr);

--- a/source/twr-c/twr-window.h
+++ b/source/twr-c/twr-window.h
@@ -222,8 +222,44 @@ void twr_window_menu_delete_widget(const struct twr_window_widget* widget);
 __attribute__((import_name("twrWindowMenuRadioItemMerge"))) void twrWindowMenuRadioItemMerge(int jsid, int widget_id1, int widget_id2);
 void twr_window_menu_radio_item_merge(const struct twr_window_widget* widget1, const struct twr_window_widget* widget2);
 
-__attribute__((import_name("twrWindowMenuWidgetSetVisibility"))) void twrWindowMenuWidgetSetVisibility(int jsid, int widget_id, int visibility);
-void twr_window_menu_widget_set_visibility(struct twr_window_widget* widget, int visibility);
+// __attribute__((import_name("twrWindowMenuWidgetSetVisibility"))) void twrWindowMenuWidgetSetVisibility(int jsid, int widget_id, int visibility);
+// void twr_window_menu_widget_set_visibility(struct twr_window_widget* widget, int visibility);
+
+enum WindowWidgetPropVal {
+   WINDOW_WIDGET_PROP_STRING = 1,
+   WINDOW_WIDGET_PROP_BOOLEAN = 2,
+   WINDOW_WIDGET_PROP_NUMBER = 4,
+   WINDOW_WIDGET_PROP_UNDEFINED = 8,
+};
+struct twr_widget_prop_value {
+   union {
+      const char* string;
+      double number;
+      int boolean;
+   };
+   enum WindowWidgetPropVal type;
+};
+__attribute__((import_name("twrWindowMenuWidgetSetProp"))) void twrWindowMenuWidgetSetProp(int jsid, int widget_id, const char* prop_name, const struct twr_widget_prop_value* data);
+void twr_window_menu_widget_set_string(const struct twr_window_widget* widget, const char* prop_name, const char* val);
+void twr_window_menu_widget_set_bool(const struct twr_window_widget* widget, const char* prop_name, int val);
+void twr_window_menu_widget_set_number(const struct twr_window_widget* widget, const char* prop_name, double val);
+void twr_window_menu_widget_set_undefined(const struct twr_window_widget* widget, const char* prop_name);
+
+__attribute__((import_name("twrWindowMenuWidgetGetProp"))) struct twr_widget_prop_value* twrWindowMenuWidgetGetProp(int jsid, int widget_id, const char* prop_name);
+struct twr_widget_prop_value* twr_window_menu_widget_get_prop(const struct twr_window_widget* widget, const char* prop_name);
+/// @brief if type is undefined defaults to null ptr, otherwise success if false
+char* twr_window_menu_widget_get_prop_string(const struct twr_window_widget* widget, const char* prop_name, int* success);
+/// @brief if type is not string, returns null string
+char* twr_window_menu_widget_get_prop_string_or_null(const struct twr_window_widget* widget, const char* prop_name);
+/// @brief if type is not boolean, success is false
+int twr_window_menu_widget_get_prop_boolean(const struct twr_window_widget* widget, const char* prop_name, int* success);
+/// @brief if type is not boolean, returns default value
+int twr_window_menu_widget_get_prop_boolean_or_default(const struct twr_window_widget* widget, const char* prop_name, int default_val);
+/// @brief if type is not number, success is false
+double twr_window_menu_widget_get_prop_number(const struct twr_window_widget* widget, const char* prop_name, int* success);
+/// @brief if type is not number, returns default value
+double twr_window_menu_widget_get_prop_number_or_default(const struct twr_window_widget* widget, const char* prop_name, double default_val);
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/twr-c/twr-window.h
+++ b/source/twr-c/twr-window.h
@@ -56,13 +56,13 @@ struct twr_widget_button_constructor {
    /// @brief defaults to "Lorem Ipsum"
    const char* text;
    /// @brief defaults to 16px Seriph
-   const char* text_font;
+   // const char* text_font;
    /// @brief defaults to Black
-   const char* text_color;
+   // const char* text_color;
    /// @brief defaults to #B0B0B0
-   const char* button_color;
+   // const char* button_color;
    /// @brief defaults to #D0D0D0
-   const char* selected_button_color;
+   // const char* selected_button_color;
 };
 
 /** 
@@ -77,7 +77,7 @@ struct twr_widget_seperator_constructor {
    /// @brief defaults to 16px Seriph
    const char* seperator_font;
    /// @brief defaults to black
-   const char* seperator_color;
+   // const char* seperator_color;
 };
 
 /** 
@@ -92,14 +92,14 @@ struct twr_widget_radio_menu_constructor {
    /// @brief defaults to 0
    long minimum_height;
    /// @brief defaults to 0
-   long y_padding;
+   // long y_padding;
    /// @brief defaults to gray
-   const char* menu_color;
+   // const char* menu_color;
    /**
     * Color options change to when hovered over
     * defaults to light gray
     */
-   const char* hovered_background_color;
+   // const char* hovered_background_color;
    /**
     * Symbol used to denote that the option is selected
     * defaults to *
@@ -109,13 +109,13 @@ struct twr_widget_radio_menu_constructor {
     * Amount of space before option text reserved for the select symbol
     * defaults to width of (selected_symbol + "  ")
     */
-   long reserved_prefix_length;
+   // long reserved_prefix_length;
    /// @brief default to 20
    long option_height;
    /// @brief defaults to 16px Seriph
-   const char* option_text_font;
+   // const char* option_text_font;
    /// @brief defaults to black
-   const char* option_text_color;
+   // const char* option_text_color;
 };
 
 /** 
@@ -131,30 +131,30 @@ struct twr_widget_sub_menu_constructor {
     */
    const char* button_text;
    /// @brief defaults to 16px Seriph
-   const char* button_text_font;
+   // const char* button_text_font;
    /// @brief defaults to "black"
-   const char* button_text_color;
+   // const char* button_text_color;
    /// @brief defaults to #B0B0B0
-   const char* button_color;
+   // const char* button_color;
    /// @brief defaults to #D0D0D0
-   const char* selected_button_color;
+   // const char* selected_button_color;
 
    /// @brief defaults to 10
    long minimum_menu_width;
    /// @brief defaults to 10
    long minimum_menu_height;
    /// @brief defaults to #B0B0B0
-   const char* menu_color;
+   // const char* menu_color;
    /// @brief defaults to 5
-   long menu_y_padding;
+   // long menu_y_padding;
    /// @brief defaults to 10
    long min_child_height;
    /// @brief defaults to black
-   const char* menu_border_color;
+   // const char* menu_border_color;
    /// @brief defaults to 0
-   long menu_border_width;
+   // long menu_border_width;
    ///@brief defaults to 0
-   long menu_open_offset;
+   // long menu_open_offset;
 };
 
 /** 
@@ -183,15 +183,15 @@ struct twr_widget_check_box_constructor {
     * amount of space to reserve for the checked and unchecked symbol prefixes
     * defaults to max(width(checked_symbol),width(unchecked_symbol)) + width(" ") * 2
     */
-   long reserved_prefix_space;
+   // long reserved_prefix_space;
    /// @brief defaults to "16px Seriph"
-   const char* text_font;
+   // const char* text_font;
    /// @brief defaults to "Black"
-   const char* text_color;
+   // const char* text_color;
    /// @brief defaults to #B0B0B0
-   const char* button_color;
+   // const char* button_color;
    /// @brief defaults to #D0D0D0
-   const char* selected_button_color;
+   // const char* selected_button_color;
 };
 
 

--- a/source/twr-c/twr-window.h
+++ b/source/twr-c/twr-window.h
@@ -206,6 +206,9 @@ void twr_window_menu_delete_widget(const struct twr_window_widget* widget);
 
 __attribute__((import_name("twrWindowMenuRadioMenuAddOption"))) void twrWindowMenuRadioMenuAddOption(int jsid, int widget_id, const char* option);
 void twr_window_menu_radio_menu_add_option(struct twr_window_widget* widget, const char* option);
+
+__attribute__((import_name("twrWindowMenuWidgetSetVisibility"))) void twrWindowMenuWidgetSetVisibility(int jsid, int widget_id, int visibility);
+void twr_window_menu_widget_set_visibility(struct twr_window_widget* widget, int visibility);
 #ifdef __cplusplus
 }
 #endif

--- a/source/twr-c/twr-window.h
+++ b/source/twr-c/twr-window.h
@@ -91,6 +91,9 @@ struct twr_window_widget twr_window_menu_add_widget(const struct twr_window_menu
 __attribute__((import_name("twrWindowMenuButtonAddCallback"))) void twrWindowMenuButtonAddCallback(int jsid, int widget_id, int event_id, void* extraPtr);
 void twr_window_menu_button_add_callback(const struct twr_window_widget* widget, int event_id, void* extraPtr);
 
+__attribute__((import_name("twrWindowMenuDeleteWidget"))) void twrWindowMenuDeleteWidget(int jsid, int widget_id);
+void twr_window_menu_delete_widget(const struct twr_window_widget* widget);
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/twr-c/twr-window.h
+++ b/source/twr-c/twr-window.h
@@ -136,14 +136,9 @@ void twr_window_menu_widget_add_callback(const struct twr_window_widget* widget,
 __attribute__((import_name("twrWindowMenuDeleteWidget"))) void twrWindowMenuDeleteWidget(int jsid, int widget_id);
 void twr_window_menu_delete_widget(const struct twr_window_widget* widget);
 
-// __attribute__((import_name("twrWindowMenuRadioMenuAddOption"))) void twrWindowMenuRadioMenuAddOption(int jsid, int widget_id, const char* option);
-// void twr_window_menu_radio_menu_add_option(struct twr_window_widget* widget, const char* option);
-
 __attribute__((import_name("twrWindowMenuRadioItemMerge"))) void twrWindowMenuRadioItemMerge(int jsid, int widget_id1, int widget_id2);
 void twr_window_menu_radio_item_merge(const struct twr_window_widget* widget1, const struct twr_window_widget* widget2);
 
-// __attribute__((import_name("twrWindowMenuWidgetSetVisibility"))) void twrWindowMenuWidgetSetVisibility(int jsid, int widget_id, int visibility);
-// void twr_window_menu_widget_set_visibility(struct twr_window_widget* widget, int visibility);
 
 enum WindowWidgetPropVal {
    WINDOW_WIDGET_PROP_STRING = 1,
@@ -158,6 +153,16 @@ struct twr_widget_prop_value {
       int boolean;
    };
    enum WindowWidgetPropVal type;
+};
+enum WindowWidgetPropAccess {
+   WINDOW_WIDGET_PROP_GETONLY = 1,
+   WINDOW_WIDGET_PROP_SETONLY = 2,
+   WINDOW_WIDGET_PROP_GETANDSET = 3,
+};
+struct twr_widget_prop_details {
+   const char* name;
+   enum WindowWidgetPropVal type;
+   enum WindowWidgetPropAccess access;
 };
 __attribute__((import_name("twrWindowMenuWidgetSetProp"))) void twrWindowMenuWidgetSetProp(int jsid, int widget_id, const char* prop_name, const struct twr_widget_prop_value* data);
 void twr_window_menu_widget_set_string(const struct twr_window_widget* widget, const char* prop_name, const char* val);
@@ -181,7 +186,12 @@ int twr_window_menu_widget_get_prop_number(const struct twr_window_widget* widge
 /// @brief if type is not number, returns default value
 double twr_window_menu_widget_get_prop_number_or_default(const struct twr_window_widget* widget, const char* prop_name, double default_val);
 
-
+__attribute__((import_name("twrWindowMenuWidgetListProps"))) struct twr_widget_prop_details* twrWindowMenuWidgetListProps(int jsid, int widget_id, long* length);
+/**
+ * Returns an array of twr_widget_prop_details representing the name, access, and types of each property
+ * The array of structs and the strings representing their names are made in one large allocation
+ */
+struct twr_widget_prop_details* twr_window_menu_widget_list_props(const struct twr_window_widget* widget, long* length);
 #ifdef __cplusplus
 }
 #endif

--- a/source/twr-c/twr-window.h
+++ b/source/twr-c/twr-window.h
@@ -23,7 +23,8 @@ struct twr_window_widget {
 enum WindowWidget {
    WINDOW_WIDGET_BUTTON,
    WINDOW_WIDGET_SEPERATOR,
-   WINDOW_WIDGET_RADIO_MENU,
+   // WINDOW_WIDGET_RADIO_MENU,
+   WINDOW_WIDGET_RADIO_ITEM,
    WINDOW_WIDGET_SUB_MENU,
    WINDOW_WIDGET_CHECK_BOX,
 };
@@ -80,42 +81,53 @@ struct twr_widget_seperator_constructor {
    // const char* seperator_color;
 };
 
+// /** 
+//  * Constructor for a radio menu widget: Displays a list of mutually exclusive options that you can select from
+//  * Any Null or Negative values will be set to their defaults
+//  */
+// struct twr_widget_radio_menu_constructor {
+//    /// @brief Base widget constructor
+//    struct twr_widget_constructor base;
+//    ///@brief defaults to 0
+//    long minimum_width;
+//    /// @brief defaults to 0
+//    long minimum_height;
+//    /// @brief defaults to 0
+//    // long y_padding;
+//    /// @brief defaults to gray
+//    // const char* menu_color;
+//    /**
+//     * Color options change to when hovered over
+//     * defaults to light gray
+//     */
+//    // const char* hovered_background_color;
+//    /**
+//     * Symbol used to denote that the option is selected
+//     * defaults to *
+//     */
+//    const char* selected_symbol;
+//    /**
+//     * Amount of space before option text reserved for the select symbol
+//     * defaults to width of (selected_symbol + "  ")
+//     */
+//    // long reserved_prefix_length;
+//    /// @brief default to 20
+//    long option_height;
+//    /// @brief defaults to 16px Seriph
+//    // const char* option_text_font;
+//    /// @brief defaults to black
+//    // const char* option_text_color;
+// };
+
 /** 
- * Constructor for a radio menu widget: Displays a list of mutually exclusive options that you can select from
+ * Constructor for a radio item widget: Items are linked together to have mutually exclusive options
  * Any Null or Negative values will be set to their defaults
  */
-struct twr_widget_radio_menu_constructor {
+struct twr_widget_radio_item_constructor {
    /// @brief Base widget constructor
    struct twr_widget_constructor base;
-   ///@brief defaults to 0
-   long minimum_width;
-   /// @brief defaults to 0
-   long minimum_height;
-   /// @brief defaults to 0
-   // long y_padding;
-   /// @brief defaults to gray
-   // const char* menu_color;
-   /**
-    * Color options change to when hovered over
-    * defaults to light gray
-    */
-   // const char* hovered_background_color;
-   /**
-    * Symbol used to denote that the option is selected
-    * defaults to *
-    */
-   const char* selected_symbol;
-   /**
-    * Amount of space before option text reserved for the select symbol
-    * defaults to width of (selected_symbol + "  ")
-    */
-   // long reserved_prefix_length;
-   /// @brief default to 20
-   long option_height;
-   /// @brief defaults to 16px Seriph
-   // const char* option_text_font;
-   /// @brief defaults to black
-   // const char* option_text_color;
+   /// @brief defaults to "Lorem Ipsum"
+   const char* text;
 };
 
 /** 
@@ -204,8 +216,11 @@ void twr_window_menu_widget_add_callback(const struct twr_window_widget* widget,
 __attribute__((import_name("twrWindowMenuDeleteWidget"))) void twrWindowMenuDeleteWidget(int jsid, int widget_id);
 void twr_window_menu_delete_widget(const struct twr_window_widget* widget);
 
-__attribute__((import_name("twrWindowMenuRadioMenuAddOption"))) void twrWindowMenuRadioMenuAddOption(int jsid, int widget_id, const char* option);
-void twr_window_menu_radio_menu_add_option(struct twr_window_widget* widget, const char* option);
+// __attribute__((import_name("twrWindowMenuRadioMenuAddOption"))) void twrWindowMenuRadioMenuAddOption(int jsid, int widget_id, const char* option);
+// void twr_window_menu_radio_menu_add_option(struct twr_window_widget* widget, const char* option);
+
+__attribute__((import_name("twrWindowMenuRadioItemMerge"))) void twrWindowMenuRadioItemMerge(int jsid, int widget_id1, int widget_id2);
+void twr_window_menu_radio_item_merge(const struct twr_window_widget* widget1, const struct twr_window_widget* widget2);
 
 __attribute__((import_name("twrWindowMenuWidgetSetVisibility"))) void twrWindowMenuWidgetSetVisibility(int jsid, int widget_id, int visibility);
 void twr_window_menu_widget_set_visibility(struct twr_window_widget* widget, int visibility);

--- a/source/twr-c/twr-window.h
+++ b/source/twr-c/twr-window.h
@@ -1,0 +1,18 @@
+#ifndef __TWR_WINDOW_H__
+#define __TWR_WINDOW_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "twr-io.h"
+
+__attribute__((import_name("twrGetAppCanvasJSID"))) int twrGetAppCanvasJSID(int jsid);
+
+twr_ioconsole_t* twr_window_get_app_canvas(twr_ioconsole_t * con);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/source/twr-c/twr-window.h
+++ b/source/twr-c/twr-window.h
@@ -41,8 +41,8 @@ struct twr_window_widget twr_window_add_menu(twr_ioconsole_t * con, const char* 
 struct twr_widget_constructor {
    /// @brief must be set and matched to the correct widget
    enum WindowWidget type;
-   /// @brief Default depends on widget
-   long width;
+   // / @brief Default depends on widget
+   // long width;
    /// @brief Default depends on widget
    long height;
 };
@@ -62,12 +62,11 @@ struct twr_widget_button_constructor {
 /**
  * @brief Adds a button with the given properties to the given menu
  * @param menu: The menu widget this button should be added to
- * @param width: Width of widget, -1 sets it to default (might be adjusted automatically by menu)
  * @param height: Height of widget, -1 sets it to default (might be adjusted automatically by menu)
  * @param text: Text displayed on button
  * @retval Struct identifying the widget and it's linked window
  */
-struct twr_window_widget twr_window_menu_add_button_widget(const struct twr_window_widget* menu, long width, long height, const char* text);
+struct twr_window_widget twr_window_menu_add_button_widget(const struct twr_window_widget* menu, long height, const char* text);
 
 /** 
  * Constructor for a seperator widget: Displays a repeating segment of text to seperate sections
@@ -84,13 +83,12 @@ struct twr_widget_seperator_constructor {
 /**
  * @brief Adds a seperator with the given properties to the given menu
  * @param menu: The menu widget this seperator should be added to
- * @param width: Width of widget, -1 sets it to default (might be adjusted automatically by menu)
  * @param height: Height of widget, -1 sets it to default (might be adjusted automatically by menu)
  * @param seperator_text: Text seperator uses, for instance "-" would fill the width with "-------"
  * @param seperator_font: Font that should be used with the seperator text
  * @retval Struct identifying the widget and it's linked window
  */
-struct twr_window_widget twr_window_menu_add_seperator_widget(const struct twr_window_widget* menu, long width, long height, const char* seperator_text, const char* seperator_font);
+struct twr_window_widget twr_window_menu_add_seperator_widget(const struct twr_window_widget* menu, long height, const char* seperator_text, const char* seperator_font);
 
 /** 
  * Constructor for a radio item widget: Items are linked together to have mutually exclusive options
@@ -105,12 +103,11 @@ struct twr_widget_radio_item_constructor {
 /**
  * @brief Adds a radio item with the given properties to the given menu
  * @param menu: The menu widget this radio item should be added to
- * @param width: Width of widget, -1 sets it to default (might be adjusted automatically by menu)
  * @param height: Height of widget, -1 sets it to default (might be adjusted automatically by menu)
  * @param text: Text displayed on the radio item
  * @retval Struct identifying the widget and it's linked window
  */
-struct twr_window_widget twr_window_menu_add_radio_item_widget(const struct twr_window_widget* menu, long width, long height, const char* text);
+struct twr_window_widget twr_window_menu_add_radio_item_widget(const struct twr_window_widget* menu, long height, const char* text);
 
 /** 
  * Constructor for a sub-menu widget: Holds a list of widgets
@@ -132,23 +129,21 @@ struct twr_widget_sub_menu_constructor {
 /**
  * @brief Adds a sub menu button with the given properties to the given menu
  * @param menu: The menu widget this sub menu should be added to
- * @param width: Width of menu button, -1 sets it to default (might be adjusted automatically by menu)
  * @param height: Height of menu button, -1 sets it to default (might be adjusted automatically by menu)
  * @param button_text: Text displayed on the button used to open the sub menu
  * @param minimum_menu_width: The minimum width of the menu when it's opened
  * @param minimum_menu_height: The minimum height of the menu when it's opened
  * @retval Struct identifying the widget and it's linked window
  */
-struct twr_window_widget twr_window_menu_add_sub_menu_widget(const struct twr_window_widget* menu, long width, long height, const char* button_text, long minimum_menu_width, long minimum_menu_height);
+struct twr_window_widget twr_window_menu_add_sub_menu_widget(const struct twr_window_widget* menu, long height, const char* button_text, long minimum_menu_width, long minimum_menu_height);
 /**
  * @brief Adds a sub menu button with the given properties to the given menu
  * @param menu: The menu widget this sub menu should be added to
- * @param width: Width of menu button, -1 sets it to default (might be adjusted automatically by menu)
  * @param height: Height of menu button, -1 sets it to default (might be adjusted automatically by menu)
  * @param button_text: Text displayed on the button used to open the sub menu
  * @retval Struct identifying the widget and it's linked window
  */
-struct twr_window_widget twr_window_menu_add_sub_menu_widget_reduced(const struct twr_window_widget* menu, long width, long height, const char* button_text);
+struct twr_window_widget twr_window_menu_add_sub_menu_widget_reduced(const struct twr_window_widget* menu, long height, const char* button_text);
 
 /** 
  * Constructor for a check box widget: Button with a checkbox that has an event for when it's state changes
@@ -166,12 +161,11 @@ struct twr_widget_check_box_constructor {
 /**
  * @brief Adds a check box with the given properties to the given menu
  * @param menu: The menu widget this check box should be added to
- * @param width: Width of widget, -1 sets it to default (might be adjusted automatically by menu)
  * @param height: Height of widget, -1 sets it to default (might be adjusted automatically by menu)
  * @param text: Text displayed on the check box
  * @retval Struct identifying the widget and it's linked window
  */
-struct twr_window_widget twr_window_menu_add_check_box_widget(const struct twr_window_widget* menu, long width, long height, const char* text);
+struct twr_window_widget twr_window_menu_add_check_box_widget(const struct twr_window_widget* menu, long height, const char* text);
 
 
 __attribute__((import_name("twrWindowMenuAddWidget"))) int twrWindowMenuAddWidget(int jsid, int menu_id, const struct twr_widget_constructor* widget);

--- a/source/twr-c/twr-window.h
+++ b/source/twr-c/twr-window.h
@@ -18,6 +18,7 @@ struct twr_window_menu {
    int menu_id;
 };
 
+
 struct twr_window_menu twr_window_add_menu(twr_ioconsole_t * con, const char* text);
 
 #ifdef __cplusplus

--- a/source/twr-c/twr-window.h
+++ b/source/twr-c/twr-window.h
@@ -56,14 +56,6 @@ struct twr_widget_button_constructor {
    struct twr_widget_constructor base;
    /// @brief defaults to "Lorem Ipsum"
    const char* text;
-   /// @brief defaults to 16px Seriph
-   // const char* text_font;
-   /// @brief defaults to Black
-   // const char* text_color;
-   /// @brief defaults to #B0B0B0
-   // const char* button_color;
-   /// @brief defaults to #D0D0D0
-   // const char* selected_button_color;
 };
 
 /** 
@@ -77,47 +69,7 @@ struct twr_widget_seperator_constructor {
    const char* seperator_text;
    /// @brief defaults to 16px Seriph
    const char* seperator_font;
-   /// @brief defaults to black
-   // const char* seperator_color;
 };
-
-// /** 
-//  * Constructor for a radio menu widget: Displays a list of mutually exclusive options that you can select from
-//  * Any Null or Negative values will be set to their defaults
-//  */
-// struct twr_widget_radio_menu_constructor {
-//    /// @brief Base widget constructor
-//    struct twr_widget_constructor base;
-//    ///@brief defaults to 0
-//    long minimum_width;
-//    /// @brief defaults to 0
-//    long minimum_height;
-//    /// @brief defaults to 0
-//    // long y_padding;
-//    /// @brief defaults to gray
-//    // const char* menu_color;
-//    /**
-//     * Color options change to when hovered over
-//     * defaults to light gray
-//     */
-//    // const char* hovered_background_color;
-//    /**
-//     * Symbol used to denote that the option is selected
-//     * defaults to *
-//     */
-//    const char* selected_symbol;
-//    /**
-//     * Amount of space before option text reserved for the select symbol
-//     * defaults to width of (selected_symbol + "  ")
-//     */
-//    // long reserved_prefix_length;
-//    /// @brief default to 20
-//    long option_height;
-//    /// @brief defaults to 16px Seriph
-//    // const char* option_text_font;
-//    /// @brief defaults to black
-//    // const char* option_text_color;
-// };
 
 /** 
  * Constructor for a radio item widget: Items are linked together to have mutually exclusive options
@@ -142,31 +94,12 @@ struct twr_widget_sub_menu_constructor {
     * defaults to Lorem Ipsum
     */
    const char* button_text;
-   /// @brief defaults to 16px Seriph
-   // const char* button_text_font;
-   /// @brief defaults to "black"
-   // const char* button_text_color;
-   /// @brief defaults to #B0B0B0
-   // const char* button_color;
-   /// @brief defaults to #D0D0D0
-   // const char* selected_button_color;
-
    /// @brief defaults to 10
    long minimum_menu_width;
    /// @brief defaults to 10
    long minimum_menu_height;
-   /// @brief defaults to #B0B0B0
-   // const char* menu_color;
-   /// @brief defaults to 5
-   // long menu_y_padding;
    /// @brief defaults to 10
    long min_child_height;
-   /// @brief defaults to black
-   // const char* menu_border_color;
-   /// @brief defaults to 0
-   // long menu_border_width;
-   ///@brief defaults to 0
-   // long menu_open_offset;
 };
 
 /** 
@@ -191,19 +124,6 @@ struct twr_widget_check_box_constructor {
     * defaults to ""
     */
    const char* unchecked_symbol;
-   /**
-    * amount of space to reserve for the checked and unchecked symbol prefixes
-    * defaults to max(width(checked_symbol),width(unchecked_symbol)) + width(" ") * 2
-    */
-   // long reserved_prefix_space;
-   /// @brief defaults to "16px Seriph"
-   // const char* text_font;
-   /// @brief defaults to "Black"
-   // const char* text_color;
-   /// @brief defaults to #B0B0B0
-   // const char* button_color;
-   /// @brief defaults to #D0D0D0
-   // const char* selected_button_color;
 };
 
 
@@ -246,19 +166,21 @@ void twr_window_menu_widget_set_number(const struct twr_window_widget* widget, c
 void twr_window_menu_widget_set_undefined(const struct twr_window_widget* widget, const char* prop_name);
 
 __attribute__((import_name("twrWindowMenuWidgetGetProp"))) struct twr_widget_prop_value* twrWindowMenuWidgetGetProp(int jsid, int widget_id, const char* prop_name);
+
 struct twr_widget_prop_value* twr_window_menu_widget_get_prop(const struct twr_window_widget* widget, const char* prop_name);
-/// @brief if type is undefined defaults to null ptr, otherwise success if false
-char* twr_window_menu_widget_get_prop_string(const struct twr_window_widget* widget, const char* prop_name, int* success);
-/// @brief if type is not string, returns null string
+/// @brief if type is string, returns 1, otherwise returns 0 and sets ret_str to null ptr
+int twr_window_menu_widget_get_prop_string(const struct twr_window_widget* widget, const char* prop_name, char** ret_str);
+/// @brief if type is not string, returns null ptr
 char* twr_window_menu_widget_get_prop_string_or_null(const struct twr_window_widget* widget, const char* prop_name);
-/// @brief if type is not boolean, success is false
-int twr_window_menu_widget_get_prop_boolean(const struct twr_window_widget* widget, const char* prop_name, int* success);
+/// @brief if type is not boolean, returns 0
+int twr_window_menu_widget_get_prop_boolean(const struct twr_window_widget* widget, const char* prop_name, int* ret_bool);
 /// @brief if type is not boolean, returns default value
 int twr_window_menu_widget_get_prop_boolean_or_default(const struct twr_window_widget* widget, const char* prop_name, int default_val);
-/// @brief if type is not number, success is false
-double twr_window_menu_widget_get_prop_number(const struct twr_window_widget* widget, const char* prop_name, int* success);
+/// @brief if type is not number, returns 1
+int twr_window_menu_widget_get_prop_number(const struct twr_window_widget* widget, const char* prop_name, double* ret_number);
 /// @brief if type is not number, returns default value
 double twr_window_menu_widget_get_prop_number_or_default(const struct twr_window_widget* widget, const char* prop_name, double default_val);
+
 
 #ifdef __cplusplus
 }

--- a/source/twr-c/twr-window.h
+++ b/source/twr-c/twr-window.h
@@ -6,10 +6,11 @@ extern "C" {
 #endif
 
 #include "twr-io.h"
+#include "twr-canvas-events.h"
 
-__attribute__((import_name("twrGetAppCanvasJSID"))) int twrGetAppCanvasJSID(int jsid);
+__attribute__((import_name("twrGetDrawCanvasJSID"))) int twrGetDrawCanvasJSID(int jsid);
 
-twr_ioconsole_t* twr_window_get_app_canvas(twr_ioconsole_t * con);
+twr_ioconsole_t* twr_window_get_draw_canvas(twr_ioconsole_t * con);
 
 __attribute__((import_name("twrWindowAddMenu"))) int twrWindowAddMenu(int jsid, const char* text);
 
@@ -187,10 +188,13 @@ void twr_window_menu_radio_item_merge(const struct twr_window_widget* widget1, c
 
 
 enum WindowWidgetPropVal {
-   WINDOW_WIDGET_PROP_STRING = 1,
-   WINDOW_WIDGET_PROP_BOOLEAN = 2,
-   WINDOW_WIDGET_PROP_NUMBER = 4,
-   WINDOW_WIDGET_PROP_UNDEFINED = 8,
+   WINDOW_WIDGET_PROP_STRING = 1, //0b0001
+   WINDOW_WIDGET_PROP_BOOLEAN = 2,//0b0010
+   WINDOW_WIDGET_PROP_NUMBER = 4, //0b0100
+   WINDOW_WIDGET_PROP_UNDEFINED = 8, //0b1000
+   // WINDOW_WIDGET_PROP_STRING_OR_UNDEFINED = 9,  //0b1001
+   // WINDOW_WIDGET_PROP_BOOLEAN_OR_UNDEFINED = 10,//0b1010
+   // WINDOW_WIDGET_PROP_NUMBER_OR_UNDEFINED = 12, //0b1100
 };
 struct twr_widget_prop_value {
    union {
@@ -273,7 +277,12 @@ void twr_window_menu_set_prop_number(twr_ioconsole_t* window, const char* prop_n
 void twr_window_menu_set_prop_string(twr_ioconsole_t* window, const char* prop_name, const char* val);
 
 
-
+enum TwrWindowEvents {
+   TWR_WINDOW_RESIZE_EVENT
+};
+void twr_window_register_event(twr_ioconsole_t* window, enum TwrWindowEvents event, int event_id);
+void twr_window_unregister_event(twr_ioconsole_t* window, enum TwrWindowEvents event, int event_id);
+void twr_window_unregiser_all_events(twr_ioconsole_t* window);
 
 #ifdef __cplusplus
 }

--- a/source/twr-c/twr-window.h
+++ b/source/twr-c/twr-window.h
@@ -58,6 +58,16 @@ struct twr_widget_button_constructor {
    const char* text;
 };
 
+/**
+ * @brief Adds a button with the given properties to the given menu
+ * @param menu: The menu widget this button should be added to
+ * @param width: Width of widget, -1 sets it to default (might be adjusted automatically by menu)
+ * @param height: Height of widget, -1 sets it to default (might be adjusted automatically by menu)
+ * @param text: Text displayed on button
+ * @retval Struct identifying the widget and it's linked window
+ */
+struct twr_window_widget twr_window_menu_add_button_widget(const struct twr_window_widget* menu, long width, long height, const char* text);
+
 /** 
  * Constructor for a seperator widget: Displays a repeating segment of text to seperate sections
  * Any Null or Negative values will be set to their defaults
@@ -70,6 +80,16 @@ struct twr_widget_seperator_constructor {
    /// @brief defaults to 16px Seriph
    const char* seperator_font;
 };
+/**
+ * @brief Adds a seperator with the given properties to the given menu
+ * @param menu: The menu widget this seperator should be added to
+ * @param width: Width of widget, -1 sets it to default (might be adjusted automatically by menu)
+ * @param height: Height of widget, -1 sets it to default (might be adjusted automatically by menu)
+ * @param seperator_text: Text seperator uses, for instance "-" would fill the width with "-------"
+ * @param seperator_font: Font that should be used with the seperator text
+ * @retval Struct identifying the widget and it's linked window
+ */
+struct twr_window_widget twr_window_menu_add_seperator_widget(const struct twr_window_widget* menu, long width, long height, const char* seperator_text, const char* seperator_font);
 
 /** 
  * Constructor for a radio item widget: Items are linked together to have mutually exclusive options
@@ -81,6 +101,15 @@ struct twr_widget_radio_item_constructor {
    /// @brief defaults to "Lorem Ipsum"
    const char* text;
 };
+/**
+ * @brief Adds a radio item with the given properties to the given menu
+ * @param menu: The menu widget this radio item should be added to
+ * @param width: Width of widget, -1 sets it to default (might be adjusted automatically by menu)
+ * @param height: Height of widget, -1 sets it to default (might be adjusted automatically by menu)
+ * @param text: Text displayed on the radio item
+ * @retval Struct identifying the widget and it's linked window
+ */
+struct twr_window_widget twr_window_menu_add_radio_item_widget(const struct twr_window_widget* menu, long width, long height, const char* text);
 
 /** 
  * Constructor for a sub-menu widget: Holds a list of widgets
@@ -99,8 +128,29 @@ struct twr_widget_sub_menu_constructor {
    /// @brief defaults to 10
    long minimum_menu_height;
    /// @brief defaults to 10
-   long min_child_height;
+   long minimum_child_height;
 };
+/**
+ * @brief Adds a sub menu button with the given properties to the given menu
+ * @param menu: The menu widget this sub menu should be added to
+ * @param width: Width of menu button, -1 sets it to default (might be adjusted automatically by menu)
+ * @param height: Height of menu button, -1 sets it to default (might be adjusted automatically by menu)
+ * @param button_text: Text displayed on the button used to open the sub menu
+ * @param minimum_menu_width: The minimum width of the menu when it's opened
+ * @param minimum_menu_height: The minimum height of the menu when it's opened
+ * @param minimum_child_height: The minimum height of the menu's child widgets
+ * @retval Struct identifying the widget and it's linked window
+ */
+struct twr_window_widget twr_window_menu_add_sub_menu_widget(const struct twr_window_widget* menu, long width, long height, const char* button_text, long minimum_menu_width, long minimum_menu_height, long minimum_child_height);
+/**
+ * @brief Adds a sub menu button with the given properties to the given menu
+ * @param menu: The menu widget this sub menu should be added to
+ * @param width: Width of menu button, -1 sets it to default (might be adjusted automatically by menu)
+ * @param height: Height of menu button, -1 sets it to default (might be adjusted automatically by menu)
+ * @param button_text: Text displayed on the button used to open the sub menu
+ * @retval Struct identifying the widget and it's linked window
+ */
+struct twr_window_widget twr_window_menu_add_sub_menu_widget_reduced(const struct twr_window_widget* menu, long width, long height, const char* button_text);
 
 /** 
  * Constructor for a check box widget: Button with a checkbox that has an event for when it's state changes
@@ -115,6 +165,15 @@ struct twr_widget_check_box_constructor {
     */
    const char* text;
 };
+/**
+ * @brief Adds a check box with the given properties to the given menu
+ * @param menu: The menu widget this check box should be added to
+ * @param width: Width of widget, -1 sets it to default (might be adjusted automatically by menu)
+ * @param height: Height of widget, -1 sets it to default (might be adjusted automatically by menu)
+ * @param text: Text displayed on the check box
+ * @retval Struct identifying the widget and it's linked window
+ */
+struct twr_window_widget twr_window_menu_add_check_box_widget(const struct twr_window_widget* menu, long width, long height, const char* text);
 
 
 __attribute__((import_name("twrWindowMenuAddWidget"))) int twrWindowMenuAddWidget(int jsid, int menu_id, const struct twr_widget_constructor* widget);
@@ -188,6 +247,19 @@ __attribute__((import_name("twrWindowMenuWidgetListProps"))) struct twr_widget_p
  * The array of structs and the strings representing their names are made in one large allocation
  */
 struct twr_widget_prop_details* twr_window_menu_widget_list_props(const struct twr_window_widget* widget, long* length);
+
+
+struct twr_menu_prop_details {
+   const char* name;
+   enum WindowWidgetPropVal type;
+};
+__attribute__((import_name("twrWindowMenuListProps"))) struct twr_menu_prop_details* twrWindowMenuListProps(int jsid, long* length);
+/**
+ * returns an array of twr_menu_prop_details representing the name and type of each property
+ * The array of structs and the strings representing their names are made in one large allocation
+ */
+struct twr_menu_prop_details* twr_window_menu_list_props(twr_ioconsole_t* window, long* length);
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/twr-ts/index.ts
+++ b/source/twr-ts/index.ts
@@ -8,6 +8,7 @@ export * from "./twrcon.js"
 export * from "./twrcondebug.js"
 export * from "./twrconcanvas.js"
 export * from "./twrlibrary.js"
+export * from "./twrconwindow.js"
 
 
 

--- a/source/twr-ts/twrcanvasevents.ts
+++ b/source/twr-ts/twrcanvasevents.ts
@@ -65,8 +65,8 @@ export function bindCanvasEvents(handler: ICanvasEvents, canvas: HTMLCanvasEleme
       (type) => (e: MouseEvent) => {
          handler.handleCanvasMouseEvent(
             type,
-            e.pageX - left - window.scrollX,
-            e.pageY - top - window.scrollY
+            e.pageX - left,
+            e.pageY - top
          );
       }
    );

--- a/source/twr-ts/twrcanvasevents.ts
+++ b/source/twr-ts/twrcanvasevents.ts
@@ -1,4 +1,4 @@
-import { keyEventToCodePoint } from "./twrcon";
+import { keyEventToCodePoint } from "./twrcon.js";
 
 export enum CanvasEventTypes {
    KEY_DOWN,
@@ -41,6 +41,7 @@ function registerSimilarEvents(canvas: HTMLCanvasElement, start: CanvasEventType
 export function bindCanvasEvents(handler: ICanvasEvents, canvas: HTMLCanvasElement) {
    registerSimilarEvents(canvas, CanvasEventTypes.KEY_DOWN, CanvasEventTypes.KEY_UP, 
       (type) => (e: KeyboardEvent) => {
+         console.log(e);
          const r=keyEventToCodePoint(e);  // twr-wasm utility function
          if (r) {
             handler.handleCanvasKeyEvent(type, r);

--- a/source/twr-ts/twrcanvasevents.ts
+++ b/source/twr-ts/twrcanvasevents.ts
@@ -1,0 +1,67 @@
+import { keyEventToCodePoint } from "./twrcon";
+
+export enum CanvasEventTypes {
+   KEY_DOWN,
+   KEY_UP,
+
+   MOUSE_DOWN,
+   MOUSE_UP,
+   MOUSE_CLICK,
+   MOUSE_DBLCLICK,
+   MOUSE_MOVE,
+
+   WHEEL
+}
+export const NUM_CANVAS_EVENTS = CanvasEventTypes.WHEEL - CanvasEventTypes.KEY_DOWN + 1;
+
+export const CANVAS_EVENTS = [
+   "keydown",
+   "keyup",
+   
+   "mousedown",
+   "mouseup",
+   "click",
+   "dblclick",
+   "mousemove",
+
+   "wheel"
+];
+
+export interface ICanvasEvents {
+   handleCanvasKeyEvent: (event: CanvasEventTypes, key: number) => void;
+   handleCanvasMouseEvent: (event: CanvasEventTypes, x: number, y: number) => void;
+   handleCanvasWheelEvent: (event: CanvasEventTypes, deltaX: number, deltaY: number, deltaZ: number, deltaMode: number) => void;
+}
+
+function registerSimilarEvents(canvas: HTMLCanvasElement, start: CanvasEventTypes, end: CanvasEventTypes, handler: (eventType: CanvasEventTypes) => (event: any) => void) {
+   for (let i = start; i <= end; i++) {
+      canvas.addEventListener(CANVAS_EVENTS[i], handler(i));
+   }
+}
+export function bindCanvasEvents(handler: ICanvasEvents, canvas: HTMLCanvasElement) {
+   registerSimilarEvents(canvas, CanvasEventTypes.KEY_DOWN, CanvasEventTypes.KEY_UP, 
+      (type) => (e: KeyboardEvent) => {
+         const r=keyEventToCodePoint(e);  // twr-wasm utility function
+         if (r) {
+            handler.handleCanvasKeyEvent(type, r);
+         }
+      }
+   );
+
+   const bounding = canvas.getBoundingClientRect();
+   const top = bounding.top + window.scrollY;
+   const left = bounding.left + window.scrollX;
+   registerSimilarEvents(canvas, CanvasEventTypes.MOUSE_DOWN, CanvasEventTypes.MOUSE_MOVE,
+      (type) => (e: MouseEvent) => {
+         handler.handleCanvasMouseEvent(
+            type,
+            e.pageX - left - window.scrollX,
+            e.pageY - top - window.scrollY
+         );
+      }
+   );
+
+   canvas.addEventListener("wheel", (e: WheelEvent) => {
+      handler.handleCanvasWheelEvent(CanvasEventTypes.WHEEL, e.deltaX, e.deltaY, e.deltaZ, e.deltaMode);
+   });
+}

--- a/source/twr-ts/twrcanvasevents.ts
+++ b/source/twr-ts/twrcanvasevents.ts
@@ -10,9 +10,11 @@ export enum CanvasEventTypes {
    MOUSE_DBLCLICK,
    MOUSE_MOVE,
 
-   WHEEL
+   WHEEL,
+
+   ANIMATION_FRAME
 }
-export const NUM_CANVAS_EVENTS = CanvasEventTypes.WHEEL - CanvasEventTypes.KEY_DOWN + 1;
+export const NUM_CANVAS_EVENTS = Object.values(CanvasEventTypes).length;
 
 export const CANVAS_EVENTS = [
    "keydown",
@@ -24,13 +26,16 @@ export const CANVAS_EVENTS = [
    "dblclick",
    "mousemove",
 
-   "wheel"
+   "wheel",
+
+   "ANIMATION_FRAME"
 ];
 
 export interface ICanvasEvents {
    handleCanvasKeyEvent: (event: CanvasEventTypes, key: number) => void;
    handleCanvasMouseEvent: (event: CanvasEventTypes, x: number, y: number) => void;
    handleCanvasWheelEvent: (event: CanvasEventTypes, deltaX: number, deltaY: number, deltaZ: number, deltaMode: number) => void;
+   handleCanvasAnimationFrameEvent: (event: CanvasEventTypes, delta: number) => void;
 }
 
 function registerSimilarEvents(canvas: HTMLCanvasElement, start: CanvasEventTypes, end: CanvasEventTypes, handler: (eventType: CanvasEventTypes) => (event: any) => void) {
@@ -65,4 +70,10 @@ export function bindCanvasEvents(handler: ICanvasEvents, canvas: HTMLCanvasEleme
    canvas.addEventListener("wheel", (e: WheelEvent) => {
       handler.handleCanvasWheelEvent(CanvasEventTypes.WHEEL, e.deltaX, e.deltaY, e.deltaZ, e.deltaMode);
    });
+
+   const animation_loop = (delta: number) => {
+      handler.handleCanvasAnimationFrameEvent(CanvasEventTypes.ANIMATION_FRAME, delta);
+      requestAnimationFrame(animation_loop);
+   };
+   requestAnimationFrame(animation_loop);
 }

--- a/source/twr-ts/twrcanvasevents.ts
+++ b/source/twr-ts/twrcanvasevents.ts
@@ -35,7 +35,8 @@ export interface ICanvasEvents {
    /// Get canvas key events, return True to intercept event and stop it from being passed along
    handleCanvasKeyEvent: (event: CanvasEventTypes, key: number) => boolean;
    /// Get canvas mouse events, return True to intercept event and stop it from being passed along
-   handleCanvasMouseEvent: (event: CanvasEventTypes, x: number, y: number) => boolean;
+   /// Button is taken directly from event as specified here: https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
+   handleCanvasMouseEvent: (event: CanvasEventTypes, x: number, y: number, button: number) => boolean;
    /// Get canvas wheel events, return True to intercept event and stop it from being passed along
    handleCanvasWheelEvent: (event: CanvasEventTypes, deltaX: number, deltaY: number, deltaZ: number, deltaMode: number) => boolean;
    /// Get canvas animation frame events
@@ -66,7 +67,8 @@ export function bindCanvasEvents(handler: ICanvasEvents, canvas: HTMLCanvasEleme
          handler.handleCanvasMouseEvent(
             type,
             e.pageX - left,
-            e.pageY - top
+            e.pageY - top,
+            e.button
          );
       }
    );

--- a/source/twr-ts/twrcanvasevents.ts
+++ b/source/twr-ts/twrcanvasevents.ts
@@ -32,9 +32,13 @@ export const CANVAS_EVENTS = [
 ];
 
 export interface ICanvasEvents {
-   handleCanvasKeyEvent: (event: CanvasEventTypes, key: number) => void;
-   handleCanvasMouseEvent: (event: CanvasEventTypes, x: number, y: number) => void;
-   handleCanvasWheelEvent: (event: CanvasEventTypes, deltaX: number, deltaY: number, deltaZ: number, deltaMode: number) => void;
+   /// Get canvas key events, return True to intercept event and stop it from being passed along
+   handleCanvasKeyEvent: (event: CanvasEventTypes, key: number) => boolean;
+   /// Get canvas mouse events, return True to intercept event and stop it from being passed along
+   handleCanvasMouseEvent: (event: CanvasEventTypes, x: number, y: number) => boolean;
+   /// Get canvas wheel events, return True to intercept event and stop it from being passed along
+   handleCanvasWheelEvent: (event: CanvasEventTypes, deltaX: number, deltaY: number, deltaZ: number, deltaMode: number) => boolean;
+   /// Get canvas animation frame events
    handleCanvasAnimationFrameEvent: (event: CanvasEventTypes, delta: number) => void;
 }
 

--- a/source/twr-ts/twrcon.ts
+++ b/source/twr-ts/twrcon.ts
@@ -109,6 +109,7 @@ export interface IConsoleDebug extends IConsoleBase, IConsoleStreamOut {}
 export interface IConsoleCanvas extends IConsoleBase, IConsoleDrawable, IConsoleEvents {}
 export interface IConsoleWindow extends IConsoleBase, IConsoleEvents {
    twrGetAppCanvasJSID: (callingMod: IWasmModuleAsync|IWasmModule) => number,
+   twrWindowAddMenu: (callingMod: IWasmModuleAsync|IWasmModule, textPtr: number) => number,
 }
 
 export interface IConsole extends IConsoleBase, Partial<IConsoleStreamOut>, Partial<IConsoleStreamIn>, Partial<IConsoleAddressable>, Partial<IConsoleDrawable>, Partial<IConsoleEvents> {}

--- a/source/twr-ts/twrcon.ts
+++ b/source/twr-ts/twrcon.ts
@@ -111,8 +111,9 @@ export interface IConsoleWindow extends IConsoleBase, IConsoleEvents {
    twrGetAppCanvasJSID: (callingMod: IWasmModuleAsync|IWasmModule) => number,
    twrWindowAddMenu: (callingMod: IWasmModuleAsync|IWasmModule, textPtr: number) => number,
    twrWindowMenuAddWidget: (mod: IWasmModuleAsync | IWasmModule, menuID: number, consPtr: number) => number,
-   twrWindowMenuButtonAddCallback: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, eventID: number, extraPtr: number) => void,
+   twrWindowMenuWidgetAddCallback: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, eventID: number, extraPtr: number) => void,
    twrWindowMenuDeleteWidget: (mod: IWasmModuleAsync | IWasmModule, widgetID: number) => void,
+   twrWindowMenuRadioMenuAddOption: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, optionPtr: number) => void,
 }
 
 export interface IConsole extends IConsoleBase, Partial<IConsoleStreamOut>, Partial<IConsoleStreamIn>, Partial<IConsoleAddressable>, Partial<IConsoleDrawable>, Partial<IConsoleEvents> {}

--- a/source/twr-ts/twrcon.ts
+++ b/source/twr-ts/twrcon.ts
@@ -112,6 +112,7 @@ export interface IConsoleWindow extends IConsoleBase, IConsoleEvents {
    twrWindowAddMenu: (callingMod: IWasmModuleAsync|IWasmModule, textPtr: number) => number,
    twrWindowMenuAddWidget: (mod: IWasmModuleAsync | IWasmModule, menuID: number, consPtr: number) => number,
    twrWindowMenuButtonAddCallback: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, eventID: number, extraPtr: number) => void,
+   twrWindowMenuDeleteWidget: (mod: IWasmModuleAsync | IWasmModule, widgetID: number) => void,
 }
 
 export interface IConsole extends IConsoleBase, Partial<IConsoleStreamOut>, Partial<IConsoleStreamIn>, Partial<IConsoleAddressable>, Partial<IConsoleDrawable>, Partial<IConsoleEvents> {}

--- a/source/twr-ts/twrcon.ts
+++ b/source/twr-ts/twrcon.ts
@@ -118,6 +118,8 @@ export interface IConsoleWindow extends IConsoleBase, IConsoleEvents {
    twrWindowMenuWidgetGetProp: (mod: IWasmModule, widgetID: number, propNamePtr: number) => number,
    twrWindowMenuWidgetListProps: (mod: IWasmModule, widgetID: number, lengthPtr: number) => number,
    twrWindowMenuWidgetGetPropDetails: (mod: IWasmModule, widgetID: number, detailsStructPtr: number) => void,
+
+   twrWindowMenuListProps: (mod: IWasmModule, lengthPtr: number) => number;
 }
 
 export interface IConsole extends IConsoleBase, Partial<IConsoleStreamOut>, Partial<IConsoleStreamIn>, Partial<IConsoleAddressable>, Partial<IConsoleDrawable>, Partial<IConsoleEvents> {}

--- a/source/twr-ts/twrcon.ts
+++ b/source/twr-ts/twrcon.ts
@@ -113,8 +113,6 @@ export interface IConsoleWindow extends IConsoleBase, IConsoleEvents {
    twrWindowMenuAddWidget: (mod: IWasmModuleAsync | IWasmModule, menuID: number, consPtr: number) => number,
    twrWindowMenuWidgetAddCallback: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, eventID: number, extraPtr: number) => void,
    twrWindowMenuDeleteWidget: (mod: IWasmModuleAsync | IWasmModule, widgetID: number) => void,
-   // twrWindowMenuRadioMenuAddOption: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, optionPtr: number) => void,
-   twrWindowMenuWidgetSetVisibility: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, visibility: number) => void,
    twrWindowMenuRadioItemMerge: (mod: IWasmModuleAsync | IWasmModule, widgetID1: number, widgetID2: number) => void,
    twrWindowMenuWidgetSetProp: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, propNamePtr: number, dataPtr: number) => void,
    twrWindowMenuWidgetGetProp: (mod: IWasmModule, widgetID: number, propNamePtr: number) => number,

--- a/source/twr-ts/twrcon.ts
+++ b/source/twr-ts/twrcon.ts
@@ -120,6 +120,9 @@ export interface IConsoleWindow extends IConsoleBase, IConsoleEvents {
    twrWindowMenuWidgetGetPropDetails: (mod: IWasmModule, widgetID: number, detailsStructPtr: number) => void,
 
    twrWindowMenuListProps: (mod: IWasmModule, lengthPtr: number) => number;
+
+   twrWindowMenuSetProp: (mod: IWasmModuleAsync | IWasmModule, propNamePtr: number, dataPtr: number) => void,
+   twrWindowMenuGetProp: (mod: IWasmModule, propNamePtr: number) => number,
 }
 
 export interface IConsole extends IConsoleBase, Partial<IConsoleStreamOut>, Partial<IConsoleStreamIn>, Partial<IConsoleAddressable>, Partial<IConsoleDrawable>, Partial<IConsoleEvents> {}

--- a/source/twr-ts/twrcon.ts
+++ b/source/twr-ts/twrcon.ts
@@ -116,6 +116,8 @@ export interface IConsoleWindow extends IConsoleBase, IConsoleEvents {
    // twrWindowMenuRadioMenuAddOption: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, optionPtr: number) => void,
    twrWindowMenuWidgetSetVisibility: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, visibility: number) => void,
    twrWindowMenuRadioItemMerge: (mod: IWasmModuleAsync | IWasmModule, widgetID1: number, widgetID2: number) => void,
+   twrWindowMenuWidgetSetProp: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, propNamePtr: number, dataPtr: number) => void,
+   twrWindowMenuWidgetGetProp: (mod: IWasmModule, widgetID: number, propNamePtr: number) => number,
 }
 
 export interface IConsole extends IConsoleBase, Partial<IConsoleStreamOut>, Partial<IConsoleStreamIn>, Partial<IConsoleAddressable>, Partial<IConsoleDrawable>, Partial<IConsoleEvents> {}

--- a/source/twr-ts/twrcon.ts
+++ b/source/twr-ts/twrcon.ts
@@ -114,6 +114,7 @@ export interface IConsoleWindow extends IConsoleBase, IConsoleEvents {
    twrWindowMenuWidgetAddCallback: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, eventID: number, extraPtr: number) => void,
    twrWindowMenuDeleteWidget: (mod: IWasmModuleAsync | IWasmModule, widgetID: number) => void,
    twrWindowMenuRadioMenuAddOption: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, optionPtr: number) => void,
+   twrWindowMenuWidgetSetVisibility: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, visibility: number) => void,
 }
 
 export interface IConsole extends IConsoleBase, Partial<IConsoleStreamOut>, Partial<IConsoleStreamIn>, Partial<IConsoleAddressable>, Partial<IConsoleDrawable>, Partial<IConsoleEvents> {}

--- a/source/twr-ts/twrcon.ts
+++ b/source/twr-ts/twrcon.ts
@@ -96,10 +96,16 @@ export interface IConsoleDrawable {
     twrConLoadImage_async: (mod:IWasmModuleAsync, urlPtr: number, id: number)=>Promise<number>,
    }
 
+export interface IConsoleEvents {
+   twrRegisterEvent: (callingMod:IWasmModuleAsync|IWasmModule, eventType: number, eventID: number) => void,
+   twrUnregisterEvent: (callingMod: IWasmModuleAsync|IWasmModule, eventType: number, eventID: number) => void,
+   twrUnregisterAllEvents: (callingMod: IWasmModuleAsync|IWasmModule) => void,
+}
+
 export interface IConsoleTerminal extends IConsoleBase, IConsoleStreamOut, IConsoleStreamIn, IConsoleAddressable {}
 export interface IConsoleDiv extends IConsoleBase, IConsoleStreamOut, IConsoleStreamIn {}
 export interface IConsoleDebug extends IConsoleBase, IConsoleStreamOut {}
-export interface IConsoleCanvas extends IConsoleBase, IConsoleDrawable {}
+export interface IConsoleCanvas extends IConsoleBase, IConsoleDrawable, IConsoleEvents {}
 
 export interface IConsole extends IConsoleBase, Partial<IConsoleStreamOut>, Partial<IConsoleStreamIn>, Partial<IConsoleAddressable>, Partial<IConsoleDrawable> {}
 

--- a/source/twr-ts/twrcon.ts
+++ b/source/twr-ts/twrcon.ts
@@ -102,12 +102,16 @@ export interface IConsoleEvents {
    twrUnregisterAllEvents: (callingMod: IWasmModuleAsync|IWasmModule) => void,
 }
 
+
 export interface IConsoleTerminal extends IConsoleBase, IConsoleStreamOut, IConsoleStreamIn, IConsoleAddressable {}
 export interface IConsoleDiv extends IConsoleBase, IConsoleStreamOut, IConsoleStreamIn {}
 export interface IConsoleDebug extends IConsoleBase, IConsoleStreamOut {}
 export interface IConsoleCanvas extends IConsoleBase, IConsoleDrawable, IConsoleEvents {}
+export interface IConsoleWindow extends IConsoleBase, IConsoleEvents {
+   twrGetAppCanvasJSID: (callingMod: IWasmModuleAsync|IWasmModule) => number,
+}
 
-export interface IConsole extends IConsoleBase, Partial<IConsoleStreamOut>, Partial<IConsoleStreamIn>, Partial<IConsoleAddressable>, Partial<IConsoleDrawable> {}
+export interface IConsole extends IConsoleBase, Partial<IConsoleStreamOut>, Partial<IConsoleStreamIn>, Partial<IConsoleAddressable>, Partial<IConsoleDrawable>, Partial<IConsoleEvents> {}
 
 
 // must match IO_TYPEs in twr_io.h

--- a/source/twr-ts/twrcon.ts
+++ b/source/twr-ts/twrcon.ts
@@ -108,7 +108,7 @@ export interface IConsoleDiv extends IConsoleBase, IConsoleStreamOut, IConsoleSt
 export interface IConsoleDebug extends IConsoleBase, IConsoleStreamOut {}
 export interface IConsoleCanvas extends IConsoleBase, IConsoleDrawable, IConsoleEvents {}
 export interface IConsoleWindow extends IConsoleBase, IConsoleEvents {
-   twrGetAppCanvasJSID: (callingMod: IWasmModuleAsync|IWasmModule) => number,
+   twrGetDrawCanvasJSID: (callingMod: IWasmModuleAsync|IWasmModule) => number,
    twrWindowAddMenu: (callingMod: IWasmModuleAsync|IWasmModule, textPtr: number) => number,
    twrWindowMenuAddWidget: (mod: IWasmModuleAsync | IWasmModule, menuID: number, consPtr: number) => number,
    twrWindowMenuWidgetAddCallback: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, eventID: number, extraPtr: number) => void,

--- a/source/twr-ts/twrcon.ts
+++ b/source/twr-ts/twrcon.ts
@@ -110,6 +110,8 @@ export interface IConsoleCanvas extends IConsoleBase, IConsoleDrawable, IConsole
 export interface IConsoleWindow extends IConsoleBase, IConsoleEvents {
    twrGetAppCanvasJSID: (callingMod: IWasmModuleAsync|IWasmModule) => number,
    twrWindowAddMenu: (callingMod: IWasmModuleAsync|IWasmModule, textPtr: number) => number,
+   twrWindowMenuAddWidget: (mod: IWasmModuleAsync | IWasmModule, menuID: number, consPtr: number) => number,
+   twrWindowMenuButtonAddCallback: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, eventID: number, extraPtr: number) => void,
 }
 
 export interface IConsole extends IConsoleBase, Partial<IConsoleStreamOut>, Partial<IConsoleStreamIn>, Partial<IConsoleAddressable>, Partial<IConsoleDrawable>, Partial<IConsoleEvents> {}

--- a/source/twr-ts/twrcon.ts
+++ b/source/twr-ts/twrcon.ts
@@ -116,7 +116,8 @@ export interface IConsoleWindow extends IConsoleBase, IConsoleEvents {
    twrWindowMenuRadioItemMerge: (mod: IWasmModuleAsync | IWasmModule, widgetID1: number, widgetID2: number) => void,
    twrWindowMenuWidgetSetProp: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, propNamePtr: number, dataPtr: number) => void,
    twrWindowMenuWidgetGetProp: (mod: IWasmModule, widgetID: number, propNamePtr: number) => number,
-   twrWindowMenuWidgetListProps: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, lengthPtr: number) => number | Promise<number>,
+   twrWindowMenuWidgetListProps: (mod: IWasmModule, widgetID: number, lengthPtr: number) => number,
+   twrWindowMenuWidgetGetPropDetails: (mod: IWasmModule, widgetID: number, detailsStructPtr: number) => void,
 }
 
 export interface IConsole extends IConsoleBase, Partial<IConsoleStreamOut>, Partial<IConsoleStreamIn>, Partial<IConsoleAddressable>, Partial<IConsoleDrawable>, Partial<IConsoleEvents> {}

--- a/source/twr-ts/twrcon.ts
+++ b/source/twr-ts/twrcon.ts
@@ -118,6 +118,7 @@ export interface IConsoleWindow extends IConsoleBase, IConsoleEvents {
    twrWindowMenuRadioItemMerge: (mod: IWasmModuleAsync | IWasmModule, widgetID1: number, widgetID2: number) => void,
    twrWindowMenuWidgetSetProp: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, propNamePtr: number, dataPtr: number) => void,
    twrWindowMenuWidgetGetProp: (mod: IWasmModule, widgetID: number, propNamePtr: number) => number,
+   twrWindowMenuWidgetListProps: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, lengthPtr: number) => number | Promise<number>,
 }
 
 export interface IConsole extends IConsoleBase, Partial<IConsoleStreamOut>, Partial<IConsoleStreamIn>, Partial<IConsoleAddressable>, Partial<IConsoleDrawable>, Partial<IConsoleEvents> {}

--- a/source/twr-ts/twrcon.ts
+++ b/source/twr-ts/twrcon.ts
@@ -113,8 +113,9 @@ export interface IConsoleWindow extends IConsoleBase, IConsoleEvents {
    twrWindowMenuAddWidget: (mod: IWasmModuleAsync | IWasmModule, menuID: number, consPtr: number) => number,
    twrWindowMenuWidgetAddCallback: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, eventID: number, extraPtr: number) => void,
    twrWindowMenuDeleteWidget: (mod: IWasmModuleAsync | IWasmModule, widgetID: number) => void,
-   twrWindowMenuRadioMenuAddOption: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, optionPtr: number) => void,
+   // twrWindowMenuRadioMenuAddOption: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, optionPtr: number) => void,
    twrWindowMenuWidgetSetVisibility: (mod: IWasmModuleAsync | IWasmModule, widgetID: number, visibility: number) => void,
+   twrWindowMenuRadioItemMerge: (mod: IWasmModuleAsync | IWasmModule, widgetID1: number, widgetID2: number) => void,
 }
 
 export interface IConsole extends IConsoleBase, Partial<IConsoleStreamOut>, Partial<IConsoleStreamIn>, Partial<IConsoleAddressable>, Partial<IConsoleDrawable>, Partial<IConsoleEvents> {}

--- a/source/twr-ts/twrconcanvas.ts
+++ b/source/twr-ts/twrconcanvas.ts
@@ -70,6 +70,14 @@ function calculateID(mod:IWasmModule|IWasmModuleAsync, id: number) {
    //should be equivalent to (mod.id << 32) | id
    return (mod.id & (2**20 - 1)) * 2**32 + id;
 }
+///modID -> [module, eventID -> numRegistrations]
+type EventHandlerMap = Map<
+   number,
+   [
+      IWasmModule|IWasmModuleAsync,
+      Map<number, number>
+   ]
+>;
 
 export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas, ICanvasEvents {
    id:number;
@@ -84,23 +92,15 @@ export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas, ICan
       HTMLImageElement
    };
 
-   registeredEvents: {
-      [eventType in CanvasEventTypes]: 
-      Map<
-         number, 
-         [
-            IWasmModule|IWasmModuleAsync,
-            {
-               [eventID: number]: number
-            }
-         ]
-      >
-   };
+   registeredEvents: { [eventType in CanvasEventTypes]: EventHandlerMap };
 
    imports:TLibImports = {
       twrConGetProp:{},
       twrConDrawSeq:{},
       twrConLoadImage:{isModuleAsyncOnly:true, isAsyncFunction:true},
+      twrRegisterEvent:{},
+      twrUnregisterEvent:{},
+      twrUnregisterAllEvents:{},
    };
 
    libSourcePath = new URL(import.meta.url).pathname;
@@ -137,24 +137,27 @@ export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas, ICan
          .reduce((acc, eventType) => {
             acc[eventType as CanvasEventTypes] = new Map();
             return acc;
-         }, {} as { [eventType in CanvasEventTypes]: Map});
+         }, {} as { [eventType in CanvasEventTypes]: EventHandlerMap});
    }
 
-   handleCanvasKeyEvent(event: CanvasEventTypes, key: number) {
+   internalSendEvent(event: CanvasEventTypes, ...args: number[]) {
       const eventHandlers = this.registeredEvents[event];
 
-      for (const modID in eventHandlers) {
-         const [mod, eventIDs] = eventHandlers[modID];
-         for (const eventID in eventIDs) {
-            mod.postEvent(Number(eventID), key);
+      for (const [mod, eventIDs] of eventHandlers.values()) {
+         for (const eventID of eventIDs.keys()) {
+            mod.postEvent(eventID, ...args);
          }
       }
    }
+   handleCanvasKeyEvent(event: CanvasEventTypes, key: number) {
+      console.log(`${event}, ${key}`);
+      this.internalSendEvent(event, key);
+   }
    handleCanvasMouseEvent(event: CanvasEventTypes, x: number, y: number) {
-
+      this.internalSendEvent(event, x, y);
    }
    handleCanvasWheelEvent(event: CanvasEventTypes, deltaX: number, deltaY: number, deltaZ: number, deltaMode: number) {
-
+      this.internalSendEvent(event, deltaX, deltaY, deltaZ, deltaMode);
    };
 
    twrRegisterEvent(mod: IWasmModule|IWasmModuleAsync, eventType: number, eventID: number) {
@@ -164,17 +167,16 @@ export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas, ICan
       
       const eventHandlers = this.registeredEvents[event];
 
-      if (!(mod.id in eventHandlers))
-         eventHandlers[mod.id] = [mod, {}];
+      if (!eventHandlers.has(mod.id))
+         eventHandlers.set(mod.id, [mod, new Map()]);
       
-      const individualHandlers = eventHandlers[mod.id][1];
+      const individualHandlers = eventHandlers.get(mod.id)![1];
       
-      if (eventID in individualHandlers) {
+      const prevCount = individualHandlers.get(eventID) ?? 0;
+      if (prevCount >= 0)
          console.log(`Warning: twrRegisterEvent was given an eventID (${eventID}) that was already registered to this event (${event.toString()})!`);
-         individualHandlers[eventID]++;
-      } else {
-         individualHandlers[eventID] = 1;
-      }
+
+      individualHandlers.set(eventID, prevCount+1);
    };
 
    twrUnregisterEvent(mod: IWasmModule|IWasmModuleAsync, eventType: number, eventID: number) {
@@ -184,22 +186,26 @@ export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas, ICan
 
       const eventHandlers = this.registeredEvents[event];
 
-      if (!(mod.id in eventHandlers))
+      if (!eventHandlers.has(mod.id))
          throw new Error(`twrUnregisterEvent: tried to unregister an event when this module has never registered an event!`);
 
-      const individualHandlers = eventHandlers[mod.id][1];
+      const individualHandlers = eventHandlers.get(mod.id)![1];
 
-      if (eventID in individualHandlers) {
-         if (individualHandlers[eventID] == 0)
-            throw new Error(`twrUnregisterEvent: Experienced an unexpected error! ${eventID} is registered but has 0 registrations`);
-         else if (individualHandlers[eventID] == 1) 
-            delete individualHandlers[eventID];
-         else {
-            individualHandlers[eventID]--;
-            console.log(`Warning: twrUnregisterEvent was given an eventID (${eventID}) that has multiple registrations to this event (${event.toString()}). Unregister needs to be called ${individualHandlers[eventID]} more time(s) before it's actually removed.`);
-         }
-      } else {
+      const prevCount = individualHandlers.get(eventID);
+      if (prevCount == undefined) {
          throw new Error(`twrUnregisterEvent: Tried to unregister an eventID (${eventID}) that hasn't been registered!`);
+      } else if (prevCount == 0) {
+         throw new Error(`twrUnregisterEvent: Experienced an unexpected error! ${eventID} is registered but has 0 registrations`);
+      } else if (prevCount == 1) {
+         individualHandlers.delete(eventID);
+      } else {
+         individualHandlers.set(eventID, prevCount-1);
+         console.log(`Warning: twrUnregisterEvent was given an eventID (${eventID}) that has multiple registrations to this event (${event.toString()}). Unregister needs to be called ${prevCount-1} more time(s) before it's actually removed.`);
+      }
+   }
+   twrUnregisterAllEvents(mod: IWasmModuleAsync | IWasmModule) {
+      for (const handlers of Object.values(this.registeredEvents)) {
+         handlers.delete(mod.id);
       }
    }
 

--- a/source/twr-ts/twrconcanvas.ts
+++ b/source/twr-ts/twrconcanvas.ts
@@ -2,6 +2,7 @@ import {IConsoleCanvas, ICanvasProps, IOTypes} from "./twrcon.js";
 import {IWasmModuleAsync} from "./twrmodasync.js"
 import {IWasmModule} from "./twrmod.js";
 import {twrLibrary, TLibImports, twrLibraryInstanceRegistry} from "./twrlibrary.js";
+import { bindCanvasEvents, CanvasEventTypes, ICanvasEvents, NUM_CANVAS_EVENTS } from "./twrcanvasevents.js";
 
 enum D2DType {
     D2D_FILLRECT=1,
@@ -70,7 +71,7 @@ function calculateID(mod:IWasmModule|IWasmModuleAsync, id: number) {
    return (mod.id & (2**20 - 1)) * 2**32 + id;
 }
 
-export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas {
+export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas, ICanvasEvents {
    id:number;
    ctx:CanvasRenderingContext2D;
    element:HTMLCanvasElement
@@ -83,6 +84,19 @@ export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas {
       HTMLImageElement
    };
 
+   registeredEvents: {
+      [eventType in CanvasEventTypes]: 
+      Map<
+         number, 
+         [
+            IWasmModule|IWasmModuleAsync,
+            {
+               [eventID: number]: number
+            }
+         ]
+      >
+   };
+
    imports:TLibImports = {
       twrConGetProp:{},
       twrConDrawSeq:{},
@@ -92,7 +106,7 @@ export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas {
    libSourcePath = new URL(import.meta.url).pathname;
    interfaceName = "twrConsole";
 
-   constructor(element:HTMLCanvasElement) {
+   constructor(element:HTMLCanvasElement, selfRegisterEvents: boolean = true) {
       // all library constructors should start with these two lines
       super();
       this.id=twrLibraryInstanceRegistry.register(this);
@@ -113,6 +127,80 @@ export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas {
       c.textBaseline="top";
 
       this.props = {canvasHeight: element.height, canvasWidth: element.width, type: IOTypes.CANVAS2D}; 
+
+      if (selfRegisterEvents) {
+         bindCanvasEvents(this, element);
+      }
+      
+      this.registeredEvents = Object.values(CanvasEventTypes)
+         .filter(value => typeof value == "number")
+         .reduce((acc, eventType) => {
+            acc[eventType as CanvasEventTypes] = new Map();
+            return acc;
+         }, {} as { [eventType in CanvasEventTypes]: Map});
+   }
+
+   handleCanvasKeyEvent(event: CanvasEventTypes, key: number) {
+      const eventHandlers = this.registeredEvents[event];
+
+      for (const modID in eventHandlers) {
+         const [mod, eventIDs] = eventHandlers[modID];
+         for (const eventID in eventIDs) {
+            mod.postEvent(Number(eventID), key);
+         }
+      }
+   }
+   handleCanvasMouseEvent(event: CanvasEventTypes, x: number, y: number) {
+
+   }
+   handleCanvasWheelEvent(event: CanvasEventTypes, deltaX: number, deltaY: number, deltaZ: number, deltaMode: number) {
+
+   };
+
+   twrRegisterEvent(mod: IWasmModule|IWasmModuleAsync, eventType: number, eventID: number) {
+      if (eventType < 0 || eventType >= NUM_CANVAS_EVENTS) throw new Error(`twrRegisterEvent was given an out of bound eventType. 0 <= ${eventType} < ${NUM_CANVAS_EVENTS}`);
+
+      const event = eventType as CanvasEventTypes;
+      
+      const eventHandlers = this.registeredEvents[event];
+
+      if (!(mod.id in eventHandlers))
+         eventHandlers[mod.id] = [mod, {}];
+      
+      const individualHandlers = eventHandlers[mod.id][1];
+      
+      if (eventID in individualHandlers) {
+         console.log(`Warning: twrRegisterEvent was given an eventID (${eventID}) that was already registered to this event (${event.toString()})!`);
+         individualHandlers[eventID]++;
+      } else {
+         individualHandlers[eventID] = 1;
+      }
+   };
+
+   twrUnregisterEvent(mod: IWasmModule|IWasmModuleAsync, eventType: number, eventID: number) {
+      if (eventType < 0 || eventType >= NUM_CANVAS_EVENTS) throw new Error(`twrUnregisterEvent was given an out of bounds eventType. 0 <= ${eventType} < ${NUM_CANVAS_EVENTS}`);
+
+      const event = eventType as CanvasEventTypes;
+
+      const eventHandlers = this.registeredEvents[event];
+
+      if (!(mod.id in eventHandlers))
+         throw new Error(`twrUnregisterEvent: tried to unregister an event when this module has never registered an event!`);
+
+      const individualHandlers = eventHandlers[mod.id][1];
+
+      if (eventID in individualHandlers) {
+         if (individualHandlers[eventID] == 0)
+            throw new Error(`twrUnregisterEvent: Experienced an unexpected error! ${eventID} is registered but has 0 registrations`);
+         else if (individualHandlers[eventID] == 1) 
+            delete individualHandlers[eventID];
+         else {
+            individualHandlers[eventID]--;
+            console.log(`Warning: twrUnregisterEvent was given an eventID (${eventID}) that has multiple registrations to this event (${event.toString()}). Unregister needs to be called ${individualHandlers[eventID]} more time(s) before it's actually removed.`);
+         }
+      } else {
+         throw new Error(`twrUnregisterEvent: Tried to unregister an eventID (${eventID}) that hasn't been registered!`);
+      }
    }
 
 

--- a/source/twr-ts/twrconcanvas.ts
+++ b/source/twr-ts/twrconcanvas.ts
@@ -106,7 +106,7 @@ export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas, ICan
    libSourcePath = new URL(import.meta.url).pathname;
    interfaceName = "twrConsole";
 
-   constructor(element:HTMLCanvasElement, selfRegisterEvents: boolean = true) {
+   constructor(element:HTMLCanvasElement, ctxOptions?: CanvasRenderingContext2DSettings, selfRegisterEvents: boolean = true) {
       // all library constructors should start with these two lines
       super();
       this.id=twrLibraryInstanceRegistry.register(this);
@@ -176,7 +176,7 @@ export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas, ICan
       const individualHandlers = eventHandlers.get(mod.id)![1];
       
       const prevCount = individualHandlers.get(eventID) ?? 0;
-      if (prevCount >= 0)
+      if (prevCount > 0)
          console.log(`Warning: twrRegisterEvent was given an eventID (${eventID}) that was already registered to this event (${event.toString()})!`);
 
       individualHandlers.set(eventID, prevCount+1);

--- a/source/twr-ts/twrconcanvas.ts
+++ b/source/twr-ts/twrconcanvas.ts
@@ -75,7 +75,7 @@ type EventHandlerMap = Map<
    number,
    [
       IWasmModule|IWasmModuleAsync,
-      Map<number, number>
+      Set<number>
    ]
 >;
 
@@ -150,14 +150,17 @@ export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas, ICan
       }
    }
    handleCanvasKeyEvent(event: CanvasEventTypes, key: number) {
-      console.log(`${event}, ${key}`);
+      // console.log(`${event}, ${key}`);
       this.internalSendEvent(event, key);
+      return false; //for now, modules can't intercept events, only receive them
    }
    handleCanvasMouseEvent(event: CanvasEventTypes, x: number, y: number) {
       this.internalSendEvent(event, x, y);
+      return false; //for now, modules can't intercept events, only receive them
    }
    handleCanvasWheelEvent(event: CanvasEventTypes, deltaX: number, deltaY: number, deltaZ: number, deltaMode: number) {
       this.internalSendEvent(event, deltaX, deltaY, deltaZ, deltaMode);
+      return false; //for now, modules can't intercept events, only receive them
    }
    handleCanvasAnimationFrameEvent(event: CanvasEventTypes, delta: number) {
       this.internalSendEvent(event, delta);
@@ -171,15 +174,14 @@ export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas, ICan
       const eventHandlers = this.registeredEvents[event];
 
       if (!eventHandlers.has(mod.id))
-         eventHandlers.set(mod.id, [mod, new Map()]);
+         eventHandlers.set(mod.id, [mod, new Set()]);
       
       const individualHandlers = eventHandlers.get(mod.id)![1];
       
-      const prevCount = individualHandlers.get(eventID) ?? 0;
-      if (prevCount > 0)
-         console.log(`Warning: twrRegisterEvent was given an eventID (${eventID}) that was already registered to this event (${event.toString()})!`);
+      if (eventID in individualHandlers)
+         throw new Error(`Error: twrRegisterEvent was given an eventID (${eventID}) that was already registered to this event (${event.toString()})!`);
 
-      individualHandlers.set(eventID, prevCount+1);
+      individualHandlers.add(eventID);
    };
 
    twrUnregisterEvent(mod: IWasmModule|IWasmModuleAsync, eventType: number, eventID: number) {
@@ -194,16 +196,10 @@ export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas, ICan
 
       const individualHandlers = eventHandlers.get(mod.id)![1];
 
-      const prevCount = individualHandlers.get(eventID);
-      if (prevCount == undefined) {
+      if (!(eventID in individualHandlers)) {
          throw new Error(`twrUnregisterEvent: Tried to unregister an eventID (${eventID}) that hasn't been registered!`);
-      } else if (prevCount == 0) {
-         throw new Error(`twrUnregisterEvent: Experienced an unexpected error! ${eventID} is registered but has 0 registrations`);
-      } else if (prevCount == 1) {
-         individualHandlers.delete(eventID);
       } else {
-         individualHandlers.set(eventID, prevCount-1);
-         console.log(`Warning: twrUnregisterEvent was given an eventID (${eventID}) that has multiple registrations to this event (${event.toString()}). Unregister needs to be called ${prevCount-1} more time(s) before it's actually removed.`);
+         individualHandlers.delete(eventID);
       }
    }
    twrUnregisterAllEvents(mod: IWasmModuleAsync | IWasmModule) {

--- a/source/twr-ts/twrconcanvas.ts
+++ b/source/twr-ts/twrconcanvas.ts
@@ -140,6 +140,15 @@ export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas, ICan
          }, {} as { [eventType in CanvasEventTypes]: EventHandlerMap});
    }
 
+   resizeCanvas(width: number, height: number) {
+      this.element.width = width;
+      this.element.height = height;
+      this.props.canvasWidth = width;
+      this.props.canvasHeight = height;
+
+      // this.ctx = this.element.getContext("2d")!;
+   }
+
    internalSendEvent(event: CanvasEventTypes, ...args: number[]) {
       const eventHandlers = this.registeredEvents[event];
 

--- a/source/twr-ts/twrconcanvas.ts
+++ b/source/twr-ts/twrconcanvas.ts
@@ -154,8 +154,8 @@ export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas, ICan
       this.internalSendEvent(event, key);
       return false; //for now, modules can't intercept events, only receive them
    }
-   handleCanvasMouseEvent(event: CanvasEventTypes, x: number, y: number) {
-      this.internalSendEvent(event, x, y);
+   handleCanvasMouseEvent(event: CanvasEventTypes, x: number, y: number, button: number) {
+      this.internalSendEvent(event, x, y, button);
       return false; //for now, modules can't intercept events, only receive them
    }
    handleCanvasWheelEvent(event: CanvasEventTypes, deltaX: number, deltaY: number, deltaZ: number, deltaMode: number) {

--- a/source/twr-ts/twrconcanvas.ts
+++ b/source/twr-ts/twrconcanvas.ts
@@ -74,7 +74,7 @@ function calculateID(mod:IWasmModule|IWasmModuleAsync, id: number) {
 type EventHandlerMap = Map<
    number,
    [
-      IWasmModule|IWasmModuleAsync,
+      WeakRef<IWasmModule|IWasmModuleAsync>,
       Set<number>
    ]
 >;
@@ -141,21 +141,31 @@ export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas, ICan
    }
 
    resizeCanvas(width: number, height: number) {
+      const imageData = this.ctx.getImageData(0, 0, this.element.width, this.element.height);
       this.element.width = width;
       this.element.height = height;
       this.props.canvasWidth = width;
       this.props.canvasHeight = height;
 
+      this.ctx.putImageData(imageData, 0, 0);
       // this.ctx = this.element.getContext("2d")!;
    }
 
    internalSendEvent(event: CanvasEventTypes, ...args: number[]) {
       const eventHandlers = this.registeredEvents[event];
-
-      for (const [mod, eventIDs] of eventHandlers.values()) {
-         for (const eventID of eventIDs.keys()) {
-            mod.postEvent(eventID, ...args);
+      let toDelete: number[] = [];
+      for (const [modID, [mod, eventIDs]] of eventHandlers) {
+         const derefedMod = mod.deref();
+         if (derefedMod) {
+            for (const eventID of eventIDs.keys()) {
+               derefedMod.postEvent(eventID, ...args);
+            }
+         } else {
+            toDelete.push(modID);
          }
+      }
+      for (const modID of toDelete) {
+         eventHandlers.delete(modID);
       }
    }
    handleCanvasKeyEvent(event: CanvasEventTypes, key: number) {
@@ -183,7 +193,7 @@ export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas, ICan
       const eventHandlers = this.registeredEvents[event];
 
       if (!eventHandlers.has(mod.id))
-         eventHandlers.set(mod.id, [mod, new Set()]);
+         eventHandlers.set(mod.id, [new WeakRef(mod), new Set()]);
       
       const individualHandlers = eventHandlers.get(mod.id)![1];
       

--- a/source/twr-ts/twrconcanvas.ts
+++ b/source/twr-ts/twrconcanvas.ts
@@ -158,7 +158,10 @@ export class twrConsoleCanvas extends twrLibrary implements IConsoleCanvas, ICan
    }
    handleCanvasWheelEvent(event: CanvasEventTypes, deltaX: number, deltaY: number, deltaZ: number, deltaMode: number) {
       this.internalSendEvent(event, deltaX, deltaY, deltaZ, deltaMode);
-   };
+   }
+   handleCanvasAnimationFrameEvent(event: CanvasEventTypes, delta: number) {
+      this.internalSendEvent(event, delta);
+   }
 
    twrRegisterEvent(mod: IWasmModule|IWasmModuleAsync, eventType: number, eventID: number) {
       if (eventType < 0 || eventType >= NUM_CANVAS_EVENTS) throw new Error(`twrRegisterEvent was given an out of bound eventType. 0 <= ${eventType} < ${NUM_CANVAS_EVENTS}`);

--- a/source/twr-ts/twrcondummy.ts
+++ b/source/twr-ts/twrcondummy.ts
@@ -35,8 +35,9 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       twrWindowMenuAddWidget: {},
       twrWindowMenuWidgetAddCallback: {},
       twrWindowMenuDeleteWidget: {},
-      twrWindowMenuRadioMenuAddOption: {},
+      // twrWindowMenuRadioMenuAddOption: {},
       twrWindowMenuWidgetSetVisibility: {},
+      twrWindowMenuRadioItemMerge: {},
    };
 
    libSourcePath = new URL(import.meta.url).pathname;
@@ -156,10 +157,13 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
    twrWindowMenuDeleteWidget(mod: IWasmModuleAsync | IWasmModule, widgetID: number) {
       throw new Error("internal error");
    }
-   twrWindowMenuRadioMenuAddOption(mod: IWasmModuleAsync | IWasmModule, widgetID: number, optionPtr: number) {
+   // twrWindowMenuRadioMenuAddOption(mod: IWasmModuleAsync | IWasmModule, widgetID: number, optionPtr: number) {
+   //    throw new Error("internal error");
+   // }
+   twrWindowMenuWidgetSetVisibility(mod: IWasmModuleAsync | IWasmModule, widgetID: number, visibility: number) {
       throw new Error("internal error");
    }
-   twrWindowMenuWidgetSetVisibility(mod: IWasmModuleAsync | IWasmModule, widgetID: number, visibility: number) {
+   twrWindowMenuRadioItemMerge(mod: IWasmModuleAsync | IWasmModule, widgetID1: number, widgetID2: number) {
       throw new Error("internal error");
    }
 }

--- a/source/twr-ts/twrcondummy.ts
+++ b/source/twr-ts/twrcondummy.ts
@@ -1,4 +1,4 @@
-import {IConsoleStreamOut, IConsoleStreamIn, IConsoleCanvas, IConsoleAddressable, ICanvasProps } from "./twrcon.js"
+import {IConsoleStreamOut, IConsoleStreamIn, IConsoleCanvas, IConsoleAddressable, ICanvasProps, IConsoleWindow } from "./twrcon.js"
 import {IWasmModuleAsync} from "./twrmodasync.js";
 import {IWasmModule} from "./twrmod.js"
 import {twrLibrary, TLibImports, twrLibraryInstanceRegistry} from "./twrlibrary.js";
@@ -8,7 +8,7 @@ import {twrLibrary, TLibImports, twrLibraryInstanceRegistry} from "./twrlibrary.
 // These functions should never be called, because twrLibrary routes a call (like io_cls(id)) to the correct console instance based on id
 // see TODO comments in twrLibrary.ts for possible better fixes
 
-export default class twrConsoleDummy extends twrLibrary implements IConsoleStreamIn, IConsoleStreamOut, IConsoleAddressable, IConsoleCanvas  {
+export default class twrConsoleDummy extends twrLibrary implements IConsoleStreamIn, IConsoleStreamOut, IConsoleAddressable, IConsoleCanvas, IConsoleWindow  {
    id:number;
 
    imports:TLibImports = {
@@ -30,6 +30,7 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       twrRegisterEvent:{},
       twrUnregisterEvent:{},
       twrUnregisterAllEvents:{},
+      twrGetAppCanvasJSID:{},
    };
 
    libSourcePath = new URL(import.meta.url).pathname;
@@ -130,6 +131,10 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       throw new Error("internal error");
    }
    twrUnregisterAllEvents(callingMod: IWasmModuleAsync | IWasmModule)  {
+      throw new Error("internal error");
+   }
+   
+   twrGetAppCanvasJSID(callingMod: IWasmModuleAsync | IWasmModule) : number {
       throw new Error("internal error");
    }
 }

--- a/source/twr-ts/twrcondummy.ts
+++ b/source/twr-ts/twrcondummy.ts
@@ -40,6 +40,7 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       twrWindowMenuRadioItemMerge: {},
       twrWindowMenuWidgetSetProp: {},
       twrWindowMenuWidgetGetProp: {isAsyncFunction: true},
+      twrWindowMenuWidgetListProps: {},
    };
 
    libSourcePath = new URL(import.meta.url).pathname;
@@ -172,6 +173,9 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       throw new Error("internal error");
    }
    twrWindowMenuWidgetGetProp(mod: IWasmModule, widgetID: number, propNamePtr: number): number {
+      throw new Error("internal error");
+   }
+   twrWindowMenuWidgetListProps(mod: IWasmModuleAsync | IWasmModule, widgetID: number, lengthPtr: number): number | Promise<number> {
       throw new Error("internal error");
    }
 }

--- a/source/twr-ts/twrcondummy.ts
+++ b/source/twr-ts/twrcondummy.ts
@@ -35,12 +35,10 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       twrWindowMenuAddWidget: {},
       twrWindowMenuWidgetAddCallback: {},
       twrWindowMenuDeleteWidget: {},
-      // twrWindowMenuRadioMenuAddOption: {},
-      twrWindowMenuWidgetSetVisibility: {},
       twrWindowMenuRadioItemMerge: {},
       twrWindowMenuWidgetSetProp: {},
       twrWindowMenuWidgetGetProp: {isAsyncFunction: true},
-      twrWindowMenuWidgetListProps: {},
+      twrWindowMenuWidgetListProps: {isAsyncFunction: true},
    };
 
    libSourcePath = new URL(import.meta.url).pathname;
@@ -158,12 +156,6 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       throw new Error("internal Error!");
    }
    twrWindowMenuDeleteWidget(mod: IWasmModuleAsync | IWasmModule, widgetID: number) {
-      throw new Error("internal error");
-   }
-   // twrWindowMenuRadioMenuAddOption(mod: IWasmModuleAsync | IWasmModule, widgetID: number, optionPtr: number) {
-   //    throw new Error("internal error");
-   // }
-   twrWindowMenuWidgetSetVisibility(mod: IWasmModuleAsync | IWasmModule, widgetID: number, visibility: number) {
       throw new Error("internal error");
    }
    twrWindowMenuRadioItemMerge(mod: IWasmModuleAsync | IWasmModule, widgetID1: number, widgetID2: number) {

--- a/source/twr-ts/twrcondummy.ts
+++ b/source/twr-ts/twrcondummy.ts
@@ -31,6 +31,7 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       twrUnregisterEvent:{},
       twrUnregisterAllEvents:{},
       twrGetAppCanvasJSID:{},
+      twrWindowAddMenu:{},
    };
 
    libSourcePath = new URL(import.meta.url).pathname;
@@ -135,6 +136,9 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
    }
    
    twrGetAppCanvasJSID(callingMod: IWasmModuleAsync | IWasmModule) : number {
+      throw new Error("internal error");
+   }
+   twrWindowAddMenu(callingMod: IWasmModuleAsync | IWasmModule, textPtr: number): number {
       throw new Error("internal error");
    }
 }

--- a/source/twr-ts/twrcondummy.ts
+++ b/source/twr-ts/twrcondummy.ts
@@ -34,6 +34,7 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       twrWindowAddMenu:{},
       twrWindowMenuAddWidget: {},
       twrWindowMenuButtonAddCallback: {},
+      twrWindowMenuDeleteWidget: {},
    };
 
    libSourcePath = new URL(import.meta.url).pathname;
@@ -148,5 +149,8 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
    }
    twrWindowMenuButtonAddCallback(mod: IWasmModuleAsync | IWasmModule, widgetID: number, eventID: number, extraPtr: number) {
       throw new Error("internal Error!");
+   }
+   twrWindowMenuDeleteWidget(mod: IWasmModuleAsync | IWasmModule, widgetID: number) {
+      throw new Error("internal error");
    }
 }

--- a/source/twr-ts/twrcondummy.ts
+++ b/source/twr-ts/twrcondummy.ts
@@ -40,6 +40,7 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       twrWindowMenuWidgetGetProp: {isAsyncFunction: true},
       twrWindowMenuWidgetListProps: {isAsyncFunction: true},
       twrWindowMenuWidgetGetPropDetails: {},
+      twrWindowMenuListProps: {isAsyncFunction: true},
    };
 
    libSourcePath = new URL(import.meta.url).pathname;
@@ -172,6 +173,9 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       throw new Error("internal error");
    }
    twrWindowMenuWidgetGetPropDetails(mod: IWasmModule, widgetID: number, detailsStructPtr: number) {
+      throw new Error("internal error");
+   }
+   twrWindowMenuListProps(mod: IWasmModule, lengthPtr: number): number {
       throw new Error("internal error");
    }
 }

--- a/source/twr-ts/twrcondummy.ts
+++ b/source/twr-ts/twrcondummy.ts
@@ -36,6 +36,7 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       twrWindowMenuWidgetAddCallback: {},
       twrWindowMenuDeleteWidget: {},
       twrWindowMenuRadioMenuAddOption: {},
+      twrWindowMenuWidgetSetVisibility: {},
    };
 
    libSourcePath = new URL(import.meta.url).pathname;
@@ -46,6 +47,7 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       super();
       this.id=twrLibraryInstanceRegistry.register(this);
    }
+   
    element?: HTMLElement | undefined;
 
    
@@ -155,6 +157,9 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       throw new Error("internal error");
    }
    twrWindowMenuRadioMenuAddOption(mod: IWasmModuleAsync | IWasmModule, widgetID: number, optionPtr: number) {
+      throw new Error("internal error");
+   }
+   twrWindowMenuWidgetSetVisibility(mod: IWasmModuleAsync | IWasmModule, widgetID: number, visibility: number) {
       throw new Error("internal error");
    }
 }

--- a/source/twr-ts/twrcondummy.ts
+++ b/source/twr-ts/twrcondummy.ts
@@ -30,7 +30,7 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       twrRegisterEvent:{},
       twrUnregisterEvent:{},
       twrUnregisterAllEvents:{},
-      twrGetAppCanvasJSID:{},
+      twrGetDrawCanvasJSID:{},
       twrWindowAddMenu:{},
       twrWindowMenuAddWidget: {},
       twrWindowMenuWidgetAddCallback: {},
@@ -147,7 +147,7 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       throw new Error("internal error");
    }
    
-   twrGetAppCanvasJSID(callingMod: IWasmModuleAsync | IWasmModule) : number {
+   twrGetDrawCanvasJSID(callingMod: IWasmModuleAsync | IWasmModule) : number {
       throw new Error("internal error");
    }
    twrWindowAddMenu(callingMod: IWasmModuleAsync | IWasmModule, textPtr: number): number {

--- a/source/twr-ts/twrcondummy.ts
+++ b/source/twr-ts/twrcondummy.ts
@@ -38,6 +38,8 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       // twrWindowMenuRadioMenuAddOption: {},
       twrWindowMenuWidgetSetVisibility: {},
       twrWindowMenuRadioItemMerge: {},
+      twrWindowMenuWidgetSetProp: {},
+      twrWindowMenuWidgetGetProp: {isAsyncFunction: true},
    };
 
    libSourcePath = new URL(import.meta.url).pathname;
@@ -164,6 +166,12 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       throw new Error("internal error");
    }
    twrWindowMenuRadioItemMerge(mod: IWasmModuleAsync | IWasmModule, widgetID1: number, widgetID2: number) {
+      throw new Error("internal error");
+   }
+   twrWindowMenuWidgetSetProp(mod: IWasmModuleAsync | IWasmModule, widgetID: number, propNamePtr: number, dataPtr: number) {
+      throw new Error("internal error");
+   }
+   twrWindowMenuWidgetGetProp(mod: IWasmModule, widgetID: number, propNamePtr: number): number {
       throw new Error("internal error");
    }
 }

--- a/source/twr-ts/twrcondummy.ts
+++ b/source/twr-ts/twrcondummy.ts
@@ -32,6 +32,8 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       twrUnregisterAllEvents:{},
       twrGetAppCanvasJSID:{},
       twrWindowAddMenu:{},
+      twrWindowMenuAddWidget: {},
+      twrWindowMenuButtonAddCallback: {},
    };
 
    libSourcePath = new URL(import.meta.url).pathname;
@@ -140,5 +142,11 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
    }
    twrWindowAddMenu(callingMod: IWasmModuleAsync | IWasmModule, textPtr: number): number {
       throw new Error("internal error");
+   }
+   twrWindowMenuAddWidget(mod: IWasmModuleAsync | IWasmModule, menuID: number, consPtr: number): number {
+      throw new Error("internal error");
+   }
+   twrWindowMenuButtonAddCallback(mod: IWasmModuleAsync | IWasmModule, widgetID: number, eventID: number, extraPtr: number) {
+      throw new Error("internal Error!");
    }
 }

--- a/source/twr-ts/twrcondummy.ts
+++ b/source/twr-ts/twrcondummy.ts
@@ -41,6 +41,8 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       twrWindowMenuWidgetListProps: {isAsyncFunction: true},
       twrWindowMenuWidgetGetPropDetails: {},
       twrWindowMenuListProps: {isAsyncFunction: true},
+      twrWindowMenuSetProp: {isAsyncFunction: true},
+      twrWindowMenuGetProp: {},
    };
 
    libSourcePath = new URL(import.meta.url).pathname;
@@ -178,4 +180,11 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
    twrWindowMenuListProps(mod: IWasmModule, lengthPtr: number): number {
       throw new Error("internal error");
    }
+   twrWindowMenuSetProp(mod: IWasmModuleAsync | IWasmModule, propNamePtr: number, dataPtr: number): void {
+      throw new Error("internal Error");
+   }
+   twrWindowMenuGetProp(mod: IWasmModule, propNamePtr: number): number {
+      throw new Error("internal Error");
+   }
+
 }

--- a/source/twr-ts/twrcondummy.ts
+++ b/source/twr-ts/twrcondummy.ts
@@ -39,6 +39,7 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       twrWindowMenuWidgetSetProp: {},
       twrWindowMenuWidgetGetProp: {isAsyncFunction: true},
       twrWindowMenuWidgetListProps: {isAsyncFunction: true},
+      twrWindowMenuWidgetGetPropDetails: {},
    };
 
    libSourcePath = new URL(import.meta.url).pathname;
@@ -167,7 +168,10 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
    twrWindowMenuWidgetGetProp(mod: IWasmModule, widgetID: number, propNamePtr: number): number {
       throw new Error("internal error");
    }
-   twrWindowMenuWidgetListProps(mod: IWasmModuleAsync | IWasmModule, widgetID: number, lengthPtr: number): number | Promise<number> {
+   twrWindowMenuWidgetListProps(mod: IWasmModule, widgetID: number, lengthPtr: number): number {
+      throw new Error("internal error");
+   }
+   twrWindowMenuWidgetGetPropDetails(mod: IWasmModule, widgetID: number, detailsStructPtr: number) {
       throw new Error("internal error");
    }
 }

--- a/source/twr-ts/twrcondummy.ts
+++ b/source/twr-ts/twrcondummy.ts
@@ -27,6 +27,9 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       twrConSetColors:{noBlock:true},
       twrConDrawSeq:{},
       twrConLoadImage:{isModuleAsyncOnly:true, isAsyncFunction:true},
+      twrRegisterEvent:{},
+      twrUnregisterEvent:{},
+      twrUnregisterAllEvents:{},
    };
 
    libSourcePath = new URL(import.meta.url).pathname;
@@ -37,6 +40,8 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       super();
       this.id=twrLibraryInstanceRegistry.register(this);
    }
+   element?: HTMLElement | undefined;
+
    
    twrConGetProp(callingMod:IWasmModule|IWasmModuleAsync, pn:number):number {
       throw new Error("internal error");
@@ -118,4 +123,13 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       throw new Error("internal error");
    }
 
+   twrRegisterEvent(callingMod: IWasmModuleAsync | IWasmModule, eventType: number, eventID: number)  {
+      throw new Error("internal error");
+   }
+   twrUnregisterEvent(callingMod: IWasmModuleAsync | IWasmModule, eventType: number, eventID: number)  {
+      throw new Error("internal error");
+   }
+   twrUnregisterAllEvents(callingMod: IWasmModuleAsync | IWasmModule)  {
+      throw new Error("internal error");
+   }
 }

--- a/source/twr-ts/twrcondummy.ts
+++ b/source/twr-ts/twrcondummy.ts
@@ -33,8 +33,9 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
       twrGetAppCanvasJSID:{},
       twrWindowAddMenu:{},
       twrWindowMenuAddWidget: {},
-      twrWindowMenuButtonAddCallback: {},
+      twrWindowMenuWidgetAddCallback: {},
       twrWindowMenuDeleteWidget: {},
+      twrWindowMenuRadioMenuAddOption: {},
    };
 
    libSourcePath = new URL(import.meta.url).pathname;
@@ -147,10 +148,13 @@ export default class twrConsoleDummy extends twrLibrary implements IConsoleStrea
    twrWindowMenuAddWidget(mod: IWasmModuleAsync | IWasmModule, menuID: number, consPtr: number): number {
       throw new Error("internal error");
    }
-   twrWindowMenuButtonAddCallback(mod: IWasmModuleAsync | IWasmModule, widgetID: number, eventID: number, extraPtr: number) {
+   twrWindowMenuWidgetAddCallback(mod: IWasmModuleAsync | IWasmModule, widgetID: number, eventID: number, extraPtr: number) {
       throw new Error("internal Error!");
    }
    twrWindowMenuDeleteWidget(mod: IWasmModuleAsync | IWasmModule, widgetID: number) {
+      throw new Error("internal error");
+   }
+   twrWindowMenuRadioMenuAddOption(mod: IWasmModuleAsync | IWasmModule, widgetID: number, optionPtr: number) {
       throw new Error("internal error");
    }
 }

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -74,10 +74,10 @@ interface Widget {
    readonly handledEvents: MenuItemEvents[];
    set visible(val: boolean);
    get visible(): boolean;
-   // set width(val: number|undefined);
-   // get width(): number|undefined;
-   // set height(val: number|undefined);
-   // get height(): number|undefined;
+   // set width(val: number);
+   // get width(): number;
+   // set height(val: number);
+   // get height(): number;
    
    getMinSize: () => [number, number];
    render: (ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) => void;
@@ -98,42 +98,46 @@ abstract class WidgetImpl implements Widget {
    readonly id: number;
    abstract readonly handledEvents: MenuItemEvents[];
 
-   protected _width?: number = undefined;
-   protected _height?: number = undefined;
+   protected abstract _width: number;
+   protected abstract _height: number;
    protected _visible: boolean = true;
 
-   constructor(globalProps: GlobalWidgetProperties, parent: WidgetManager) {
+   constructor(globalProps: GlobalWidgetProperties, parent: WidgetManager, cons: WidgetConstructor) {
       this.id = ++NEXT_WIDGET_ID;
       this.parent = parent;
       this.globalProps = globalProps;
+
    }
    abstract getMinSize(): [number, number];
    abstract render(ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number): void;
    abstract handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData): void;
    abstract delete(ctx: CanvasRenderingContext2D): Widget[];
    abstract fullUpdate(ctx: CanvasRenderingContext2D): void;
-   protected abstract propograteUpdate(ctx?: CanvasRenderingContext2D): void;
+   protected abstract propagateUpdate(ctx?: CanvasRenderingContext2D): void;
+
+   abstract getDimensions(): [number, number];
+   abstract setDimensions(width?: number, height?: number): void;
 
    set visible(val: boolean) {
       if (this._visible != val) {
          this._visible = val;
-         this.propograteUpdate();
+         this.propagateUpdate();
       }
    }
    get visible() {return this._visible};
 
-   set width(val: number|undefined) {
+   set width(val: number) {
       if (this._width != val) {
          this._width = val;
-         this.propograteUpdate();
+         this.propagateUpdate();
       }
    }
    get width() {return this._width};
 
-   set height(val: number|undefined) {
+   set height(val: number) {
       if (this._height != val) {
          this._height = val;
-         this.propograteUpdate();
+         this.propagateUpdate();
       }
    }
 
@@ -161,37 +165,38 @@ interface ButtonWidgetConstructor extends WidgetConstructor {
    reservePrefixSpace?: boolean;
 }
  
-class Button implements Widget, WidgetEvents {
-   readonly globalProps: GlobalWidgetProperties;
-   readonly parent: WidgetManager; 
-   readonly id: number;
+class Button extends WidgetImpl implements WidgetEvents {
+   // readonly globalProps: GlobalWidgetProperties;
+   // readonly parent: WidgetManager; 
+   // readonly id: number;
    readonly handledEvents: MenuItemEvents[] = [
       MenuItemEvents.CLICKED,
       MenuItemEvents.HOVERING,
       MenuItemEvents.UNHOVERED
    ];
 
-   private width: number;
-   private height: number;
+   // private width: number;
+   // private height: number;
 
-   private textOffsets: [number, number, number];
+   protected _width: number;
+   protected _height: number;
 
-   private updateProperty() {
-      const ctx = this.parent.getCtx();
-      this.textOffsets = this.getTextOffsets(ctx);
-      this.parent.childUpdated(ctx, this);
-   }
+   // private updateProperty() {
+   //    const ctx = this.parent.getCtx();
+   //    this.textOffsets = this.getTextOffsets(ctx);
+   //    this.parent.childUpdated(ctx, this);
+   // }
    private _text: string;
    private _prefixText?: string;
    private _suffixText?: string;
    private centeredHorizontally: boolean;
    private reservePrefixSpace: boolean;
 
-   set text(val: string) {this._text = val; this.updateProperty()};
+   set text(val: string) {this._text = val; this.propagateUpdate()};
    get text(): string {return this._text};
-   set prefixText(val: string|undefined) {this._prefixText = val; this.updateProperty()};
+   set prefixText(val: string|undefined) {this._prefixText = val; this.propagateUpdate()};
    get prefixText(): string|undefined {return this._prefixText};
-   set suffixText(val: string|undefined) {this._suffixText = val; this.updateProperty()};
+   set suffixText(val: string|undefined) {this._suffixText = val; this.propagateUpdate()};
    get suffixText(): string|undefined {return this._suffixText};
 
 
@@ -199,29 +204,89 @@ class Button implements Widget, WidgetEvents {
    private selected: boolean = false;
    private events: Set<((ctx: CanvasRenderingContext2D) => void)> = new Set();
 
-   private _visible: boolean = true;
+   // private _visible: boolean = true;
+
+   // private calculatedWidth: number;
+   // private calculatedHeight: number;
+   // private textOffsets: [number, number, number];
+   private calculatedFields: {
+      width: number,
+      height: number,
+      textOffsets: {
+         mainTextX: number,
+         suffixX: number,
+         y: number,
+      },
+   } = {
+      width: 0,
+      height: 0,
+      textOffsets: {
+         mainTextX: 0,
+         suffixX: 0,
+         y: 0,
+      }
+   };
 
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, cons: ButtonWidgetConstructor, globalProps: GlobalWidgetProperties) {
-      this.parent = parent;
-      this.id = id;
+      super(globalProps, parent, cons);
+      // this.parent = parent;
+      // this.id = id;
 
       this._text = cons.text;
       this._prefixText = cons.prefixText;
       this._suffixText = cons.suffixText;
       this.centeredHorizontally = cons.centeredHorizontally ?? false;
-      this.globalProps = globalProps;
+      // this.globalProps = globalProps;
 
       this.reservePrefixSpace = cons.reservePrefixSpace ?? true;
 
       const [minWidth, minHeight] = this.getMinSize();
-
-      this.width = cons.width ?? minWidth;
-      this.height = cons.height ?? minHeight;
+      this._width = cons.width ?? minWidth;
+      this._height = cons.height ?? minHeight;
+      // this.calculatedWidth = minWidth;
+      // this.calculatedHeight = minHeight;
+      // this.width = cons.width ?? minWidth;
+      // this.height = cons.height ?? minHeight;
       
-      this.textOffsets = this.getTextOffsets(ctx);
+      // this.textOffsets = this.getTextOffsets(ctx);
+      this.updateCalculatedFields(ctx);
    }
+
+   protected propagateUpdate(ctx?: CanvasRenderingContext2D): void {
+      const n_ctx = ctx ?? this.parent.getCtx();
+
+      this.updateCalculatedFields(n_ctx);
+      this.parent.childUpdated(n_ctx);
+   }
+
+   private updateCalculatedFields(ctx: CanvasRenderingContext2D) {
+      const [minWidth, minHeight, minPrefix, minSuffix] = this.getFullMinSize(ctx);
+
+      const calcFields = this.calculatedFields;
+      calcFields.width = minWidth;
+      calcFields.height = minHeight;
+
+      const textOffsets = calcFields.textOffsets;
+
+      function getHeight(ctx: CanvasRenderingContext2D, font: string): number {
+         ctx.save();minHeight
+         ctx.font = font;
+         const measure = ctx.measureText("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.!?*&^%$#@)(0123456789-=_+`~[]{}\\|;:'\"");
+         ctx.restore();
+
+         return measure.actualBoundingBoxAscent + measure.actualBoundingBoxDescent;
+      }
+
+      textOffsets.mainTextX = this.centeredHorizontally 
+         ? (this.width - (minWidth - minPrefix - minSuffix))/2.0 
+         : minPrefix;
+      
+      textOffsets.y = (this.height + getHeight(ctx, this.getFont()))/2.0;
+      textOffsets.suffixX = minSuffix
+   }
+
    fullUpdate(ctx: CanvasRenderingContext2D) {
-      this.textOffsets = this.getTextOffsets(ctx);
+      this.updateCalculatedFields(ctx);
    }
    delete(ctx: CanvasRenderingContext2D): Widget[] {
       this.parent.handleDelete(ctx, this);
@@ -232,30 +297,33 @@ class Button implements Widget, WidgetEvents {
       return this.globalProps.widgetTextFont;
    }
 
-   set visible(visible: boolean) {
-      if (this._visible != visible) {
-         this._visible = visible;
-         this.parent.childUpdated(this.parent.getCtx(), this, false);
-      }
-   }
-   get visible() {
-      return this._visible;
-   }
+   // set visible(visible: boolean) {
+   //    if (this._visible != visible) {
+   //       this._visible = visible;
+   //       this.parent.childUpdated(this.parent.getCtx(), this, false);
+   //    }
+   // }
+   // get visible() {
+   //    return this._visible;
+   // }
 
    getDimensions(): [number, number] {
-      return [this.width, this.height];
+      return [
+         this.width, 
+         this.height
+      ];
    }
    setDimensions(width?: number, height?: number) {
-      this.height = height ?? this.height;
-      this.width = width ?? this.width;
+      if (
+         (width != undefined && width != this._width)
+         || (height != undefined && height != this._height)
+      ) {
+         this._height = height ?? this._height;
+         this._width = width ?? this._width;
 
-      const ctx = this.parent.getCtx();
-
-      if (height != undefined || width != undefined)
-         this.textOffsets = this.getTextOffsets(ctx);
-      
-      if (height != undefined || width != undefined)
-         this.parent.childUpdated(ctx);
+         console.log(`new dimensions (${this._text}): (${this._width}, ${this._height})`);
+         this.propagateUpdate();
+      }
    }
 
    private getFullMinSize(ctx: CanvasRenderingContext2D): [number, number, number, number] {
@@ -297,37 +365,50 @@ class Button implements Widget, WidgetEvents {
       return [minWidth, minHeight, minPrefix, minSuffix];
    }
    getMinSize(): [number, number] {
-      const [width, height,,] = this.getFullMinSize(this.parent.getCtx());
+      // const [width, height,,] = this.getFullMinSize(this.parent.getCtx());
       // console.log(`button min size (${this._text}), (${width}, ${height})`)
-      return [width, height];
-   }
-   getTextOffsets(ctx: CanvasRenderingContext2D): [number, number, number] {
-      const [minWidth, minHeight, minPrefix, minSuffix] = this.getFullMinSize(ctx);
-
-      function getHeight(ctx: CanvasRenderingContext2D, font: string): number {
-         ctx.save();minHeight
-         ctx.font = font;
-         const measure = ctx.measureText("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.!?*&^%$#@)(0123456789-=_+`~[]{}\\|;:'\"");
-         ctx.restore();
-
-         return measure.actualBoundingBoxAscent + measure.actualBoundingBoxDescent;
-      }
-
+      // return [width, height];
+      console.log(`button min size (${this._text}): (${this.calculatedFields.width}, ${this.calculatedFields.height})`);
       return [
-         this.centeredHorizontally ? (this.width - (minWidth - minPrefix - minSuffix))/2.0 : minPrefix,
-         (this.height + getHeight(ctx, this.getFont()))/2.0,
-         minSuffix
-      ];
+         this.calculatedFields.width,
+         this.calculatedFields.height
+      ]
    }
+   // getTextOffsets(ctx: CanvasRenderingContext2D): [number, number, number] {
+   //    const [minWidth, minHeight, minPrefix, minSuffix] = this.getFullMinSize(ctx);
+
+   //    function getHeight(ctx: CanvasRenderingContext2D, font: string): number {
+   //       ctx.save();minHeight
+   //       ctx.font = font;
+   //       const measure = ctx.measureText("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.!?*&^%$#@)(0123456789-=_+`~[]{}\\|;:'\"");
+   //       ctx.restore();
+
+   //       return measure.actualBoundingBoxAscent + measure.actualBoundingBoxDescent;
+   //    }
+
+   //    return [
+   //       this.centeredHorizontally ? (this.width - (minWidth - minPrefix - minSuffix))/2.0 : minPrefix,
+   //       (this.height + getHeight(ctx, this.getFont()))/2.0,
+   //       minSuffix
+   //    ];
+   // }
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
       if (!this._visible)
          return;
 
       ctx.save();
 
+      if (this._text == "Box Options") {
+         console.log(`box option dims: (${this._width}, ${this._height})`);
+      }
+
+      // const width = this._width ?? this.calculatedFields.width;
+      // const height = this._height ?? this.calculatedFields.height;
+      const textOffsets = this.calculatedFields.textOffsets;
+
       const button_color = this.selected ? this.globalProps.selectedColor : this.globalProps.borderColor;
       ctx.fillStyle = button_color;
-      ctx.fillRect(offsetX, offsetY, this.width, this.height);
+      ctx.fillRect(offsetX, offsetY, this._width, this._height);
 
       // ctx.font = this.globalProps.widgetTextFont;
       ctx.font = this.getFont();
@@ -336,19 +417,19 @@ class Button implements Widget, WidgetEvents {
          ctx.fillText(
             this._prefixText,
             offsetX,
-            this.textOffsets[1] + offsetY
+            textOffsets.y + offsetY
          );
       } 
       ctx.fillText(
          this._text,
-         this.textOffsets[0] + offsetX,
-         this.textOffsets[1] + offsetY
+         textOffsets.mainTextX + offsetX,
+         textOffsets.y + offsetY
       );
       if (this._suffixText != undefined) {
          ctx.fillText(
             " " + this._suffixText,
-            offsetX + (this.width - this.textOffsets[2]),
-            this.textOffsets[1] + offsetY
+            offsetX + (this._width - textOffsets.suffixX),
+            textOffsets.y + offsetY
          );
       }
 

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -59,7 +59,7 @@ interface Widget {
    readonly handledEvents: MenuItemEvents[];
    getMinSize: (ctx: CanvasRenderingContext2D) => [number, number];
    render: (ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) => void;
-   handleMenuEvent: (event: MenuItemEventData) => void;
+   handleMenuEvent: (ctx: CanvasRenderingContext2D, event: MenuItemEventData) => void;
    getDimensions: () => [number, number, number, number];
    setDimensions: (ctx: CanvasRenderingContext2D, x?: number, y?: number, width?: number, height?: number) => void;
    delete: (ctx: CanvasRenderingContext2D) => Widget[];
@@ -121,7 +121,7 @@ class Button implements Widget, WidgetEvents {
    private selectedButtonColor: string;
 
    private selected: boolean = false;
-   private events: Set<(() => void)> = new Set();
+   private events: Set<((ctx: CanvasRenderingContext2D) => void)> = new Set();
 
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, cons: ButtonWidgetConstructor) {
       this.parent = parent;
@@ -165,7 +165,7 @@ class Button implements Widget, WidgetEvents {
    setButtonText(ctx: CanvasRenderingContext2D, newText: string) {
       this.text = newText;
       this.textOffsets = this.getTextOffsets(ctx);
-      this.parent.childUpdated(ctx);
+      this.parent.childUpdated(ctx, this);
    }
 
    getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
@@ -205,12 +205,12 @@ class Button implements Widget, WidgetEvents {
 
       ctx.restore();
    }
-   handleMenuEvent(event: MenuItemEventData) {
+   handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
       switch (event[0]) {
          case MenuItemEvents.CLICKED:
          {
             for (const callback of this.events.keys()) {
-               callback();
+               callback(ctx);
             }
          }
          break;
@@ -232,7 +232,7 @@ class Button implements Widget, WidgetEvents {
       }
    }
 
-   addEvent(callback: () => void) {
+   addEvent(callback: (ctx: CanvasRenderingContext2D) => void) {
       this.events.add(callback);
    }
    removeEvent(callback: () => void) {
@@ -388,7 +388,7 @@ class Menu implements Widget, WidgetManager {
       } else if (!this.supressChildUpdates) {
          this.updateChildSize(ctx);
          this.selectedItem = undefined;
-         this.parent.childUpdated(ctx, undefined, false);
+         this.parent.childUpdated(ctx, this, false);
       }
    }
    addChild<
@@ -400,6 +400,7 @@ class Menu implements Widget, WidgetManager {
 
       this.children.push(widget);
       this.updateChildSize(ctx, true);
+      this.parent.childUpdated(ctx, this);
 
       return widget;
    }
@@ -429,9 +430,9 @@ class Menu implements Widget, WidgetManager {
       ctx.restore();
 	}
    
-   private dispatchEvent(widget: Widget, event: MenuItemEventData) {
+   private dispatchEvent(ctx: CanvasRenderingContext2D, widget: Widget, event: MenuItemEventData) {
       if (widget.handledEvents.includes(event[0])) {
-         widget.handleMenuEvent(event);
+         widget.handleMenuEvent(ctx, event);
       }
    }
 
@@ -443,14 +444,14 @@ class Menu implements Widget, WidgetManager {
 
    //updates the currently selected object using the given coords
    //also handles HOVERING and UNHOVERED events
-   private updateSelectedObject(x: number, y: number) {
+   private updateSelectedObject(ctx: CanvasRenderingContext2D,x: number, y: number) {
       //check if hovering over selected item
       if (this.selectedItem) {
          if (this.mouseInWidgetBounds(this.selectedItem, x, y)) {
             return; //the selected item is in bounds
          } else {
             //selected item is out of bounds
-            this.dispatchEvent(this.selectedItem, [MenuItemEvents.UNHOVERED]);
+            this.dispatchEvent(ctx, this.selectedItem, [MenuItemEvents.UNHOVERED]);
             this.selectedItem = undefined;
          }
       }
@@ -459,36 +460,36 @@ class Menu implements Widget, WidgetManager {
          //found child it's hovering over
          if (this.mouseInWidgetBounds(child, x, y)) {
             this.selectedItem = child;
-            this.dispatchEvent(child, [MenuItemEvents.HOVERING]);
+            this.dispatchEvent(ctx, child, [MenuItemEvents.HOVERING]);
             //break early
             return;
          }
       }
    }
-   handleMenuEvent(event: MenuItemEventData): void {
+   handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData): void {
 		switch (event[0]) {
          case MenuItemEvents.MOUSE_MOVE:
          {
             const [, eX, eY] = event;
             const [x, y] = [eX - this.x, eY - this.y];
-            this.updateSelectedObject(x, y);
+            this.updateSelectedObject(ctx, x, y);
             if (this.selectedItem)
-               this.dispatchEvent(this.selectedItem, [MenuItemEvents.MOUSE_MOVE, x, y]);
+               this.dispatchEvent(ctx, this.selectedItem, [MenuItemEvents.MOUSE_MOVE, x, y]);
          }
          break;
          case MenuItemEvents.CLICKED:
          {
             const [, eX, eY] = event;
             const [x, y] = [eX - this.x, eY - this.y];
-            this.updateSelectedObject(x, y);
+            this.updateSelectedObject(ctx, x, y);
             if (this.selectedItem)
-               this.dispatchEvent(this.selectedItem, [MenuItemEvents.CLICKED, x, y]);
+               this.dispatchEvent(ctx, this.selectedItem, [MenuItemEvents.CLICKED, x, y]);
          }
          break;
          case MenuItemEvents.UNHOVERED:
          {
             if (this.selectedItem) {
-               this.dispatchEvent(this.selectedItem, [MenuItemEvents.UNHOVERED]);
+               this.dispatchEvent(ctx, this.selectedItem, [MenuItemEvents.UNHOVERED]);
                this.selectedItem = undefined;
             }
             for (const handler of this.unhoverHandlers) {
@@ -562,7 +563,7 @@ interface RadioMenuWidgetConstructor extends MenuWidgetConstructor {
    hoveredBackgroundColor?: string;
 }
 
-class RadioMenu implements Widget, WidgetManager {
+class RadioMenu implements Widget, WidgetManager, WidgetEvents {
    readonly parent: WidgetManager;
    readonly id: number;
    readonly handledEvents: MenuItemEvents[];
@@ -577,6 +578,8 @@ class RadioMenu implements Widget, WidgetManager {
    
    private options: Map<string, Button> = new Map();
    private selected?: string;
+
+   private events: Set<(ctx: CanvasRenderingContext2D, opt: string) => void> = new Set();
 
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: RadioMenuWidgetConstructor) {
       this.backgroundColor = props.menuColor ?? "gray";
@@ -609,7 +612,7 @@ class RadioMenu implements Widget, WidgetManager {
          y: 0,
          width: -1,
          height: this.optionHeight,
-         text: " ".repeat(this.selectedSymbol.length + 1) + opt,
+         text: prefix + opt,
          textColor: this.optionTextColor,
          textFont: this.optionTextFont,
          buttonColor: this.backgroundColor,
@@ -619,7 +622,27 @@ class RadioMenu implements Widget, WidgetManager {
 
       this.options.set(opt, button);
 
-      
+      button.addEvent(((ctx: CanvasRenderingContext2D) => {
+         this.changeSelected(ctx, opt);
+      }).bind(this));
+   }
+
+   changeSelected(ctx: CanvasRenderingContext2D, opt: string) {
+      if (this.selected != opt) {
+         if (this.selected != undefined) {
+            let selectedLength = this.selectedSymbol.length+1;
+            let selectedPrefix = " ".repeat(selectedLength);
+            let button = this.options.get(this.selected)!;
+
+            button.setButtonText(ctx, selectedPrefix + this.selected);
+         }
+         this.selected = opt;
+         this.options.get(this.selected)!.setButtonText(ctx, this.selectedSymbol + " " + this.selected);
+         
+         for (const event of this.events) {
+            event(ctx, this.selected);
+         }
+      }
    }
 
    getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
@@ -628,8 +651,8 @@ class RadioMenu implements Widget, WidgetManager {
    render(ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) {
       this.menu.render(ctx, offsetX, offsetY);
    }
-   handleMenuEvent(event: MenuItemEventData) {
-      this.menu.handleMenuEvent(event);
+   handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
+      this.menu.handleMenuEvent(ctx, event);
    }
    getDimensions(): [number, number, number, number] {
       return this.menu.getDimensions();
@@ -660,6 +683,13 @@ class RadioMenu implements Widget, WidgetManager {
    handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
       if (this.supressDeleteHandle) return;
       throw new Error("RadialMenu shouldn't be handling an delete events!!!");
+   }
+
+   addEvent(callback: (ctx: CanvasRenderingContext2D, opt: string) => void) {
+      this.events.add(callback);
+   }
+   removeEvent(callback: (ctx: CanvasRenderingContext2D, opt: string) => void) {
+      this.events.delete(callback);
    }
 
 }
@@ -714,17 +744,17 @@ class RootWidgetManager implements WidgetManager {
       return wX <= x && x <= wX + wW
          && wY <= y && y <= wY + wH;
    }
-   private dispatchEvent(widget: Widget, event: MenuItemEventData) {
+   private dispatchEvent(ctx: CanvasRenderingContext2D, widget: Widget, event: MenuItemEventData) {
       if (widget.handledEvents.includes(event[0])) {
-         widget.handleMenuEvent(event);
+         widget.handleMenuEvent(ctx, event);
       }
    }
-   private updateSelected(x: number, y: number) {
+   private updateSelected(ctx: CanvasRenderingContext2D, x: number, y: number) {
       if (this.selectedWidget) {
          if (this.widgetInBounds(this.selectedWidget, x, y)) {
             return;
          } else {
-            this.dispatchEvent(this.selectedWidget, [MenuItemEvents.UNHOVERED]);
+            this.dispatchEvent(ctx, this.selectedWidget, [MenuItemEvents.UNHOVERED]);
             this.selectedWidget = undefined;
          }
       }
@@ -736,7 +766,7 @@ class RootWidgetManager implements WidgetManager {
          const widget = widgetList[i];
          if (this.widgetInBounds(widget, x, y)) {
             this.selectedWidget = widget;
-            this.dispatchEvent(widget, [MenuItemEvents.HOVERING]);
+            this.dispatchEvent(ctx, widget, [MenuItemEvents.HOVERING]);
             return;
          }
       }
@@ -745,18 +775,18 @@ class RootWidgetManager implements WidgetManager {
          const widget = this.boundWidgets[i];
          if (this.widgetInBounds(widget, x, y)) {
             this.selectedWidget = widget;
-            this.dispatchEvent(widget, [MenuItemEvents.HOVERING]);
+            this.dispatchEvent(ctx, widget, [MenuItemEvents.HOVERING]);
             return;
          }
       }
    }
 
    handleCanvasMouseEvent(ctx: CanvasRenderingContext2D, event: CanvasEventTypes, x: number, y: number): boolean {
-      this.updateSelected(x, y);
+      this.updateSelected(ctx, x, y);
       if (!this.selectedWidget) {
          if (event == CanvasEventTypes.MOUSE_CLICK) {
             for (const popup of this.popupWidgets) {
-               this.dispatchEvent(popup, [MenuItemEvents.CLICKED_OFF]);
+               this.dispatchEvent(ctx, popup, [MenuItemEvents.CLICKED_OFF]);
             }
          }
          return false;
@@ -764,16 +794,16 @@ class RootWidgetManager implements WidgetManager {
 
       switch (event) {
          case CanvasEventTypes.MOUSE_MOVE:
-            this.dispatchEvent(this.selectedWidget, [MenuItemEvents.MOUSE_MOVE, x, y]);
+            this.dispatchEvent(ctx, this.selectedWidget, [MenuItemEvents.MOUSE_MOVE, x, y]);
          break;
 
          case CanvasEventTypes.MOUSE_CLICK:
             const selected = this.selectedWidget;
             for (const popup of this.popupWidgets) {
                if (selected != popup)
-                  this.dispatchEvent(popup, [MenuItemEvents.CLICKED_OFF]);
+                  this.dispatchEvent(ctx, popup, [MenuItemEvents.CLICKED_OFF]);
             }
-            this.dispatchEvent(selected, [MenuItemEvents.CLICKED, x, y]);
+            this.dispatchEvent(ctx, selected, [MenuItemEvents.CLICKED, x, y]);
             
          break;
       }
@@ -855,8 +885,8 @@ class MenuButton implements Widget, WidgetManager {
    render(ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) {
       this.button.render(ctx, offsetX, offsetY);
    }
-   handleMenuEvent(event: MenuItemEventData) {
-      this.button.handleMenuEvent(event);
+   handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
+      this.button.handleMenuEvent(ctx, event);
    }
    getDimensions(): [number, number, number, number] {
       return this.button.getDimensions();
@@ -964,7 +994,7 @@ class Seperator implements Widget {
 
       ctx.restore();
    }
-   handleMenuEvent(event: MenuItemEventData) {
+   handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
       throw new Error(`Seperator widget doesn't accept events!!`);
    }
    getDimensions(): [number, number, number, number] {
@@ -994,7 +1024,8 @@ const MENU_START_X = BORDER_SIZE;
 
 enum WidgetType {
    Button,
-   Seperator
+   Seperator,
+   RadioMenu
 }
 
 export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, IConsoleWindow {
@@ -1012,6 +1043,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       number, 
       [WidgetType.Button, Button]
       | [WidgetType.Seperator, Seperator]
+      | [WidgetType.RadioMenu, RadioMenu]
    > = new Map();
    
    nextMenuItem: number = 0;
@@ -1027,8 +1059,9 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       twrGetAppCanvasJSID: {},
       twrWindowAddMenu: {},
       twrWindowMenuAddWidget: {},
-      twrWindowMenuButtonAddCallback: {},
+      twrWindowMenuWidgetAddCallback: {},
       twrWindowMenuDeleteWidget: {},
+      twrWindowMenuRadioMenuAddOption: {},
    };
 
    // every library should have this line
@@ -1065,16 +1098,16 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          type: 0
       };
 
-      const buttonOpts: ButtonWidgetConstructor = {
-         x: 100,
-         y: 100,
-         text: "TEST!!!",
-         textFont: "64px Serif",
-         width: 300,
-         height: 300,
-         buttonColor: "#B0B0B0B0"
-      };
-      this.manager.addChild(this.ctx, -10, Button, buttonOpts);
+      // const buttonOpts: ButtonWidgetConstructor = {
+      //    x: 100,
+      //    y: 100,
+      //    text: "TEST!!!",
+      //    textFont: "64px Serif",
+      //    width: 300,
+      //    height: 300,
+      //    buttonColor: "#B0B0B0B0"
+      // };
+      // this.manager.addChild(this.ctx, -10, Button, buttonOpts);
    }
 
    getProp(propName: string) {
@@ -1193,37 +1226,8 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       const [, , width, ] = button.getDimensions();
       button.setDimensions(this.ctx, undefined, undefined, width + MENU_PADDING_X, undefined);
 
-      // const seperatorOptions: SeperatorWidgetConstructor = {
-      //    x: 0,
-      //    y: 0,
-      //    height: 10,
-      //    seperatorText: "-",
-      //    seperatorColor: "black",
-      //    seperatorFont: "20px Seriph"
-      // }
-
       this.menus.set(id, button);
 
-      // const buttonOptions: ButtonWidgetConstructor = {
-      //    x: 0,
-      //    y: 0,
-      //    height: 20,
-      //    text: "Hello!!!",
-      //    textColor: "black",
-      //    buttonColor: "#B0B0B0",
-      //    selectedButtonColor: "#D0D0D0"
-      // };
-      // const secondButton: Button = button.addChild(this.ctx, ++this.nextMenuItem, Button, buttonOptions);
-      // secondButton.addEvent(() => {
-      //    console.log("pressed!!!");
-      // });
-      // button.addChild(this.ctx, ++this.nextMenuItem, Seperator, seperatorOptions);
-
-      // const thirdButton: Button = button.addChild(this.ctx, ++this.nextMenuItem, Button, buttonOptions);
-
-      // button.addEvent((() => {
-      //    // this.openMenu = menu;
-      // }).bind(this));
       return id;
    }
 
@@ -1239,7 +1243,11 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       //    long height;
       // };
       function getLongOrDef<T>(ptr: number, def: T): number|T {
-         const val = mod.getLong(ptr);
+         const ptrx32=Math.floor(ptr/4);
+         if (ptrx32*4!=ptr) throw new Error("getLongOrDef passed non long aligned address")
+         if (ptrx32<0 || ptrx32 >= mod.wasmMem.mem32.length) throw new Error("invalid index passed to getLongOrDef: "+ptr+", this.mem32.length: "+mod.wasmMem.mem32.length);
+         const val: number = mod.wasmMem.mem32[ptrx32];
+
          if (val < 0) {
             return def;
          } else {
@@ -1324,6 +1332,57 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          }
          break;
 
+         case WidgetType.RadioMenu:
+         {
+            // struct twr_widget_radio_menu_constructor {
+            //    /// @brief Base widget constructor
+            //    struct twr_widget_constructor base;
+            //    ///@brief defaults to 0
+            //    long minimumWidth;
+            //    /// @brief defaults to 0
+            //    long minimumHeight;
+            //    /// @brief defaults to 0
+            //    long yPadding;
+            //    /// @brief defaults to gray
+            //    const char* menuColor;
+            //    /**
+            //     * Color options change to when hovered over
+            //     * defaults to light gray
+            //     */
+            //    const char* hoveredBackgroundColor;
+            //    /**
+            //     * Symbol used to denote that the option is selected
+            //     * defaults to *
+            //     */
+            //    const char* selectedSymbol;
+            //    /// @brief default to 20
+            //    long optionHeight;
+            //    /// @brief defaults to 16px Seriph
+            //    const char* optionTextFont;
+            //    /// @brief defaults to black
+            //    const char* optionTextColor;
+            // };
+            const cons: RadioMenuWidgetConstructor = {
+               x: x,
+               y: y,
+               width: width,
+               height: height,
+               minimumWidth: getLongOrDef(extraPtr + 0, 0),            
+               minimumHeight: getLongOrDef(extraPtr + 4, 0),
+               yPadding: getLongOrDef(extraPtr + 8, 0),
+               menuColor: getStringOrDef(extraPtr + 12, "gray"),
+               hoveredBackgroundColor: getStringOrDef(extraPtr + 16, "lightgray"),
+               selectedSymbol: getStringOrDef(extraPtr + 20, "*"),
+               optionHeight: getLongOrDef(extraPtr + 24, 20),
+               optionTextFont: getStringOrDef(extraPtr + 28, "16px Seriph"),
+               optionTextColor: getStringOrDef(extraPtr + 32, "black"),
+            };
+            console.log(cons);
+            const radio: RadioMenu = menu.addChild(this.ctx, id, RadioMenu, cons);
+            this.menuItems.set(id, [WidgetType.RadioMenu, radio]);
+         }
+         break;
+
          default:
          {
             throw new Error(`twrWindowMenuAddWidget: Error! Was given an unknown type (${type})!`);
@@ -1334,17 +1393,36 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       return id;
    }
 
-   twrWindowMenuButtonAddCallback(mod: IWasmModuleAsync | IWasmModule, widgetID: number, eventID: number, extraPtr: number) {
+   twrWindowMenuWidgetAddCallback(mod: IWasmModuleAsync | IWasmModule, widgetID: number, eventID: number, extraPtr: number) {
       if (!this.menuItems.has(widgetID)) throw new Error(`twrWindowMenuButtonAddCallback: Error! was given an invalid widgetID (${widgetID})`);
       const widget = this.menuItems.get(widgetID)!;
 
-      if (widget[0] != WidgetType.Button) throw new Error(`twrWindowMenuButtonAddCallback: Error! was given an invalid widget type! Expected Button, got ${WidgetType[widget[0]]}`);
-      
-      const button: Button = widget[1];
+      switch (widget[0]) {
+         case WidgetType.Button:
+         {
+            const button: Button = widget[1];
 
-      button.addEvent(() => {
-         mod.postEvent(eventID, extraPtr)
-      });
+            button.addEvent(() => {
+               mod.postEvent(eventID, extraPtr)
+            });
+         }
+         break;
+
+         case WidgetType.RadioMenu:
+         {
+            const radio: RadioMenu = widget[1];
+            radio.addEvent(async (ctx: CanvasRenderingContext2D, opt: string) => {
+               mod.postEvent(eventID, extraPtr, await mod.putString(opt));
+            });
+         }
+         break;
+
+         default:
+         {
+            throw new Error(`twrWindowMenuWidgetAddCallback: Error! was given an invalid widget type! Expected button or radioMenu, got ${WidgetType[widget[0]]}`);
+         }
+         break;
+      }      
    }
 
    twrWindowMenuDeleteWidget(mod: IWasmModuleAsync | IWasmModule, widgetID: number) {
@@ -1355,6 +1433,17 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       for (const del of deleted) {
          this.menuItems.delete(del.id);
       }
+   }
+
+   twrWindowMenuRadioMenuAddOption(mod: IWasmModuleAsync | IWasmModule, widgetID: number, optionPtr: number) {
+      if (!this.menuItems.has(widgetID)) throw new Error(`twrWindowMenuRadioMenuAddOption: Error! was given an invalid widgetID (${widgetID})`);
+      const widget = this.menuItems.get(widgetID)!;
+
+      if (widget[0] != WidgetType.RadioMenu) throw new Error(`twrWindowMenuRadioMenuAddOption: Error! was given an invalid widget type! Expected RadioMenu, got ${WidgetType[widget[0]]}`);
+      
+      const radio: RadioMenu = widget[1];
+
+      radio.addOption(this.ctx, mod.getString(optionPtr));
    }
 
 

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -47,10 +47,11 @@ interface WidgetManager {
    //really, really long type. Basically accepts any class constructor that created a Widget
    // and accepts a CanvasRenderingContext2D, an id, a parent WidgetManager, and a set of properties of any type
    // the idea is that you give the manager a widget and it constructs it internally.
-   addChild: <T extends Widget, U, O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U) => T>(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U) => T;
+   // addChild: <T extends Widget, U, O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U) => T>(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U) => T;
 
    openPopup: (ctx: CanvasRenderingContext2D, widget: Widget) => void;
    closePopup: (ctx: CanvasRenderingContext2D, widget: Widget) => void;
+   handleDelete: (ctx: CanvasRenderingContext2D, widget: Widget) => void;
 }
 interface Widget {
    readonly parent: WidgetManager; 
@@ -61,6 +62,7 @@ interface Widget {
    handleMenuEvent: (event: MenuItemEventData) => void;
    getDimensions: () => [number, number, number, number];
    setDimensions: (ctx: CanvasRenderingContext2D, x?: number, y?: number, width?: number, height?: number) => void;
+   delete: (ctx: CanvasRenderingContext2D) => Widget[];
 }
 
 interface WidgetConstructor {
@@ -140,6 +142,10 @@ class Button implements Widget, WidgetEvents {
       
       this.textOffsets = this.getTextOffsets(ctx);
    }
+   delete(ctx: CanvasRenderingContext2D) {
+      this.parent.handleDelete(ctx, this);
+      return [this];
+   }
 
    getDimensions(): [number, number, number, number] {
       return [this.x, this.y, this.width, this.height];
@@ -155,6 +161,11 @@ class Button implements Widget, WidgetEvents {
       
       if (x != undefined || y != undefined || height != undefined || width != undefined)
          this.parent.childUpdated(ctx);
+   }
+   setButtonText(ctx: CanvasRenderingContext2D, newText: string) {
+      this.text = newText;
+      this.textOffsets = this.getTextOffsets(ctx);
+      this.parent.childUpdated(ctx);
    }
 
    getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
@@ -291,6 +302,33 @@ class Menu implements Widget, WidgetManager {
       this.yPadding = props.yPadding ?? 10;
 
       this.menuColor = props.menuColor ?? "gray";
+   }
+   pauseDeleteHandle: boolean = false;
+   handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
+      if (this.pauseDeleteHandle)
+         return;
+
+      let i = this.children.indexOf(widget);
+      if (i >= 0) {
+         this.children.splice(i, 1);
+         this.childUpdated(ctx);
+      }
+   }
+   delete(ctx: CanvasRenderingContext2D) {
+      this.parent.handleDelete(ctx, this);
+      
+      this.pauseDeleteHandle = true;
+      let deleted: Widget[] = [];
+      for (const widget of this.children) {
+         deleted = deleted.concat(widget.delete(ctx));
+      }
+      //push self to list
+      deleted.push(this);
+      this.children = [];
+      this.updateChildSize(ctx);
+      this.pauseDeleteHandle = false;
+      return deleted;
+
    }
    openPopup(ctx: CanvasRenderingContext2D, widget: Widget) {
       this.parent.openPopup(ctx, widget);
@@ -501,7 +539,7 @@ class Menu implements Widget, WidgetManager {
    unbindUnhoverEvent(callback: () => void) {
       const index = this.unhoverHandlers.indexOf(callback);
       if (index >= 0)
-         this.unhoverHandlers.splice(index);
+         this.unhoverHandlers.splice(index, 1);
    }
 
    bindClickedOffEvent(callback: () => void) {
@@ -510,8 +548,118 @@ class Menu implements Widget, WidgetManager {
    unbindClickedOffEvent(callback: () => void) {
       const index = this.clickedOffHandlers.indexOf(callback);
       if (index >= 0) {
-         this.clickedOffHandlers.splice(index);
+         this.clickedOffHandlers.splice(index, 1);
       }
+   }
+
+}
+
+interface RadioMenuWidgetConstructor extends MenuWidgetConstructor {
+   optionHeight?: number;
+   selectedSymbol?: string;
+   optionTextFont?: string;
+   optionTextColor?: string;
+   hoveredBackgroundColor?: string;
+}
+
+class RadioMenu implements Widget, WidgetManager {
+   readonly parent: WidgetManager;
+   readonly id: number;
+   readonly handledEvents: MenuItemEvents[];
+
+   private menu: Menu;
+   private optionHeight: number;
+   private selectedSymbol: string;
+   private optionTextFont: string;
+   private optionTextColor: string;
+   private backgroundColor: string;
+   private hoveredBackgroundColor: string;
+   
+   private options: Map<string, Button> = new Map();
+   private selected?: string;
+
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: RadioMenuWidgetConstructor) {
+      this.backgroundColor = props.menuColor ?? "gray";
+      props.menuColor = this.backgroundColor;
+
+      this.menu = new Menu(ctx, this, 0, props);
+      this.parent = parent;
+      this.id = id;
+
+      this.optionHeight = props.optionHeight ?? 20;
+      this.selectedSymbol = props.selectedSymbol ?? "*";
+      this.optionTextFont = props.optionTextFont ?? "16px Seriph";
+      this.optionTextColor = props.optionTextColor ?? "black";
+      this.hoveredBackgroundColor = props.hoveredBackgroundColor ?? "lightgray";
+      this.handledEvents = this.menu.handledEvents;
+   }
+
+   addOption(ctx: CanvasRenderingContext2D, opt: string) {
+      if (this.options.has(opt))
+         throw new Error(`RadioMenu: addOption already has the ${opt} option!`);
+
+      let prefix = " ".repeat(this.selectedSymbol.length + 1);
+      if (this.selected == undefined) {
+         this.selected = opt;
+         prefix = this.selectedSymbol + " ";
+      }
+
+      const buttonOpts: ButtonWidgetConstructor = {
+         x: 0,
+         y: 0,
+         width: -1,
+         height: this.optionHeight,
+         text: " ".repeat(this.selectedSymbol.length + 1) + opt,
+         textColor: this.optionTextColor,
+         textFont: this.optionTextFont,
+         buttonColor: this.backgroundColor,
+         selectedButtonColor: this.hoveredBackgroundColor,
+      };
+      const button: Button = this.menu.addChild(ctx, 0, Button, buttonOpts);
+
+      this.options.set(opt, button);
+
+      
+   }
+
+   getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
+      return this.menu.getMinSize(ctx);
+   }
+   render(ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) {
+      this.menu.render(ctx, offsetX, offsetY);
+   }
+   handleMenuEvent(event: MenuItemEventData) {
+      this.menu.handleMenuEvent(event);
+   }
+   getDimensions(): [number, number, number, number] {
+      return this.menu.getDimensions();
+   }
+   setDimensions(ctx: CanvasRenderingContext2D, x?: number, y?: number, width?: number, height?: number) {
+      return this.menu.setDimensions(ctx, x, y, width, height);
+   }
+
+   childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) {
+      this.parent.childUpdated(ctx, widget, sendToRoot);
+   }
+
+   openPopup(ctx: CanvasRenderingContext2D, widget: Widget) {
+      this.parent.openPopup(ctx, widget);
+   }
+   closePopup(ctx: CanvasRenderingContext2D, widget: Widget) {
+      this.parent.closePopup(ctx, widget);
+   }
+
+   private supressDeleteHandle: boolean = false;
+   delete(ctx: CanvasRenderingContext2D) {
+      this.supressDeleteHandle = true;
+      this.parent.handleDelete(ctx, this);
+      this.menu.delete(ctx);
+      this.supressDeleteHandle = false;
+      return [this];
+   }
+   handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
+      if (this.supressDeleteHandle) return;
+      throw new Error("RadialMenu shouldn't be handling an delete events!!!");
    }
 
 }
@@ -524,6 +672,13 @@ class RootWidgetManager implements WidgetManager {
 
    constructor() {
 
+   }
+   handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
+      const i = this.boundWidgets.indexOf(widget);
+      if (i < 0)
+         return;
+      this.boundWidgets.splice(i, 1);
+      this.childUpdated(ctx);
    }
 
    addChild<
@@ -671,6 +826,28 @@ class MenuButton implements Widget, WidgetManager {
 
       this.handledEvents = this.button.handledEvents;
    }
+   private supressHandleDelete: boolean = false;
+   handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
+      if (this.supressHandleDelete)
+         return;
+      if (widget == this.button)
+         throw new Error("MenuButton's internal button shouldn't be externally accesible");
+      else if (widget == this.menu)
+         throw new Error("MenuButton's internal menu shouldn't be externally accesible");
+      else
+         throw new Error("MenuButton shouldn't be handling any deletions?");
+   }
+   delete(ctx: CanvasRenderingContext2D) {
+      this.supressHandleDelete = true;
+      this.parent.handleDelete(ctx, this);
+      let deleted: Widget[] = this.menu.delete(ctx);
+      this.button.delete(ctx);
+      //delete menu from list since it's not exposed externally
+      deleted.splice(deleted.indexOf(this.menu), 1);
+      deleted.push(this); //push self
+      this.supressHandleDelete = false;
+      return deleted;
+   }
 
    getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
       return this.button.getMinSize(ctx);
@@ -743,6 +920,10 @@ class Seperator implements Widget {
       this.height = props.height ?? 0;
       
       this.updateText(ctx);
+   }
+   delete(ctx: CanvasRenderingContext2D) {
+      this.parent.handleDelete(ctx, this);
+      return [this];
    }
    private updateText(ctx: CanvasRenderingContext2D) {
       ctx.save();
@@ -847,6 +1028,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       twrWindowAddMenu: {},
       twrWindowMenuAddWidget: {},
       twrWindowMenuButtonAddCallback: {},
+      twrWindowMenuDeleteWidget: {},
    };
 
    // every library should have this line
@@ -1163,6 +1345,16 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       button.addEvent(() => {
          mod.postEvent(eventID, extraPtr)
       });
+   }
+
+   twrWindowMenuDeleteWidget(mod: IWasmModuleAsync | IWasmModule, widgetID: number) {
+      if (!this.menuItems.has(widgetID)) throw new Error(`twrWindowMenuDeleteWidget: Error! was given an invalid widgetID (${widgetID})`);
+      const widget = this.menuItems.get(widgetID)!;
+
+      const deleted = widget[1].delete(this.ctx);
+      for (const del of deleted) {
+         this.menuItems.delete(del.id);
+      }
    }
 
 

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -28,13 +28,40 @@ enum MenuItemEvents {
    MOUSE_MOVE,
    CLICKED_OFF,
 }
-type MenuItemEventData = [ MenuItemEvents.HOVERING ]
-   | [ MenuItemEvents.UNHOVERED ]
-   | [ MenuItemEvents.CLICKED, number, number, number]
-   | [ MenuItemEvents.MOUSE_MOVE, number, number]
-   | [ MenuItemEvents.CLICKED_OFF];
+type MenuItemHoverEvent = {
+   type: MenuItemEvents.HOVERING
+};
+type MenuItemUnhoverEvent = {
+   type: MenuItemEvents.UNHOVERED
+};
+type MenuItemClickedEvent = {
+   type: MenuItemEvents.CLICKED,
+   x: number,
+   y: number,
+   button: number
+};
+type MenuItemMouseMoveEvent = {
+   type: MenuItemEvents.MOUSE_MOVE,
+   x: number,
+   y: number
+};
+type MenuItemClickedOffEvent = {
+   type: MenuItemEvents.CLICKED_OFF
+};
+// type MenuItemEventData = [ MenuItemEvents.HOVERING ]
+//    | [ MenuItemEvents.UNHOVERED ]
+//    | [ MenuItemEvents.CLICKED, number, number, number]
+//    | [ MenuItemEvents.MOUSE_MOVE, number, number]
+//    | [ MenuItemEvents.CLICKED_OFF];
+type MenuItemEventData = MenuItemHoverEvent
+   | MenuItemUnhoverEvent
+   | MenuItemClickedEvent
+   | MenuItemMouseMoveEvent
+   | MenuItemClickedOffEvent;
 
-
+// Globals used in widgets for a given window to specify things like:
+//    font, colors, spacing, etc.
+// can be updated from the program and values should propogate
 interface GlobalWidgetProperties {
    borderColor: string,
    selectedColor: string,
@@ -58,10 +85,6 @@ interface GlobalWidgetProperties {
 interface WidgetManager {
    getCtx: () => CanvasRenderingContext2D;
    childUpdated: (ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) => void;
-   //really, really long type. Basically accepts any class constructor that created a Widget
-   // and accepts a CanvasRenderingContext2D, an id, a parent WidgetManager, and a set of properties of any type
-   // the idea is that you give the manager a widget and it constructs it internally.
-   // addChild: <T extends Widget, U, O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U) => T>(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U) => T;
 
    openPopup: (ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) => void;
    closePopup: (ctx: CanvasRenderingContext2D, widget: Widget) => void;
@@ -84,16 +107,24 @@ interface Widget {
    get minWidth(): number;
    get minHeight(): number;
 
-   // getMinSize: () => [number, number];
    render: (ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) => void;
    handleMenuEvent: (ctx: CanvasRenderingContext2D, event: MenuItemEventData) => void;
-   // getDimensions: () => [number, number];
-   // setDimensions: (width?: number, height?: number) => void;
    delete: (ctx: CanvasRenderingContext2D) => Widget[];
-   // setVisibility: (visibility: boolean) => void;
-   // isVisible: () => boolean;
 
    fullUpdate: (ctx: CanvasRenderingContext2D) => void;
+}
+///"deep" clones a json object
+///doesn't clone classes, etc. Just clones sub-JSON objects
+function cloneJSONObject<T>(to_copy: T): T {
+   if (typeof to_copy == "object") {
+      const obj: {[val: string]: any} = {};
+      for (const [key, value] of Object.entries(to_copy as {[val: string]: any})) {
+         obj[key] = cloneJSONObject(value);
+      }
+      return obj as T;
+   } else {
+      return to_copy;
+   }
 }
 
 let NEXT_WIDGET_ID: number = 0;
@@ -113,15 +144,11 @@ abstract class WidgetImpl implements Widget {
       this.globalProps = globalProps;
 
    }
-   // abstract getMinSize(): [number, number];
    abstract render(ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number): void;
    abstract handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData): void;
    abstract delete(ctx: CanvasRenderingContext2D): Widget[];
    abstract fullUpdate(ctx: CanvasRenderingContext2D): void;
    protected abstract propagateUpdate(ctx?: CanvasRenderingContext2D): void;
-
-   // abstract getDimensions(): [number, number];
-   // abstract setDimensions(width?: number, height?: number): void;
 
    set visible(val: boolean) {
       if (this._visible != val) {
@@ -138,8 +165,10 @@ abstract class WidgetImpl implements Widget {
       }
    }
    get width() {return this._width};
-   abstract get usedWidth(): number;
    abstract get minWidth(): number;
+   get usedWidth(): number {
+      return this._width ?? this.minWidth;
+   }
 
    set height(val: number|undefined) {
       if (this._height != val) {
@@ -148,10 +177,10 @@ abstract class WidgetImpl implements Widget {
       }
    }
    get height() {return this._height};
-   abstract get usedHeight(): number;
    abstract get minHeight(): number;
-
-
+   get usedHeight(): number {
+      return this._height ?? this.minHeight;
+   }
 }
 
 //constructor fields in interfaces are ... weird
@@ -176,26 +205,15 @@ interface ButtonWidgetConstructor extends WidgetConstructor {
 }
  
 class Button extends WidgetImpl implements WidgetEvents {
-   // readonly globalProps: GlobalWidgetProperties;
-   // readonly parent: WidgetManager; 
-   // readonly id: number;
    readonly handledEvents: MenuItemEvents[] = [
       MenuItemEvents.CLICKED,
       MenuItemEvents.HOVERING,
       MenuItemEvents.UNHOVERED
    ];
 
-   // private width: number;
-   // private height: number;
-
    protected _width?: number;
    protected _height?: number;
 
-   // private updateProperty() {
-   //    const ctx = this.parent.getCtx();
-   //    this.textOffsets = this.getTextOffsets(ctx);
-   //    this.parent.childUpdated(ctx, this);
-   // }
    private _text: string;
    private _prefixText?: string;
    private _suffixText?: string;
@@ -214,20 +232,7 @@ class Button extends WidgetImpl implements WidgetEvents {
    private mousedOver: boolean = false;
    private events: Set<((ctx: CanvasRenderingContext2D) => void)> = new Set();
 
-   // private _visible: boolean = true;
-
-   // private calculatedWidth: number;
-   // private calculatedHeight: number;
-   // private textOffsets: [number, number, number];
-   private calculatedFields: {
-      width: number,
-      height: number,
-      textOffsets: {
-         mainTextX: number,
-         suffixX: number,
-         y: number,
-      },
-   } = {
+   private calculatedFields = {
       width: 0,
       height: 0,
       textOffsets: {
@@ -239,28 +244,17 @@ class Button extends WidgetImpl implements WidgetEvents {
 
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, cons: ButtonWidgetConstructor, globalProps: GlobalWidgetProperties) {
       super(globalProps, parent, cons);
-      // this.parent = parent;
-      // this.id = id;
 
       this._text = cons.text;
       this._prefixText = cons.prefixText;
       this._suffixText = cons.suffixText;
       this.centeredHorizontally = cons.centeredHorizontally ?? false;
-      // this.globalProps = globalProps;
 
       this.reservePrefixSpace = cons.reservePrefixSpace ?? true;
 
-      // this.updateCalculatedFields(ctx);
-      // const [minWidth, minHeight] = this.getMinSize();
-      // console.log(`defaults (minWidth, minHeight): (${minWidth}, ${minHeight})`);
-      this._width = cons.width/* ?? minWidth*/;
-      this._height = cons.height/* ?? minHeight*/;
-      // this.calculatedWidth = minWidth;
-      // this.calculatedHeight = minHeight;
-      // this.width = cons.width ?? minWidth;
-      // this.height = cons.height ?? minHeight;
-      
-      // this.textOffsets = this.getTextOffsets(ctx);
+      this._width = cons.width;
+      this._height = cons.height;
+
       this.updateCalculatedFields(ctx);
    }
 
@@ -295,7 +289,7 @@ class Button extends WidgetImpl implements WidgetEvents {
       
       textOffsets.y = (this.usedHeight + getHeight(ctx, this.getFont()))/2.0;
       textOffsets.suffixX = minSuffix;
-      console.log(`test: ${textOffsets.mainTextX}, ${textOffsets.y}, ${textOffsets.suffixX}, ${minPrefix}, ${minWidth}, ${minSuffix}, ${this.width}, ${this.height}, ${getHeight(ctx, this.getFont())}, ${minSuffix}`);
+      // console.log(`test: ${textOffsets.mainTextX}, ${textOffsets.y}, ${textOffsets.suffixX}, ${minPrefix}, ${minWidth}, ${minSuffix}, ${this.width}, ${this.height}, ${getHeight(ctx, this.getFont())}, ${minSuffix}`);
    }
 
    fullUpdate(ctx: CanvasRenderingContext2D) {
@@ -310,38 +304,8 @@ class Button extends WidgetImpl implements WidgetEvents {
       return this.globalProps.widgetTextFont;
    }
 
-   // set visible(visible: boolean) {
-   //    if (this._visible != visible) {
-   //       this._visible = visible;
-   //       this.parent.childUpdated(this.parent.getCtx(), this, false);
-   //    }
-   // }
-   // get visible() {
-   //    return this._visible;
-   // }
-
-   // getDimensions(): [number, number] {
-   //    return [
-   //       this.usedWidth, 
-   //       this.usedHeight
-   //    ];
-   // }
-   // setDimensions(width?: number, height?: number) {
-   //    if (
-   //       (width != undefined && width != this._width)
-   //       || (height != undefined && height != this._height)
-   //    ) {
-   //       this._height = height ?? this._height;
-   //       this._width = width ?? this._width;
-
-   //       console.log(`new dimensions (${this._text}): (${this._width}, ${this._height})`);
-   //       this.propagateUpdate();
-   //    }
-   // }
-
    private getFullMinSize(ctx: CanvasRenderingContext2D): [number, number, number, number] {
       ctx.save();
-      // ctx.font = this.globalProps.widgetTextFont;
       ctx.font = this.getFont();
       const spaceMeasure = ctx.measureText(" ");
       const spaceWidth = spaceMeasure.width;
@@ -373,70 +337,31 @@ class Button extends WidgetImpl implements WidgetEvents {
 
       const [minPrefix, minSuffix, ] = partWidths;
 
-      console.log(`getFullMinSize: ${minWidth}, ${minHeight}, ${minPrefix}, ${minSuffix}`);
+      // console.log(`getFullMinSize: ${minWidth}, ${minHeight}, ${minPrefix}, ${minSuffix}`);
 
       return [minWidth, minHeight, minPrefix, minSuffix];
    }
-   // getMinSize(): [number, number] {
-   //    // const [width, height,,] = this.getFullMinSize(this.parent.getCtx());
-   //    // console.log(`button min size (${this._text}), (${width}, ${height})`)
-   //    // return [width, height];
-   //    console.log(`button min size (${this._text}): (${this.calculatedFields.width}, ${this.calculatedFields.height})`);
-   //    return [
-   //       this.calculatedFields.width,
-   //       this.calculatedFields.height
-   //    ]
-   // }
+
    get minWidth() {
       return this.calculatedFields.width;
    }
-   get usedWidth() {
-      return this._width ?? this.calculatedFields.width;
-   }
+
    get minHeight() {
       return this.calculatedFields.height;
    }
-   get usedHeight() {
-      return this._height ?? this.calculatedFields.height;
-   }
-   // getTextOffsets(ctx: CanvasRenderingContext2D): [number, number, number] {
-   //    const [minWidth, minHeight, minPrefix, minSuffix] = this.getFullMinSize(ctx);
 
-   //    function getHeight(ctx: CanvasRenderingContext2D, font: string): number {
-   //       ctx.save();minHeight
-   //       ctx.font = font;
-   //       const measure = ctx.measureText("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.!?*&^%$#@)(0123456789-=_+`~[]{}\\|;:'\"");
-   //       ctx.restore();
-
-   //       return measure.actualBoundingBoxAscent + measure.actualBoundingBoxDescent;
-   //    }
-
-   //    return [
-   //       this.centeredHorizontally ? (this.width - (minWidth - minPrefix - minSuffix))/2.0 : minPrefix,
-   //       (this.height + getHeight(ctx, this.getFont()))/2.0,
-   //       minSuffix
-   //    ];
-   // }
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
       if (!this._visible)
          return;
 
       ctx.save();
 
-      if (this._text == "Box Options") {
-         // console.log(`box option dims: (${this._width}, ${this._height}); (${offsetX}, ${offsetY}); ${this.calculatedFields.textOffsets}`);
-         // console.log(this.calculatedFields.textOffsets);
-      }
-
-      // const width = this._width ?? this.calculatedFields.width;
-      // const height = this._height ?? this.calculatedFields.height;
       const textOffsets = this.calculatedFields.textOffsets;
 
       const button_color = this.mousedOver ? this.globalProps.selectedColor : this.globalProps.borderColor;
       ctx.fillStyle = button_color;
       ctx.fillRect(offsetX, offsetY, this.usedWidth, this.usedHeight);
 
-      // ctx.font = this.globalProps.widgetTextFont;
       ctx.font = this.getFont();
       ctx.fillStyle = this.globalProps.textColor;
       if (this._prefixText != undefined) {
@@ -465,7 +390,7 @@ class Button extends WidgetImpl implements WidgetEvents {
       if (!this._visible)
          return;
 
-      switch (event[0]) {
+      switch (event.type) {
          case MenuItemEvents.CLICKED:
          {
             for (const callback of this.events.keys()) {
@@ -487,7 +412,7 @@ class Button extends WidgetImpl implements WidgetEvents {
          break;
 
          default:
-            throw new Error(`Button handleMenuEvent was given an unrecognized event ${MenuItemEvents[event[0]] ?? event[0]}!`);
+            throw new Error(`Button handleMenuEvent was given an unrecognized event ${MenuItemEvents[event.type] ?? event.type}!`);
       }
    }
 
@@ -509,9 +434,6 @@ interface Vec2 {
    y: number
 }
 abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
-   // readonly globalProps: GlobalWidgetProperties;
-   // readonly parent: WidgetManager;
-   // readonly id: number;
 
    readonly handledEvents: MenuItemEvents[] = [
       MenuItemEvents.CLICKED,
@@ -537,22 +459,13 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
       }
    }
 
-   // protected get width() {return this._width};
-   // protected get height() {return this._height};
-
-   //the currently hovered over/selected item 
-   //resets to undefined on menu update or UNHOVERED event
    private selectedItem?: ContainedWidget;
 
-   // private _visible: boolean = true;
    private _drawOutline: boolean;
    get drawOutline() {return this._drawOutline};
    
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, props: MenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
       super(globalProps, parent, {});
-      // this.globalProps = globalProps;
-      // this.parent = parent;
-      // this.id = id;
 
       this._width = props.width;
       this._height = props.height;
@@ -574,27 +487,15 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
       this.selectedItem = undefined;
    }
 
-   // set visible(visible: boolean) {
-   //    const ctx = this.parent.getCtx();
-   //    if (this._visible != visible) {
-   //       if (!visible)
-   //          this.handleMenuEvent(ctx, [MenuItemEvents.CLICKED_OFF]);
-
-   //       this._visible = visible;
-   //       this.parent.childUpdated(ctx, this, false);
-   //    }
-   // }
-   // get visible() {
-   //    return this._visible;
-   // }
-
    protected propagateUpdate(ctx?: CanvasRenderingContext2D): void {
+      // this.supressChildUpdates = true;
       const n_ctx = ctx ?? this.parent.getCtx();
-      this.handleMenuEvent(n_ctx, [MenuItemEvents.CLICKED_OFF]);
+      this.handleMenuEvent(n_ctx, {type: MenuItemEvents.CLICKED_OFF});
 
       if (this._visible) {
          this.updateChildSize();
       }
+      // this.supressChildUpdates = false;
    }
 
    pauseDeleteHandle: boolean = false;
@@ -633,8 +534,6 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
       this.parent.closePopup(ctx, widget);
    }
 
-   // lastWidth: number = 0;
-   // lastHeight: number = 0;
    protected supressChildUpdates: boolean = false;
    protected abstract updateChildSize(forceRun?: boolean): void;
 
@@ -664,12 +563,6 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
       return widget;
    }
 
-   // getMinSize(): [number, number] {
-   //    return [
-   //       this._calculatedDimensions.x, 
-   //       this._calculatedDimensions.y
-   //    ];
-   // }
    get minWidth() {
       return this._calculatedDimensions.x;
    }
@@ -716,7 +609,7 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
 	}
    
    private dispatchEvent(ctx: CanvasRenderingContext2D, widget: Widget, event: MenuItemEventData) {
-      if (widget.handledEvents.includes(event[0]) && widget.visible) {
+      if (widget.handledEvents.includes(event.type) && widget.visible) {
          widget.handleMenuEvent(ctx, event);
       }
    }
@@ -737,7 +630,7 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
             return; //the selected item is in bounds
          } else {
             //selected item is out of bounds
-            this.dispatchEvent(ctx, this.selectedItem.widget, [MenuItemEvents.UNHOVERED]);
+            this.dispatchEvent(ctx, this.selectedItem.widget, {type:MenuItemEvents.UNHOVERED});
             this.selectedItem = undefined;
          }
       }
@@ -746,7 +639,7 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
          //found child it's hovering over
          if (this.mouseInWidgetBounds(child, x, y) && child.widget.visible) {
             this.selectedItem = child;
-            this.dispatchEvent(ctx, child.widget, [MenuItemEvents.HOVERING]);
+            this.dispatchEvent(ctx, child.widget, {type:MenuItemEvents.HOVERING});
             //break early
             return;
          }
@@ -755,30 +648,30 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
    handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData): void {
       if (!this._visible)
          return;
-		switch (event[0]) {
+		switch (event.type) {
          case MenuItemEvents.MOUSE_MOVE:
          {
-            const [, eX, eY] = event;
+            const {x: eX, y: eY} = event;
             this.updateSelectedObject(ctx, eX, eY);
             if (this.selectedItem) {
                const {widget, x: wX, y: wY} = this.selectedItem;
                const [x, y] = [eX - wX, eY - wY];
-               this.dispatchEvent(ctx, widget, [MenuItemEvents.MOUSE_MOVE, x, y]);
+               this.dispatchEvent(ctx, widget, {type: MenuItemEvents.MOUSE_MOVE, x: x, y: y});
             }
          }
          break;
          case MenuItemEvents.CLICKED:
          {
-            const [, eX, eY, button] = event;
+            const {x: eX, y: eY, button} = event;
             this.updateSelectedObject(ctx, eX, eY);
             const selected = this.selectedItem;
             for (const {widget} of this.children) {
                if (selected == undefined || widget != selected.widget)
-                  this.dispatchEvent(ctx, widget, [MenuItemEvents.CLICKED_OFF]);
+                  this.dispatchEvent(ctx, widget, {type: MenuItemEvents.CLICKED_OFF});
             }
             if (selected) {
                const [x, y] = [eX - selected.x, eY - selected.y];
-               this.dispatchEvent(ctx, selected.widget, [MenuItemEvents.CLICKED, x, y, button]);
+               this.dispatchEvent(ctx, selected.widget, {type: MenuItemEvents.CLICKED, x: x, y: y, button: button});
             }
             
          }
@@ -786,7 +679,7 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
          case MenuItemEvents.UNHOVERED:
          {
             if (this.selectedItem) {
-               this.dispatchEvent(ctx, this.selectedItem.widget, [MenuItemEvents.UNHOVERED]);
+               this.dispatchEvent(ctx, this.selectedItem.widget, {type: MenuItemEvents.UNHOVERED});
                this.selectedItem = undefined;
             }
             for (const handler of this.unhoverHandlers) {
@@ -800,40 +693,11 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
                handler();
             }
             for (const {widget} of this.children)
-               this.dispatchEvent(ctx, widget, [MenuItemEvents.CLICKED_OFF]);
+               this.dispatchEvent(ctx, widget, {type: MenuItemEvents.CLICKED_OFF});
          }
          break;
       }
 	}
-
-   // getDimensions(): [number, number] {
-   //    return [
-   //       this._width ?? this._calculatedDimensions.x,
-   //       this._height ?? this._calculatedDimensions.y
-   //    ];
-	// }
-   get usedWidth() {
-      return this._width ?? this._calculatedDimensions.x;
-   }
-   get usedHeight() {
-      return this._height ?? this._calculatedDimensions.y;
-   }
-
-   // setDimensions(width?: number, height?: number): void {
-   //    if (width != undefined){
-   //       if (width == 0)
-   //          this._width = undefined;
-   //       else
-   //          this._width = width;
-   //    }
-   //    if (height != undefined){
-   //       if (height == 0)
-   //          this._height = undefined;
-   //       else
-   //          this._height = height;
-   //    }
-	// }
-
 
    bindUnhoverEvent(callback: () => void) {
       this.unhoverHandlers.push(callback);
@@ -883,7 +747,6 @@ class Menu extends WidgetContainer {
             }
          }
       }
-      // console.log(`open popup (Menu): (${x}, ${y}); (${nX}, ${nY})`);
       this.parent.openPopup(ctx, widget, nX, nY, nextRelative);
    }
 
@@ -892,25 +755,19 @@ class Menu extends WidgetContainer {
    supressChildUpdates: boolean = false;
    protected updateChildSize(forceRun: boolean = false) {
       let childWidth = 0;
-      // let maxChildHeight = this.minChildHeight;
       let childHeight = 0;
       for (const {widget} of this.children) {
          if (!widget.visible)
             continue;
-         // const [width, ] = widget.getMinSize();
          const width = widget.minWidth;
          childWidth = Math.max(childWidth, width);
-         // maxChildHeight = Math.max(maxChildHeight, height+this.yPadding);
-         // const [, height] = widget.getDimensions();
          childHeight += widget.usedHeight + this.globalProps.yPadding;
       }
       childWidth += this.globalProps.menuBorderWidth * 4;
       childHeight += this.globalProps.menuBorderWidth * 2;
 
-      // console.log(childWidth, childHeight);
 
       childWidth = Math.max(childWidth, this.globalProps.emptyMenuWidth);
-      // let childHeight = Math.max(maxChildHeight*this.children.length, this.absoluteMinHeight);
       childHeight = Math.max(childHeight, this.globalProps.emptyMenuHeight);
 
       const newWidth = super.width ?? childWidth;
@@ -920,9 +777,6 @@ class Menu extends WidgetContainer {
          y: newHeight
       };
 
-      // console.log(newWidth, newHeight, this.childWidth, this.childHeight);
-
-      // console.log(`updating width: ${newWidth}; ${super.width}, ${childWidth}`);
       if (this.lastWidth != newWidth || this.lastHeight != newHeight || forceRun) {
          this.lastWidth = newWidth;
          this.lastHeight = newHeight;
@@ -931,13 +785,10 @@ class Menu extends WidgetContainer {
          for (const child of this.children) {
             if (!child.widget.visible)
                continue;
-            // const [, height] = child.widget.getDimensions();
             this.supressChildUpdates = true;
             child.widget.width = newWidth - this.globalProps.menuBorderWidth * 4;
-            // child.widget.setDimensions(newWidth - this.globalProps.menuBorderWidth * 4, undefined);
             child.y = curHeight;
             this.supressChildUpdates = false;
-            // curHeight += maxChildHeight;
             curHeight += child.widget.usedHeight + this.globalProps.yPadding;
          }
 
@@ -963,14 +814,11 @@ class MenuBar extends WidgetContainer {
          if (!widget.visible)
             continue;
 
-         // const [widgetWidth, widgetHeight] = widget.getDimensions();
          const [widgetWidth, widgetHeight] = [widget.usedWidth, widget.usedHeight];
-         // const [widgetMinWidth, widgetMinHeight] = widget.getMinSize();
          const [widgetMinWidth, widgetMinHeight] = [widget.minWidth, widget.minHeight];
          
          minHeight = Math.max(minHeight, widgetHeight, widgetMinHeight);
          width += Math.max(this.globalProps.emptyMenuWidth, widgetWidth, widgetMinWidth) + this.globalProps.xPadding;
-         // console.log(`${widgetWidth}, ${widgetMinWidth}, ${Math.max(this.minChildWidth, widgetWidth, widgetMinWidth)}`);
       }
 
       super.calculatedDimensions = {
@@ -987,15 +835,9 @@ class MenuBar extends WidgetContainer {
          if (!child.widget.visible)
             continue;
 
-         // const [widgetWidth, widgetHeight] = child.widget.getDimensions();
          const widgetWidth = child.widget.usedWidth;
-         // const [minWidgetWidth,] = child.widget.getMinSize();
          const minWidgetWidth = child.widget.minWidth;
          const nWidth = Math.max(this.globalProps.emptyMenuWidth, widgetWidth, minWidgetWidth);
-         // child.widget.setDimensions(
-         //    nWidth,
-         //    tmpHeight
-         // );
          child.widget.width = nWidth;
          child.widget.height = tmpHeight;
 
@@ -1027,7 +869,6 @@ class MenuBar extends WidgetContainer {
             }
          }
       }
-      // console.log(`open popup (MenuBar): (${x}, ${y}); (${nX}, ${nY})`);
       this.parent.openPopup(ctx, widget, nX, nY += this.globalProps.menuBorderWidth, nextRelative);
    }
 }
@@ -1082,7 +923,6 @@ class RootWidgetManager implements WidgetManager {
             }
          }
       }
-      // console.log(`open popup (Root): (${x}, ${y}); (${nX}, ${nY})`);
       this.popupWidgets.set(widget, [nX, nY]);
       this.childUpdated(ctx, widget);
    }
@@ -1096,13 +936,12 @@ class RootWidgetManager implements WidgetManager {
    }
 
    private widgetInBounds(widget: Widget, widgetX: number, widgetY: number, x: number, y: number): boolean {
-      // const [wW, wH] = widget.getDimensions();
       const [wW, wH] = [widget.usedWidth, widget.usedHeight];
       return widgetX <= x && x <= widgetX + wW
          && widgetY <= y && y <= widgetY + wH;
    }
    private dispatchEvent(ctx: CanvasRenderingContext2D, widget: Widget, event: MenuItemEventData) {
-      if (widget.handledEvents.includes(event[0])) {
+      if (widget.handledEvents.includes(event.type)) {
          widget.handleMenuEvent(ctx, event);
       }
    }
@@ -1111,7 +950,7 @@ class RootWidgetManager implements WidgetManager {
          if (this.widgetInBounds(this.selectedWidget[0], this.selectedWidget[1], this.selectedWidget[2], x, y) && this.selectedWidget[0].visible) {
             return;
          } else {
-            this.dispatchEvent(ctx, this.selectedWidget[0], [MenuItemEvents.UNHOVERED]);
+            this.dispatchEvent(ctx, this.selectedWidget[0], {type: MenuItemEvents.UNHOVERED});
             this.selectedWidget = undefined;
          }
       }
@@ -1123,7 +962,7 @@ class RootWidgetManager implements WidgetManager {
          const [widget, [widgetX, widgetY]] = widgetList[i];
          if (this.widgetInBounds(widget, widgetX, widgetY, x, y)) {
             this.selectedWidget = [widget, widgetX, widgetY];
-            this.dispatchEvent(ctx, widget, [MenuItemEvents.HOVERING]);
+            this.dispatchEvent(ctx, widget, {type: MenuItemEvents.HOVERING});
             return;
          }
       }
@@ -1133,7 +972,7 @@ class RootWidgetManager implements WidgetManager {
 
          if (this.widgetInBounds(widget, widgetX, widgetY, x, y) && widget.visible) {
             this.selectedWidget = [widget, widgetX, widgetY];
-            this.dispatchEvent(ctx, widget, [MenuItemEvents.HOVERING]);
+            this.dispatchEvent(ctx, widget, {type: MenuItemEvents.HOVERING});
             return;
          }
       }
@@ -1144,7 +983,7 @@ class RootWidgetManager implements WidgetManager {
       if (!this.selectedWidget) {
          if (event == CanvasEventTypes.MOUSE_CLICK) {
             for (const [popup, ] of this.popupWidgets) {
-               this.dispatchEvent(ctx, popup, [MenuItemEvents.CLICKED_OFF]);
+               this.dispatchEvent(ctx, popup, {type: MenuItemEvents.CLICKED_OFF});
             }
          }
          return false;
@@ -1154,7 +993,7 @@ class RootWidgetManager implements WidgetManager {
          case CanvasEventTypes.MOUSE_MOVE:
          {
             const [nX, nY] = [x - this.selectedWidget[1], y - this.selectedWidget[2]];
-            this.dispatchEvent(ctx, this.selectedWidget[0], [MenuItemEvents.MOUSE_MOVE, nX, nY]);
+            this.dispatchEvent(ctx, this.selectedWidget[0], {type: MenuItemEvents.MOUSE_MOVE, x: nX, y: nY});
          }
          break;
 
@@ -1164,11 +1003,11 @@ class RootWidgetManager implements WidgetManager {
             if (!this.popupWidgets.has(selected[0])) {
                for (const popup of this.popupWidgets) {
                   if (selected[0] != popup[0])
-                     this.dispatchEvent(ctx, popup[0], [MenuItemEvents.CLICKED_OFF]);
+                     this.dispatchEvent(ctx, popup[0], {type: MenuItemEvents.CLICKED_OFF});
                }
             }
             const [nX, nY] = [x - selected[1], y - selected[2]];
-            this.dispatchEvent(ctx, selected[0], [MenuItemEvents.CLICKED, nX, nY, button]);
+            this.dispatchEvent(ctx, selected[0], {type: MenuItemEvents.CLICKED, x: nX, y: nY, button: button});
          }
          break;
       }
@@ -1223,11 +1062,9 @@ class MenuButton extends Button implements WidgetManager {
       }, globalProps);
 
       super.addEvent((() => {
-         // const [width,height] = super.getDimensions();
          const [width, height] = [super.usedWidth, super.usedHeight];
          let x = this.openToRight ? width + this.offset : 0;
          let y = this.openToRight ? 0 : height + this.offset;
-         // console.log(`spawning menu at: (${x}, ${y})`)
          this.parent.openPopup(ctx, this.menu, x, y, this);
          this.menuOpened = true;
       }).bind(this));
@@ -1264,9 +1101,9 @@ class MenuButton extends Button implements WidgetManager {
       return deleted;
    }
    handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
-      if (event[0] == MenuItemEvents.CLICKED_OFF) {
+      if (event.type == MenuItemEvents.CLICKED_OFF) {
          if (this.menuOpened) {
-            this.menu.handleMenuEvent(ctx, [MenuItemEvents.CLICKED_OFF]);
+            this.menu.handleMenuEvent(ctx, {type: MenuItemEvents.CLICKED_OFF});
             this.parent.closePopup(ctx, this.menu);
          }
       } else {
@@ -1296,15 +1133,10 @@ interface SeperatorWidgetConstructor extends WidgetConstructor {
    seperatorText: string,
 }
 class Seperator extends WidgetImpl {
-   // readonly globalProps: GlobalWidgetProperties;
-   // readonly parent: WidgetManager;
-   // readonly id: number;
    readonly handledEvents: MenuItemEvents[] = [];
 
    private seperatorText: string;
 
-   // private width: number;
-   // private height: number;
    protected _width?: number;
    protected _height?: number;
 
@@ -1317,19 +1149,11 @@ class Seperator extends WidgetImpl {
    set text(val: string) {this._text = val; this.fullUpdate(this.parent.getCtx())};
    get text(): string {return this._text};
 
-   // private _visible: boolean = true;
-
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, props: SeperatorWidgetConstructor, globalProps: GlobalWidgetProperties) {
       super(globalProps, parent, {});
-      // this.globalProps = globalProps;
-      // this.parent = parent;
-      // // this.id = id;
-      // this.id = ++NEXT_WIDGET_ID;
       
       this.seperatorText = props.seperatorText;
 
-      // this.width = props.width ?? 0;
-      // this.height = props.height ?? 0;
       this._width = props.width;
       this._height = props.height;
 
@@ -1339,23 +1163,12 @@ class Seperator extends WidgetImpl {
       this.updateText(ctx);
    }
 
-   // set visible(visible: boolean) {
-   //    if (this._visible != visible) {
-   //       this._visible = visible;
-   //       this.parent.childUpdated(this.parent.getCtx(), this, false);
-   //    }
-   // }
-   // get visible() {
-   //    return this._visible;
-   // }
-
    delete(ctx: CanvasRenderingContext2D) {
       this.parent.handleDelete(ctx, this);
       return [this];
    }
    private updateText(ctx: CanvasRenderingContext2D) {
       ctx.save();
-      // console.log(this.width);
 
       ctx.font = this.globalProps.widgetTextFont;
       const metrics = ctx.measureText(this.seperatorText);
@@ -1368,22 +1181,17 @@ class Seperator extends WidgetImpl {
       this._text = this.seperatorText.repeat(repeats);
 
       this.textXOffset = (this.usedWidth - width)/2.0;
-      // console.log(width, this.width, this.textXOffset);
       this.textYOffset = (this.usedHeight + height)/2.0;
       
 
       ctx.restore();
    }
 
-   // getMinSize(): [number, number] {
-   //    return [0, this.minHeight];
-   // }
+
    get minWidth() {
       return 0;
    }
-   get usedWidth() {
-      return this._width ?? 0;
-   }
+
    get minHeight() {
       if (this._width == 0) {
          return 0;
@@ -1391,9 +1199,7 @@ class Seperator extends WidgetImpl {
          return this._minHeight;
       }
    }
-   get usedHeight() {
-      return this._height ?? this.minHeight;
-   }
+
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
       if (!this._visible)
          return;
@@ -1403,7 +1209,6 @@ class Seperator extends WidgetImpl {
       ctx.font = this.globalProps.widgetTextFont;
       ctx.fillStyle = this.globalProps.textColor;
 
-      // console.log(this.x, offsetX, this.textXOffset, this.x + offsetX + this.textXOffset);
       ctx.fillText(
          this._text,
          offsetX + this.textXOffset,
@@ -1415,20 +1220,9 @@ class Seperator extends WidgetImpl {
    handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
       throw new Error(`Seperator widget doesn't accept events!!`);
    }
-   // getDimensions(): [number, number] {
-   //    return [this.usedWidth, this.usedHeight];
-   // }
    protected propagateUpdate(ctx?: CanvasRenderingContext2D): void {
       this.updateText(ctx ?? this.parent.getCtx());
    }
-   // setDimensions(width?: number, height?: number) {
-   //    this.width = width ?? this.width;
-   //    this.height = height ?? this.height;
-   //    if (width != undefined || height != undefined) {
-   //       // this.updateText(this.parent.getCtx());
-   //       this.propagateUpdate();
-   //    }
-   // }
 }
 
 
@@ -1603,8 +1397,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       | [WidgetType.CheckBox, CheckBox]
    > = new Map();
    
-   // nextWidgetID: number = 0;
-
    readonly manager: RootWidgetManager;
    readonly menu: MenuBar;
 
@@ -1637,7 +1429,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       twrWindowMenuAddWidget: {},
       twrWindowMenuWidgetAddCallback: {},
       twrWindowMenuDeleteWidget: {},
-      // twrWindowMenuRadioMenuAddOption: {},
       twrWindowMenuWidgetSetVisibility: {},
       twrWindowMenuRadioItemMerge: {},
    };
@@ -1654,14 +1445,9 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       this.ctx = canvas.getContext("2d")!;
       this.manager = new RootWidgetManager(this.ctx);
 
-      // const perimiterThickness = Math.min(canvas.height, canvas.width) * 0.025;
-      // const menuThickness = Math.min(canvas.height, canvas.width) * 0.1;
-
       this.appCanvasHeight = Math.floor(canvas.height - BORDER_SIZE - TOP_BAR_SIZE);
       this.appCanvasWidth = Math.floor(canvas.width - BORDER_SIZE*2.0);
 
-      // this.topBarSize = menuThickness;
-      // this.borderSize = perimiterThickness;
 
       const appCanvas = document.createElement("canvas");
       appCanvas.height = this.appCanvasHeight;
@@ -1677,23 +1463,13 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          type: 0
       };
 
-      // const buttonOpts: ButtonWidgetConstructor = {
-      //    x: 100,
-      //    y: 100,
-      //    text: "TEST!!!",
-      //    textFont: "64px Serif",
-      //    width: 300,
-      //    height: 300,
-      //    buttonColor: "#B0B0B0B0"
-      // };
-      // this.manager.addChild(this.ctx, -10, Button, buttonOpts);
       const menuBarCons: MenuWidgetConstructor = {
          // minChildWidth: 10,
          // menuColor: "#B0B0B0",
          height: TOP_BAR_SIZE - 2,
          // xPadding: MENU_PADDING_X,
       };
-      console.log(`Menu Bar target size: ${menuBarCons.height}, ${TOP_BAR_SIZE - 0.5}`);
+      // console.log(`Menu Bar target size: ${menuBarCons.height}, ${TOP_BAR_SIZE - 0.5}`);
       this.menu = this.manager.addChild(this.ctx, MenuBar, menuBarCons, this.widgetSettings, BORDER_SIZE + MENU_PADDING_X, 0);
    }
 
@@ -2067,16 +1843,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       }
    }
 
-   // twrWindowMenuRadioMenuAddOption(mod: IWasmModuleAsync | IWasmModule, widgetID: number, optionPtr: number) {
-   //    if (!this.widgets.has(widgetID)) throw new Error(`twrWindowMenuRadioMenuAddOption: Error! was given an invalid widgetID (${widgetID})`);
-   //    const widget = this.widgets.get(widgetID)!;
-
-   //    if (widget[0] != WidgetType.RadioMenu) throw new Error(`twrWindowMenuRadioMenuAddOption: Error! was given an invalid widget type! Expected RadioMenu, got ${WidgetType[widget[0]]}`);
-      
-   //    const radio: RadioMenu = widget[1];
-
-   //    radio.addOption(this.ctx, mod.getString(optionPtr));
-   // }
    twrWindowMenuRadioItemMerge(mod: IWasmModuleAsync | IWasmModule, widgetID1: number, widgetID2: number) {
       const widget1 = this.widgets.get(widgetID1);
       const widget2 = this.widgets.get(widgetID2);

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -24,30 +24,31 @@ enum twrWindowEvents {
 //    isAsync: boolean,
 //    then: <U>(func: (...val: T) => U) => U | Promise<U>;
 // }
-class FakePromise<T> implements PromiseLike<T> {
-   private val: T | Promise<T>;
+class FakePromise<T> {
+   private val: T;
    constructor(val: T) {
+      if (val instanceof Promise) {
+         throw new Error("FakePromise can't accept promises!!");
+      }
       this.val = val;
    }
-   then<TResult1, TResult2>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined): PromiseLike<TResult1 | TResult2> {
-      if ((onfulfilled == null || onfulfilled == undefined) && (onrejected == null || onrejected == undefined)) {
-         throw new Error(`FakePromise.then must have at least one parameter defined!!`);
-      }
-      if (this.val instanceof Promise) {
-         return new FakePromise(this.val.then(onfulfilled, onrejected));
-      }
-      throw new Error();
-   }
-   extractVal(): T | Promise<T> {
-      return this.val;
-   }
-   private setupNextFakePromise<U>(val: U | FakePromise<U> | Promise<U>): FakePromise<U> | FakePromise<Promise<U>> {
-      if (val instanceof FakePromise) {
-         return val;
-      } else if (val instanceof Promise) {
-         return new FakePromise(val);
+   then<TResult1, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | FakePromise<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined): FakePromise<TResult1 | TResult2> {
+      if (onfulfilled != undefined && onfulfilled != null) {
+         const val = onfulfilled(this.extractVal());
+         if (val instanceof FakePromise) {
+            return new FakePromise(val.extractVal());
+         } else {
+            return new FakePromise(val);
+         }
       } else {
-         return new FakePromise(val);
+         throw new Error("must have a fullfilled case?");
+      }
+   }
+   extractVal(): T {
+      if (this.val instanceof FakePromise) {
+         return this.val.extractVal();
+      } else {
+         return this.val;
       }
    }
 }
@@ -1605,6 +1606,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       twrWindowMenuRadioItemMerge: {},
       twrWindowMenuWidgetSetProp: {},
       twrWindowMenuWidgetGetProp: {isAsyncFunction: true},
+      twrWindowMenuWidgetListProps: {},
    };
 
    // every library should have this line
@@ -2243,43 +2245,19 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       return propField[0] as number;
    }
 
-   // private wrapPossibleSync<T extends (...args: any[]) => any>(func: T, ...args: Parameters<T>): AsyncLikeSyncInterface<[ReturnType<T>]> {
-   //    const val = func(...args);
-   //    if (val instanceof Promise) {
-   //       return {
-   //          isAsync: true,
-   //          then: <U>(n_func: (val: ReturnType<T>) => U): U | Promise<U> => {
-   //             return val.then(n_func);
-   //          }
-   //       };
-   //    } else {
-   //       return {
-   //          isAsync: false,
-   //          then: <U>(n_func: (val: ReturnType<T>) => U): U | Promise<U> => {
-   //             return n_func(val);
-   //          }
-   //       }
-   //    }
-   // }
-   private wrapPossibleSync<T extends (...args: any[]) => any>(func: T, ...args: Parameters<T>): FakePromise<ReturnType<T>> | Promise<ReturnType<T>> {
-      const val = func(...args);
+   private wrapPossibleSync<T>(val: Promise<T>|T): Promise<T>|FakePromise<T> {
       if (val instanceof Promise) {
-         // return {
-         //    isAsync: true,
-         //    then: <U>(n_func: (val: ReturnType<T>) => U): U | Promise<U> => {
-         //       return val.then(n_func);
-         //    }
-         // };
          return val;
       } else {
-         // return {
-         //    isAsync: false,
-         //    then: <U>(n_func: (val: ReturnType<T>) => U): U | Promise<U> => {
-         //       return n_func(val);
-         //    }
-         // }
-         
          return new FakePromise(val);
+      }
+   }
+
+   private unwrapPossibleSync<T>(val: Promise<T>|FakePromise<T>): Promise<T>|T {
+      if (val instanceof FakePromise) {
+         return val.extractVal();
+      } else {
+         return val;
       }
    }
    // private waitForAll<
@@ -2298,7 +2276,17 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    //       }
    //    }
    // }
-   twrWindowMenuWidgetListProps(mod: IWasmModuleAsync, widgetID: number, lengthPtr: number) {
+   waitForAll<T extends any[]>(
+      vals: (FakePromise<T[number]> | Promise<T[number]>)[]
+   ): Promise<T> | FakePromise<T> {
+      if (vals[0] instanceof Promise) {
+         return Promise.all(vals) as Promise<T>;
+      } else if (vals[0] instanceof FakePromise) {
+         return new FakePromise((vals as FakePromise<any>[]).map((val) => val.extractVal())) as FakePromise<T>;
+      }
+      throw new Error('internal error!');
+   }
+   twrWindowMenuWidgetListProps(mod: IWasmModuleAsync | IWasmModule, widgetID: number, lengthPtr: number) {
       const widget = this.widgets.get(widgetID);
       if (widget == undefined) throw new Error(`twrWindowMenuWidgetListProps: Error! was given an invalid widgetID (${widgetID})`);
 
@@ -2313,7 +2301,8 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       totalSize += props.length * 4;
       mod.wasmMem.setLong(lengthPtr, props.length);
 
-      return this.wrapPossibleSync(mod.malloc, totalSize).then((alloc) => {
+
+      return this.unwrapPossibleSync(this.wrapPossibleSync(mod.malloc(totalSize)).then((alloc) => {
          let offset = props.length*4;
          for (let i = 0; i < props.length; i++) {
             mod.wasmMem.setLong(i * 4, offset);
@@ -2322,8 +2311,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             offset += props[i].length + 1;
          }
          return alloc;
-      });
-      
+      }));
 
       // return alloc
    }

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -694,6 +694,236 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
 
 }
 
+interface MenuBarWidgetConstructor extends WidgetConstructor {
+   minimumWidth?: number;
+   minimumHeight?: number;
+   menuColor?: string;
+   xPadding?: number;
+   minChildWidth?: number;
+}
+
+class MenuBar implements Widget, WidgetManager {
+   readonly parent: WidgetManager;
+   readonly id: number;
+   readonly handledEvents: MenuItemEvents[] = [
+      MenuItemEvents.CLICKED,
+      MenuItemEvents.CLICKED_OFF,
+      MenuItemEvents.UNHOVERED,
+      MenuItemEvents.MOUSE_MOVE
+   ];
+
+   private x: number;
+   private y: number;
+   private width?: number;
+   private height?: number;
+   private minimumWidth: number;
+   private minimumHeight: number;
+   private menuColor: string;
+   private xPadding: number;
+   private minChildWidth: number;
+
+   private calcHeight;
+   private calcWidth;
+
+   private children: Widget[] = [];
+
+   private supressChildUpdates = false;
+
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuBarWidgetConstructor) {
+      this.parent = parent;
+      this.id = id;
+
+      this.x = props.x;
+      this.y = props.y;
+      this.width = props.width;
+      this.height = props.height;
+
+      this.minimumWidth = props.minimumWidth ?? 10;
+      this.minimumHeight = props.minimumHeight ?? 10;
+      this.calcWidth = this.minimumWidth;
+      this.calcHeight = this.minimumHeight;
+      this.menuColor = props.menuColor ?? "#B0B0B0";
+      this.xPadding = props.xPadding ?? 5;
+      this.minChildWidth = props.minChildWidth ?? 10;
+   }
+   getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
+      return [this.calcWidth, this.calcHeight];
+   }
+   render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
+      for (let i = this.children.length-1; i >= 0; i--) {
+         const widget = this.children[i];
+         widget.render(
+            ctx,
+            this.x + offsetX,
+            this.y + offsetY
+         );
+      }
+   };
+
+   private selected?: Widget;
+   private dispatchEvent(ctx: CanvasRenderingContext2D, widget: Widget, event: MenuItemEventData) {
+      if (widget.handledEvents.includes(event[0])) {
+         widget.handleMenuEvent(ctx, event);
+      }
+   }
+   private mouseInWidgetBounds(widget: Widget, x: number, y: number) {
+      const [wX, wY, wW, wH] = widget.getDimensions();
+      return wX <= x && x <= wX + wW
+            && wY <= y && y <= wY + wH;
+   }
+   private updateSelected(ctx: CanvasRenderingContext2D, x: number, y: number) {
+      if (this.selected) {
+         if (this.mouseInWidgetBounds(this.selected, x, y)) {
+            return;
+         } else {
+            this.dispatchEvent(ctx, this.selected, [MenuItemEvents.UNHOVERED]);
+            this.selected = undefined;
+         }
+      }
+
+      for (const widget of this.children) {
+         if (this.mouseInWidgetBounds(widget, x, y)) {
+            this.selected = widget;
+            this.dispatchEvent(ctx, widget, [MenuItemEvents.HOVERING]);
+            return;
+         }
+      }
+   }
+   handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
+      switch (event[0]) {
+         case MenuItemEvents.MOUSE_MOVE:
+         {
+            const [,eX, eY] = event;
+            const [x, y] = [eX - this.x, eY - this.y];
+            this.updateSelected(ctx, x, y);
+            if (this.selected)
+               this.dispatchEvent(ctx, this.selected, [MenuItemEvents.MOUSE_MOVE, x, y]);
+         }
+         break;
+         case MenuItemEvents.CLICKED:
+         {
+            const [,eX, eY] = event;
+            const [x, y] = [eX - this.x, eY - this.y];
+            this.updateSelected(ctx, x, y);
+            if (this.selected)
+               this.dispatchEvent(ctx, this.selected, [MenuItemEvents.CLICKED, x, y]);
+         }
+         break;
+         case MenuItemEvents.UNHOVERED:
+         {
+            if (this.selected)
+               this.dispatchEvent(ctx, this.selected, [MenuItemEvents.UNHOVERED]);
+            this.selected = undefined;
+         }
+         break;
+
+         default:
+         {
+            throw new Error(`MenuBar HandleMenuEvent: Error! Was given an unhandled event (${MenuItemEvents[event[0]]})!`);
+         }
+         break;
+      }
+   }
+   getDimensions(): [number, number, number, number] {
+      return [
+         this.x,
+         this.y,
+         this.width ?? this.calcWidth,
+         this.height ?? this.calcHeight
+      ];
+   }
+   setDimensions(ctx: CanvasRenderingContext2D, x?: number, y?: number, width?: number, height?: number) {
+      this.x = x ?? this.x;
+      this.y = y ?? this.y;
+      this.width = width ?? this.width;
+      this.height = height ?? this.height;
+      this.parent.childUpdated(ctx, this);
+   }
+   delete(ctx: CanvasRenderingContext2D): Widget[] {
+      this.supressChildUpdates = true;
+      let deleted: Widget[] = [this];
+      for (const widget of this.children) {
+         deleted.push(...widget.delete(ctx));
+      }
+      this.children = [];
+      this.supressChildUpdates = false;
+      return deleted;
+   }
+   private updateChildren(ctx: CanvasRenderingContext2D) {
+      let minHeight = this.minimumHeight;
+      let width = 0;
+      for (const widget of this.children) {
+         const [,,widgetWidth, widgetHeight] = widget.getDimensions();
+         const [widgetMinWidth, widgetMinHeight] = widget.getMinSize(ctx);
+         
+         minHeight = Math.max(minHeight, widgetHeight, widgetMinHeight);
+         width += Math.max(this.minChildWidth, widgetWidth, widgetMinWidth) + this.xPadding;
+         console.log(`${widgetWidth}, ${widgetMinWidth}, ${Math.max(this.minChildWidth, widgetWidth, widgetMinWidth)}`);
+      }
+
+      this.calcHeight = minHeight;
+      this.calcWidth = width;
+
+      const tmpHeight = this.height ?? this.calcHeight;
+      const tmpWidth = this.width ?? this.calcWidth;
+      
+      let pos = 0;
+      this.supressChildUpdates = true;
+      for (const widget of this.children) {
+         const [,,widgetWidth, widgetHeight] = widget.getDimensions();
+         const [minWidgetWidth,] = widget.getMinSize(ctx);
+         const nWidth = Math.max(this.minChildWidth, widgetWidth, minWidgetWidth);
+         widget.setDimensions(
+            ctx,
+            pos,
+            0,
+            nWidth,
+            tmpHeight
+         );
+         pos += nWidth + this.xPadding;
+      }
+      this.supressChildUpdates = false;
+   }
+
+   childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) {
+      if (sendToRoot) {
+         this.parent.childUpdated(ctx, widget, true);
+      } else if(!this.supressChildUpdates) {
+         this.updateChildren(ctx);
+      }
+   }
+   addChild<
+      T extends Widget, 
+      U, 
+      O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U) => T
+   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
+      const widget: T = new cons(ctx, this, id, props);
+      
+      this.children.push(widget);
+      this.childUpdated(ctx, widget);
+
+      return widget;
+   }
+
+   openPopup(ctx: CanvasRenderingContext2D, widget: Widget) {
+      this.parent.openPopup(ctx, widget);
+   }
+   closePopup(ctx: CanvasRenderingContext2D, widget: Widget) {
+      this.parent.closePopup(ctx, widget);
+   }
+   handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
+      if (!this.supressChildUpdates) {
+         const i = this.children.indexOf(widget);
+         if (i < 0)
+            throw new Error(`MenuBar handleDelete was given an unregistered widget to delete!`);
+         
+         this.children.splice(i, 1);
+         this.updateChildren(ctx);
+            
+      }
+   }
+}
+
 class RootWidgetManager implements WidgetManager {
    private boundWidgets: Widget[] = [];
    private popupWidgets: Set<Widget> = new Set();
@@ -1050,9 +1280,8 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
 
    menus: Map<number, MenuButton> = new Map();
    nextMenuID: number = 0;
-
    readonly manager: RootWidgetManager = new RootWidgetManager();
-
+   readonly menu: MenuBar;
    
 
    imports: TLibImports = {
@@ -1108,6 +1337,15 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       //    buttonColor: "#B0B0B0B0"
       // };
       // this.manager.addChild(this.ctx, -10, Button, buttonOpts);
+      const menuBarCons: MenuBarWidgetConstructor = {
+         x: 0,
+         y: 0,
+         minChildWidth: 10,
+         menuColor: "#B0B0B0",
+         height: TOP_BAR_SIZE,
+         xPadding: MENU_PADDING_X,
+      };
+      this.menu = this.manager.addChild(this.ctx, 0, MenuBar, menuBarCons);
    }
 
    getProp(propName: string) {
@@ -1195,25 +1433,17 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
 
       const id = ++this.nextMenuID;
 
-      let maxX = MENU_START_X;
-      for (const button of this.menus.values()) {
-         const [x, , width, ] = button.getDimensions();
-         const rX = x + width;
-
-         maxX = Math.max(maxX, rX);
-      }
-
-
       const menuOptions: MenuWidgetConstructor = {
-         x: maxX,
+         x: 0,
          y: TOP_BAR_SIZE,
          menuColor: "#B0B0B0",
          minimumHeight: TOP_BAR_SIZE/2.0,
          yPadding: 2,
       };
 
-      const button: MenuButton = this.manager.addChild(this.ctx, id, MenuButton, {
-         x: maxX,
+      const button: MenuButton = this.menu.addChild(this.ctx, id, MenuButton, {
+         // x: maxX,
+         x: 0, 
          y: 0,
          height: TOP_BAR_SIZE - 0.5,
          text: text,
@@ -1222,9 +1452,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          selectedButtonColor: "#D0D0D0",
          menuOptions: menuOptions
       });
-
-      const [, , width, ] = button.getDimensions();
-      button.setDimensions(this.ctx, undefined, undefined, width + MENU_PADDING_X, undefined);
 
       this.menus.set(id, button);
 

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -234,6 +234,7 @@ interface MenuWidgetConstructor extends WidgetConstructor {
    minimumHeight?: number;
    menuColor?: string;
    yPadding?: number;
+   minChildHeight?: number;
 }
 
 class Menu implements Widget, WidgetManager {
@@ -249,6 +250,7 @@ class Menu implements Widget, WidgetManager {
 
    private absoluteMinWidth: number;
    private absoluteMinHeight: number;
+   private minChildHeight: number;
    
    private x: number;
    private y: number;
@@ -282,6 +284,7 @@ class Menu implements Widget, WidgetManager {
       this.absoluteMinHeight = props.minimumHeight ?? 5;
       this.childWidth = this.absoluteMinWidth;
       this.childHeight = this.absoluteMinHeight;
+      this.minChildHeight = props.minChildHeight ?? 5;
 
       this.width = props.width;
       this.height = props.height;
@@ -301,16 +304,20 @@ class Menu implements Widget, WidgetManager {
    supressChildUpdates: boolean = false;
    updateChildSize(ctx: CanvasRenderingContext2D, forceRun: boolean = false) {
       let childWidth = 0;
+      // let maxChildHeight = this.minChildHeight;
       let childHeight = 0;
       for (const widget of this.children) {
-         const [width, height] = widget.getMinSize(ctx);
+         const [width, ] = widget.getMinSize(ctx);
          childWidth = Math.max(childWidth, width);
+         // maxChildHeight = Math.max(maxChildHeight, height+this.yPadding);
+         const [, , , height] = widget.getDimensions();
          childHeight += height + this.yPadding;
       }
 
       // console.log(childWidth, childHeight);
 
       childWidth = Math.max(childWidth, this.absoluteMinWidth);
+      // let childHeight = Math.max(maxChildHeight*this.children.length, this.absoluteMinHeight);
       childHeight = Math.max(childHeight, this.absoluteMinHeight);
 
       const newWidth = this.width ?? childWidth;
@@ -326,11 +333,11 @@ class Menu implements Widget, WidgetManager {
          
          let curHeight = 0;
          for (const widget of this.children) {
-            const [, height] = widget.getMinSize(ctx);
-
+            const [, , , height] = widget.getDimensions();
             this.supressChildUpdates = true;
-            widget.setDimensions(ctx, 0, curHeight, newWidth, height);
+            widget.setDimensions(ctx, 0, curHeight, newWidth, undefined);
             this.supressChildUpdates = false;
+            // curHeight += maxChildHeight;
             curHeight += height + this.yPadding;
          }
 
@@ -717,6 +724,7 @@ class Seperator implements Widget {
    private y: number;
    private width: number;
    private height: number;
+   private minHeight: number = 0;
 
    private text: string = "";
    private textXOffset: number = 0;
@@ -750,14 +758,15 @@ class Seperator implements Widget {
       this.text = this.seperatorText.repeat(repeats);
 
       this.textXOffset = (this.width - width)/2.0;
-      console.log(width, this.width, this.textXOffset);
+      // console.log(width, this.width, this.textXOffset);
       this.textYOffset = (this.height + height)/2.0;
+      this.minHeight = height;
 
       ctx.restore();
    }
 
    getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
-      return [0, 0];
+      return [0, this.minHeight];
    }
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
       ctx.save();
@@ -765,13 +774,14 @@ class Seperator implements Widget {
       ctx.font = this.seperatorFont;
       ctx.fillStyle = this.seperatorColor;
 
+      // console.log(this.x, offsetX, this.textXOffset, this.x + offsetX + this.textXOffset);
       ctx.fillText(
          this.text,
          this.x + offsetX + this.textXOffset,
          this.y + offsetY + this.textYOffset
       );
 
-      ctx. restore();
+      ctx.restore();
    }
    handleMenuEvent(event: MenuItemEventData) {
       throw new Error(`Seperator widget doesn't accept events!!`);
@@ -801,6 +811,11 @@ const TOP_BAR_SIZE: number = 30;
 const BORDER_SIZE: number = 5;
 const MENU_START_X = BORDER_SIZE;
 
+enum WidgetType {
+   Button,
+   Seperator
+}
+
 export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, IConsoleWindow {
    id: number;
    props: IConsoleBaseProps;
@@ -812,13 +827,16 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    appCanvasHeight: number;
    readonly appCanvas: twrConsoleCanvas;
 
-   menuItems: Map<number, MenuItem> = new Map();
+   menuItems: Map<
+      number, 
+      [WidgetType.Button, Button]
+      | [WidgetType.Seperator, Seperator]
+   > = new Map();
+   
    nextMenuItem: number = 0;
 
    menus: Map<number, MenuButton> = new Map();
    nextMenuID: number = 0;
-
-   openMenu: Menu|undefined = undefined;
 
    readonly manager: RootWidgetManager = new RootWidgetManager();
 
@@ -827,6 +845,8 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    imports: TLibImports = {
       twrGetAppCanvasJSID: {},
       twrWindowAddMenu: {},
+      twrWindowMenuAddWidget: {},
+      twrWindowMenuButtonAddCallback: {},
    };
 
    // every library should have this line
@@ -903,7 +923,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    mouseWasOnMenu: boolean = false;
    handleCanvasMouseEvent(event: CanvasEventTypes, x: number, y: number) {
       const n_x = x - BORDER_SIZE;
-      const n_y = y - TOP_BAR_SIZE;
+      const n_y = y - TOP_BAR_SIZE;10
 
       if (this.manager.handleCanvasMouseEvent(this.ctx, event, x, y)) {
 
@@ -913,7 +933,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          && n_y <= this.appCanvasHeight
       ) {
          this.appCanvas.handleCanvasMouseEvent(event, n_x, n_y);
-      }
+      }10
 
       return true;
    }
@@ -947,11 +967,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       this.ctx.stroke();
       this.ctx.closePath();
 
-      // for (const [button, ] of this.menus.values()) {
-      //    button.render(this.ctx, 0, 0);
-      // }
-
-      this.openMenu?.render(this.ctx);
 
       this.manager.handleCanvasAnimationFrameEvent(this.ctx, event, delta);
    }
@@ -979,6 +994,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          y: TOP_BAR_SIZE,
          menuColor: "#B0B0B0",
          minimumHeight: TOP_BAR_SIZE/2.0,
+         yPadding: 2,
       };
 
       const button: MenuButton = this.manager.addChild(this.ctx, id, MenuButton, {
@@ -995,35 +1011,158 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       const [, , width, ] = button.getDimensions();
       button.setDimensions(this.ctx, undefined, undefined, width + MENU_PADDING_X, undefined);
 
-      const seperatorOptions: SeperatorWidgetConstructor = {
-         x: 0,
-         y: 0,
-         height: 10,
-         seperatorText: "-",
-         seperatorColor: "black",
-         seperatorFont: "20px Seriph"
-      }
-      button.addChild(this.ctx, ++this.nextMenuItem, Seperator, seperatorOptions);
+      // const seperatorOptions: SeperatorWidgetConstructor = {
+      //    x: 0,
+      //    y: 0,
+      //    height: 10,
+      //    seperatorText: "-",
+      //    seperatorColor: "black",
+      //    seperatorFont: "20px Seriph"
+      // }
 
       this.menus.set(id, button);
 
-      const buttonOptions: ButtonWidgetConstructor = {
-         x: 0,
-         y: 0,
-         text: "Hello!!!",
-         textColor: "black",
-         buttonColor: "#B0B0B0",
-         selectedButtonColor: "#D0D0D0"
-      };
-      const secondButton: Button = button.addChild(this.ctx, ++this.nextMenuItem, Button, buttonOptions);
-      secondButton.addEvent(() => {
-         console.log("pressed!!!");
-      });
+      // const buttonOptions: ButtonWidgetConstructor = {
+      //    x: 0,
+      //    y: 0,
+      //    height: 20,
+      //    text: "Hello!!!",
+      //    textColor: "black",
+      //    buttonColor: "#B0B0B0",
+      //    selectedButtonColor: "#D0D0D0"
+      // };
+      // const secondButton: Button = button.addChild(this.ctx, ++this.nextMenuItem, Button, buttonOptions);
+      // secondButton.addEvent(() => {
+      //    console.log("pressed!!!");
+      // });
+      // button.addChild(this.ctx, ++this.nextMenuItem, Seperator, seperatorOptions);
+
+      // const thirdButton: Button = button.addChild(this.ctx, ++this.nextMenuItem, Button, buttonOptions);
 
       // button.addEvent((() => {
       //    // this.openMenu = menu;
       // }).bind(this));
       return id;
+   }
+
+   twrWindowMenuAddWidget(mod: IWasmModuleAsync | IWasmModule, menuID: number, consPtr: number): number {
+      if (!this.menus.has(menuID)) throw new Error(`twrWindowMenuAddWidget was given an invalid menu ID (${menuID})!`);
+      const menu = this.menus.get(menuID)!;
+
+      // struct twr_widget_constructor {
+      //    enum WindowWidget type;
+      //    long x;
+      //    long y;
+      //    long width;
+      //    long height;
+      // };
+      function getLongOrDef<T>(ptr: number, def: T): number|T {
+         const val = mod.getLong(ptr);
+         if (val < 0) {
+            return def;
+         } else {
+            return val;
+         }
+      }
+      function getStringOrDef(ptr: number, def: string): string {
+         const strPtr = mod.getLong(ptr);
+         if (strPtr == 0) {
+            return def;
+         } else {
+            return mod.getString(strPtr);
+         }
+      }
+
+      const type = mod.getLong(consPtr + 0) as WidgetType;
+
+      const x = getLongOrDef(consPtr + 4, 0);
+      const y = getLongOrDef(consPtr + 8, 0);
+      const width = getLongOrDef(consPtr + 12, undefined);
+      const height = getLongOrDef(consPtr + 16, undefined);
+
+      const extraPtr = consPtr + 20;
+
+      const id = ++this.nextMenuItem;
+      switch (type) {
+         case WidgetType.Button:
+         {
+            // struct twr_widget_button_constructor {
+            //    /// @brief Base widget constructor
+            //    struct twr_widget_constructor base;
+            //    /// @brief defaults to "Lorem Ipsum"
+            //    const char* text;
+            //    /// @brief defaults to 16px Seriph
+            //    const char* text_font;
+            //    /// @brief defaults to Black
+            //    const char* text_color;
+            //    /// @brief defaults to #B0B0B0
+            //    const char* button_color;
+            //    /// @brief defaults to #D0D0D0
+            //    const char* selected_button_color;
+            // };
+            let button: ButtonWidgetConstructor = {
+               x: x,
+               y: y,
+               width: width,
+               height: height,
+               text: getStringOrDef(extraPtr + 0, "Lorem Ipsum"),
+               textFont: getStringOrDef(extraPtr + 4, "16px Seriph"),
+               textColor: getStringOrDef(extraPtr + 8, "black"),
+               buttonColor: getStringOrDef(extraPtr + 12, "#B0B0B0"),
+               selectedButtonColor: getStringOrDef(extraPtr + 16, "#D0D0D0")
+            };
+            const widget: Button = menu.addChild(this.ctx, id, Button, button);
+            this.menuItems.set(id, [WidgetType.Button, widget]);
+         }
+         break;
+
+         case WidgetType.Seperator:
+         {
+            // struct twr_widget_seperator_constructor {
+            //    /// @brief Base widget constructor
+            //    struct twr_widget_constructor base;
+            //    /// @brief defaults to "-"
+            //    const char* seperator_text;
+            //    /// @brief defaults to 16px Seriph
+            //    const char* seperator_font;
+            //    /// @brief defaults to black
+            //    const char* seperator_color;
+            // };
+            let seperator: SeperatorWidgetConstructor = {
+               x: x,
+               y: y,
+               width: width,
+               height: height,
+               seperatorText: getStringOrDef(extraPtr + 0, "-"),
+               seperatorFont: getStringOrDef(extraPtr + 4, "16px Seriph"),
+               seperatorColor: getStringOrDef(extraPtr + 8, "black")
+            };
+            const widget: Seperator = menu.addChild(this.ctx, id, Seperator, seperator);
+            this.menuItems.set(id, [WidgetType.Seperator, widget]);
+         }
+         break;
+
+         default:
+         {
+            throw new Error(`twrWindowMenuAddWidget: Error! Was given an unknown type (${type})!`);
+         }
+         break;
+      }
+
+      return id;
+   }
+
+   twrWindowMenuButtonAddCallback(mod: IWasmModuleAsync | IWasmModule, widgetID: number, eventID: number, extraPtr: number) {
+      if (!this.menuItems.has(widgetID)) throw new Error(`twrWindowMenuButtonAddCallback: Error! was given an invalid widgetID (${widgetID})`);
+      const widget = this.menuItems.get(widgetID)!;
+
+      if (widget[0] != WidgetType.Button) throw new Error(`twrWindowMenuButtonAddCallback: Error! was given an invalid widget type! Expected Button, got ${WidgetType[widget[0]]}`);
+      
+      const button: Button = widget[1];
+
+      button.addEvent(() => {
+         mod.postEvent(eventID, extraPtr)
+      });
    }
 
 

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -1,0 +1,88 @@
+import { bindCanvasEvents, CanvasEventTypes, ICanvasEvents } from "./twrcanvasevents.js";
+import { IConsole, IConsoleEvents } from "./twrcon.js";
+import twrConsoleCanvas from "./twrconcanvas.js";
+import { TLibImports, twrLibrary, twrLibraryInstanceRegistry } from "./twrlibrary.js";
+import { IWasmModule } from "./twrmod";
+import { IWasmModuleAsync } from "./twrmodasync";
+
+
+type FullID = number;
+
+function calculateID(mod:IWasmModule|IWasmModuleAsync, id: number): FullID {
+   if (mod.id >= (2**20)) throw new Error("twrlibaudio was given a module ID greater than 20 bits long!");
+   if (id >= (2**32)) throw new Error("twrlibaudio was given an object ID greater than 32 bits!");
+   //should be equivalent to (mod.id << 32) | id
+   //can't use shift operations without being limited to 32-bit signed integers or using bignumber
+   return ((mod.id & (2**20 - 1)) * 2**32 + id) as FullID;
+}
+
+export default class twrConsoleWindow extends twrLibrary implements ICanvasEvents {
+   id: number;
+
+   element: HTMLCanvasElement;
+   ctx: CanvasRenderingContext2D;
+   readonly borderSizes: [number, number];
+   readonly appCanvas: twrConsoleCanvas;
+
+   imports: TLibImports = {
+      
+   };
+
+   // every library should have this line
+   libSourcePath = new URL(import.meta.url).pathname;
+
+   constructor(canvas: HTMLCanvasElement, selfRegisterEvents: boolean = true) {
+      // all library constructors should start with these two lines
+      super();
+      this.id=twrLibraryInstanceRegistry.register(this);
+
+      this.element = canvas;
+      this.ctx = canvas.getContext("2d")!;
+
+      const perimiterThickness = Math.min(canvas.height, canvas.width) * 0.05;
+      const menuThickness = Math.min(canvas.height, canvas.width) * 0.1;
+
+      const appCanvasHeight = Math.floor(canvas.height - perimiterThickness - menuThickness);
+      const appCanvasWidth = Math.floor(canvas.width - menuThickness*2.0);
+
+      this.borderSizes = [perimiterThickness, menuThickness];
+
+      const appCanvas = new HTMLCanvasElement();
+      appCanvas.height = appCanvasHeight;
+      appCanvas.width = appCanvasWidth;
+
+      this.appCanvas = new twrConsoleCanvas(appCanvas, false);
+
+      bindCanvasEvents(this, this.element);
+   }
+
+   handleCanvasKeyEvent(event: CanvasEventTypes, key: number) {
+      this.appCanvas.handleCanvasKeyEvent(event, key);
+   }
+   handleCanvasMouseEvent(event: CanvasEventTypes, x: number, y: number) {
+      this.appCanvas.handleCanvasMouseEvent(event, x, y);
+   }
+   handleCanvasWheelEvent(event: CanvasEventTypes, deltaX: number, deltaY: number, deltaZ: number, deltaMode: number) {
+      this.appCanvas.handleCanvasWheelEvent(event, deltaX, deltaY, deltaZ, deltaMode);
+   }
+   handleCanvasAnimationFrameEvent(event: CanvasEventTypes, delta: number) {
+      this.appCanvas.handleCanvasAnimationFrameEvent(event, delta);
+
+      //draw "app" canvas
+      this.ctx.drawImage(this.appCanvas.element, this.borderSizes[0], this.borderSizes[1]);
+
+      //draw border around it
+      this.ctx.fillStyle = "blue";
+      this.ctx.fillRect(0, 0, this.borderSizes[1], this.element.height);
+      this.ctx.fillRect(this.element.width - this.borderSizes[1], 0, this.element.width, this.element.height);
+      this.ctx.fillRect(0, this.element.height - this.borderSizes[1], this.element.width, this.element.height);
+      
+      this.ctx.fillRect(0, 0, this.element.width, this.borderSizes[0]);
+   }
+
+   twrGetAppCanvas(mod:IWasmModule|IWasmModuleAsync) {
+      return this.appCanvas.id;
+   }
+
+
+}

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -85,10 +85,15 @@ enum PropBaseType {
    Undefined = 8,
    Combination = 512
 };
+type PropPrimitiveType = PropBaseType.String
+   | PropBaseType.Boolean
+   | PropBaseType.Number
+   | PropBaseType.Undefined;
+
 type PropType = [PropBaseType.String]
    | [PropBaseType.Boolean]
    | [PropBaseType.Number]
-   | [PropBaseType.Combination, ...PropBaseType[]];
+   | [PropBaseType.Combination, ...PropPrimitiveType[]];
 
 type GetPropVal = [PropBaseType.String, string]
    | [PropBaseType.Boolean, boolean]
@@ -99,9 +104,9 @@ type AllocGetPropVal = [PropBaseType.String, string, number]
    | [PropBaseType.Number, number]
    | [PropBaseType.Undefined];
 enum PropPerms {
-   ReadOnly,
-   SetOnly,
-   ReadAndSet,
+   ReadOnly = 1,   //0b01
+   SetOnly = 2,    //0b10
+   ReadAndSet = 3, //0b11 -- Just addition of above two flags
 }
 interface WidgetManager {
    getCtx: () => CanvasRenderingContext2D;
@@ -2120,5 +2125,126 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       return retPtr;
    }
 
+   twrWindowMenuWidgetGetPropTypes(mod: IWasmModuleAsync | IWasmModule, widgetID: number, propNamePtr: number) {
+      const widget = this.widgets.get(widgetID);
+      if (widget == undefined) throw new Error(`twrWindowMenuWidgetGetPropTypes: Error! was given an invalid widgetID (${widgetID})`);
+      
+      const propName = mod.getString(propNamePtr);
+      const propField = widget[1].publicProperties[propName];
+      if (propField == undefined) throw new Error(`twrWindowMenuWidgetGetPropTypes: Couldn't find prop name "${propName}" in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
+      
+      function getPropTypes(propType: PropType): number {
+         switch (propType[0]) {
+            case PropBaseType.Combination:
+            {
+               let out = 0;
+               for (let i = 1; i < propType.length; i++) {
+                  const typ = propType[i];
+                  if (typ == PropBaseType.Undefined) {
+                     out &= PropBaseType.Undefined;
+                  } else {
+                     out &= getPropTypes([typ]);
+                  }
+               }
+               return out;
+            }
+
+            case PropBaseType.Boolean:
+            case PropBaseType.Number:
+            case PropBaseType.String:
+            {
+               return propType[0] as number;
+            }
+            
+            default:
+               throw new Error(`twrWindowMenuWidgetGetPropTypes: Error! was given unexpected prop type: ${PropBaseType[propType[0]] ?? propType[0]}!`);
+         }
+      }
+
+      return getPropTypes(propField[1]);
+   }
+
+   twrWindowMenuWidgetGetPropType(mod: IWasmModuleAsync | IWasmModule, widgetID: number, propNamePtr: number) {
+      const widget = this.widgets.get(widgetID);
+      if (widget == undefined) throw new Error(`twrWindowMenuWidgetGetPropType: Error! was given an invalid widgetID (${widgetID})`);
+      
+      const propName = mod.getString(propNamePtr);
+      const propField = widget[1].publicProperties[propName];
+      if (propField == undefined) throw new Error(`twrWindowMenuWidgetGetPropType: Couldn't find prop name "${propName}" in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
+      if (propField[0] == PropPerms.SetOnly) throw new Error(`twrWindowMenuWidgetGetPropType: Property "${propName}" is set only in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
+      
+      function assertFine(typ: PropBaseType) {
+         if (!(
+            propField[1][0] == typ
+            || (
+               propField[1][0] == PropBaseType.Combination
+               && propField[1].includes(typ)
+            )
+         )) {
+            throw new Error(`twrWindowMenuWidgetGetPropType: Internal error! Widget property was of type ${PropBaseType[typ] ?? typ} but was expecting: ${propField[1]}`);
+         }
+      }
+      switch (typeof (widget as any)[propName]) {
+         case "boolean":
+            assertFine(PropBaseType.Boolean);
+            return PropBaseType.Boolean;
+         case "string":
+            assertFine(PropBaseType.String);
+            return PropBaseType.String;
+         case "undefined":
+            assertFine(PropBaseType.Undefined);
+            return PropBaseType.Undefined;
+         case "number":
+            assertFine(PropBaseType.Number);
+            return PropBaseType.Number;
+         default:
+            throw new Error(`twrWindowMenuWidgetGetPropType: Internal error! property was of type: ${typeof (widget as any)[propName]}`)
+      }
+   }
+
+   twrWindowMenuWidgetGetPropAccess(mod: IWasmModuleAsync | IWasmModule, widgetID: number, propNamePtr: number) {
+      const widget = this.widgets.get(widgetID);
+      if (widget == undefined) throw new Error(`twrWindowMenuWidgetGetPropAccess: Error! was given an invalid widgetID (${widgetID})`);
+      
+      const propName = mod.wasmMem.getString(propNamePtr);
+      const propField = widget[1].publicProperties[propName];
+      if (propField == undefined) throw new Error(`twrWindowMenuWidgetGetPropAccess: Couldn't find prop name "${propName}" in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
+      
+      return propField[0] as number;
+   }
+
+   twrWindowMenuWidgetListProps(mod: IWasmModule, widgetID: number, lengthPtr: number) {
+      const widget = this.widgets.get(widgetID);
+      if (widget == undefined) throw new Error(`twrWindowMenuWidgetListProps: Error! was given an invalid widgetID (${widgetID})`);
+
+      const props = [];
+      let totalSize = 0;
+      for (const name in widget[1].publicProperties) {
+         const ru8=mod.wasmMem.stringToU8(name);
+         // const strIndex:number=this.malloc(ru8.length+1);
+         // this.mem8u.set(ru8, strIndex);
+         // this.mem8u[strIndex+ru8.length]=0;
+   
+         totalSize += ru8.length + 1;
+         props.push(ru8);
+      }
+      totalSize += props.length * 4;
+      mod.wasmMem.setLong(lengthPtr, props.length);
+
+      const alloc = mod.malloc(totalSize);
+      let offset = props.length*4;
+      for (let i = 0; i < props.length; i++) {
+         mod.wasmMem.setDouble(i * 4, offset);
+         mod.wasmMem.mem8u.set(props[i], offset);
+         mod.wasmMem.mem8u[offset+props[i].length] = 0; //null ptr at end
+         offset += props[i].length + 1;
+      }
+
+      return alloc
+
+   }
+
+
 
 }
+

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -144,21 +144,14 @@ interface GlobalWidgetProperties {
    radioMenuUncheckedPrefix: string;
 };
 enum PropBaseType {
-   String = 1,
-   Boolean = 2,
-   Number = 4,
-   Undefined = 8,
-   Combination = 512
+   String = 1, //0b0001
+   Boolean = 2,//0b0010
+   Number = 4, //0b0100
+   Undefined = 8, //0b1000
+   StringOrUndefined = 9,  //0b1001
+   BooleanOrUndefined = 10,//0b1010 
+   NumberOrUndefined = 12  //0b1100
 };
-type PropPrimitiveType = PropBaseType.String
-   | PropBaseType.Boolean
-   | PropBaseType.Number
-   | PropBaseType.Undefined;
-
-type PropType = [PropBaseType.String]
-   | [PropBaseType.Boolean]
-   | [PropBaseType.Number]
-   | [PropBaseType.Combination, ...PropPrimitiveType[]];
 enum PropPerms {
    ReadOnly = 1,   //0b01
    SetOnly = 2,    //0b10
@@ -177,7 +170,7 @@ interface WidgetManager extends ManagerAndWidgetCombined {
 
    resendLastMove: () => void;
 }
-type PublicPropertiesType = { [propName: string]: [[undefined|(() => string|number|undefined|boolean), undefined|((val: any) => void)], PropType]; };
+type PublicPropertiesType = { [propName: string]: [[undefined|(() => string|number|undefined|boolean), undefined|((val: any) => void)], PropBaseType]; };
 
 interface Widget extends ManagerAndWidgetCombined {
    readonly globalProps: GlobalWidgetProperties;
@@ -214,14 +207,14 @@ abstract class WidgetImpl implements Widget {
    abstract readonly handledEvents: MenuItemEvents[];
    getPublicProperties(): PublicPropertiesType {
       return {
-         "width": [[this.getWidth.bind(this), this.setWidth.bind(this)], [PropBaseType.Combination, PropBaseType.Number, PropBaseType.Undefined]],
-         "height": [[this.getHeight.bind(this), this.setHeight.bind(this)], [PropBaseType.Combination, PropBaseType.Number, PropBaseType.Undefined]],
-         "isVisible": [[this.getIsVisible.bind(this), this.setIsVisible.bind(this)], [PropBaseType.Boolean]],
-         "isDisabled": [[this.getIsDisabled.bind(this), this.setIsDisabled.bind(this)], [PropBaseType.Boolean]],
-         "minWidth": [[this.getMinWidth.bind(this), undefined], [PropBaseType.Number]],
-         "usedWidth": [[this.getUsedWidth.bind(this), undefined], [PropBaseType.Number]],
-         "minHeight": [[this.getMinHeight.bind(this), undefined], [PropBaseType.Number]],
-         "usedHeight": [[this.getUsedHeight.bind(this), undefined], [PropBaseType.Number]]
+         "width": [[this.getWidth.bind(this), this.setWidth.bind(this)], PropBaseType.NumberOrUndefined],
+         "height": [[this.getHeight.bind(this), this.setHeight.bind(this)], PropBaseType.NumberOrUndefined],
+         "isVisible": [[this.getIsVisible.bind(this), this.setIsVisible.bind(this)], PropBaseType.Boolean],
+         "isDisabled": [[this.getIsDisabled.bind(this), this.setIsDisabled.bind(this)], PropBaseType.Boolean],
+         "minWidth": [[this.getMinWidth.bind(this), undefined], PropBaseType.Number],
+         "usedWidth": [[this.getUsedWidth.bind(this), undefined], PropBaseType.Number],
+         "minHeight": [[this.getMinHeight.bind(this), undefined], PropBaseType.Number],
+         "usedHeight": [[this.getUsedHeight.bind(this), undefined], PropBaseType.Number]
       }
    }
 
@@ -331,7 +324,7 @@ abstract class ButtonBase extends WidgetImpl {
    getPublicProperties(): PublicPropertiesType {
       return {
          ...super.getPublicProperties(),
-         "text": [[this.getText.bind(this), this.setText.bind(this)], [PropBaseType.String]]
+         "text": [[this.getText.bind(this), this.setText.bind(this)], PropBaseType.String]
       }
    };
 
@@ -547,8 +540,8 @@ class Button extends ButtonBase implements WidgetEvents {
    getPublicProperties(): PublicPropertiesType {
       return {
          ...super.getPublicProperties(),
-         "suffixText": [[this.getSuffixText.bind(this), this.setSuffixText.bind(this)], [PropBaseType.Combination, PropBaseType.String, PropBaseType.Undefined]],
-         "prefixText": [[this.getPrefixText.bind(this), this.setPrefixText.bind(this)], [PropBaseType.Combination, PropBaseType.String, PropBaseType.Undefined]],
+         "suffixText": [[this.getSuffixText.bind(this), this.setSuffixText.bind(this)], PropBaseType.StringOrUndefined],
+         "prefixText": [[this.getPrefixText.bind(this), this.setPrefixText.bind(this)], PropBaseType.StringOrUndefined],
       }
    } 
 
@@ -1336,7 +1329,7 @@ class Seperator extends WidgetImpl {
    getPublicProperties(): PublicPropertiesType {
       return {
          ...super.getPublicProperties(),
-         "text": [[this.getText.bind(this), this.setText.bind(this)], [PropBaseType.String]]
+         "text": [[this.getText.bind(this), this.setText.bind(this)], PropBaseType.String]
       }
    }
 
@@ -1568,6 +1561,9 @@ enum WidgetType {
    SubMenu,
    CheckBox,
 }
+enum WindowEventTypes {
+   WindowResize,
+}
 
 export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, IConsoleWindow {
    id: number;
@@ -1576,10 +1572,11 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    element: HTMLCanvasElement;
    ctx: CanvasRenderingContext2D;
    
-   appCanvasWidth: number;
-   appCanvasHeight: number;
-   readonly appCanvas: twrConsoleCanvas;
+   drawCanvasWidth: number;
+   drawCanvasHeight: number;
+   readonly drawCanvas: twrConsoleCanvas;
 
+   private windowEventHandlers: Map<WindowEventTypes, [IWasmModule|IWasmModuleAsync, number][]> = new Map();
    widgets: Map<
       number, 
       [WidgetType.Button, Button]
@@ -1617,7 +1614,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    
 
    imports: TLibImports = {
-      twrGetAppCanvasJSID: {},
+      twrGetDrawCanvasJSID: {},
       twrWindowAddMenu: {},
       twrWindowMenuAddWidget: {},
       twrWindowMenuWidgetAddCallback: {},
@@ -1629,11 +1626,21 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       twrWindowMenuWidgetGetPropDetails: {},
       twrWindowMenuListProps: {isAsyncFunction: true},
       twrWindowMenuSetProp: {},
-      twrWindowMenuGetProp: {isAsyncFunction: true},  
+      twrWindowMenuGetProp: {isAsyncFunction: true}, 
+      twrRegisterEvent: {},
+      twrUnregisterEvent: {},
+      twrUnregisterAllEvents: {},
    };
 
    // every library should have this line
    libSourcePath = new URL(import.meta.url).pathname;
+
+   calculatedrawCanvasDims(): [number, number] {
+      return [
+         this.element.width - BORDER_SIZE*2.0,
+         this.element.height - BORDER_SIZE - TOP_BAR_SIZE,
+      ];
+   }
 
    constructor(canvas: HTMLCanvasElement, selfRegisterEvents: boolean = true) {
       // all library constructors should start with these two lines
@@ -1644,15 +1651,15 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       this.ctx = canvas.getContext("2d")!;
       this.manager = new RootWidgetManager(this.ctx);
 
-      this.appCanvasHeight = Math.floor(canvas.height - BORDER_SIZE - TOP_BAR_SIZE);
-      this.appCanvasWidth = Math.floor(canvas.width - BORDER_SIZE*2.0);
+      // this.drawCanvasHeight = Math.floor(canvas.height - BORDER_SIZE - TOP_BAR_SIZE);
+      // this.drawCanvasWidth = Math.floor(canvas.width - BORDER_SIZE*2.0);
+      [this.drawCanvasWidth, this.drawCanvasHeight] = this.calculatedrawCanvasDims();
 
+      const drawCanvas = document.createElement("canvas");
+      drawCanvas.height = this.drawCanvasHeight;
+      drawCanvas.width = this.drawCanvasWidth;
 
-      const appCanvas = document.createElement("canvas");
-      appCanvas.height = this.appCanvasHeight;
-      appCanvas.width = this.appCanvasWidth;
-
-      this.appCanvas = new twrConsoleCanvas(appCanvas, undefined, false);
+      this.drawCanvas = new twrConsoleCanvas(drawCanvas, undefined, false);
 
       if (selfRegisterEvents)
          bindCanvasEvents(this, this.element);
@@ -1677,18 +1684,60 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       return this.getProp(propName);
    };
 
-   twrRegisterEvent(callingMod: IWasmModuleAsync | IWasmModule, eventType: number, eventID: number) {
+   private internalSendEvent(eventType: WindowEventTypes, ...extraArgs: number[]) {
+      const handlers = this.windowEventHandlers.get(eventType);
+      if (handlers == undefined) return;
 
+      for (const [mod, eventID] of handlers) {
+         mod.postEvent(eventID, ...extraArgs);
+      }
+   }
+
+   twrRegisterEvent(callingMod: IWasmModuleAsync | IWasmModule, eventType: number, eventID: number) {
+      if (WindowEventTypes[eventType] == undefined) throw new Error(`twrRegisterEvent: Invalid event type (${eventType}) for twrConsoleWindow!`);
+      const event: WindowEventTypes = eventType as WindowEventTypes;
+
+      const eventHandlersTmp = this.windowEventHandlers.get(event);
+      const eventHandlers = eventHandlersTmp ?? [];
+      if (eventHandlersTmp == undefined) {
+         this.windowEventHandlers.set(event, eventHandlers);
+      }
+
+      for (let i = 0; i < eventHandlers.length; i++) {
+         if (eventHandlers[i][0] == callingMod && eventHandlers[i][1] == eventID)
+            throw new Error(`twrRegisterEvent: eventID ${eventID} is already registered for module ${callingMod.id}!`);
+      }
+
+      eventHandlers.push([callingMod, eventID]);
    }
    twrUnregisterEvent(callingMod: IWasmModuleAsync | IWasmModule, eventType: number, eventID: number) {
+      if (WindowEventTypes[eventType] == undefined) throw new Error(`twrUnregisterEvent: Invalid event type ${eventType} for twrConsoleWindow!`);
+      const event: WindowEventTypes = eventType as WindowEventTypes;
+      
+      const eventHandlers = this.windowEventHandlers.get(event);
+      if (eventHandlers == undefined || eventHandlers.length == 0)
+         throw new Error(`twrUnregisterEvent: There are no events registered for event type ${WindowEventTypes[eventType]}!`);
 
+      for (let i = 0; i < eventHandlers.length; i++) {
+         if (eventHandlers[i][0] == callingMod && eventHandlers[i][1] == eventID) {
+            eventHandlers.splice(i, 1);
+            return;
+         }
+      }
+      throw new Error(`twrUnregisterEvent: eventID ${eventID} isn't registered for event type ${WindowEventTypes[eventType]} with module ${callingMod.id}!`);
    }
    twrUnregisterAllEvents(callingMod: IWasmModuleAsync | IWasmModule) {
-
+      for (const [, handlers] of this.windowEventHandlers) {
+         for (let i = handlers.length-1; i >= 0; i--) {
+            if (handlers[i][0] == callingMod) {
+               handlers.splice(i, 1);
+            }
+         }
+      }
    }
 
    handleCanvasKeyEvent(event: CanvasEventTypes, key: number) {
-      this.appCanvas.handleCanvasKeyEvent(event, key);
+      this.drawCanvas.handleCanvasKeyEvent(event, key);
       return true;
    }
 
@@ -1696,31 +1745,31 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    mouseWasOnMenu: boolean = false;
    handleCanvasMouseEvent(event: CanvasEventTypes, x: number, y: number, button: number) {
       const n_x = x - BORDER_SIZE;
-      const n_y = y - TOP_BAR_SIZE;10
+      const n_y = y - TOP_BAR_SIZE;
 
       if (this.manager.handleCanvasMouseEvent(this.ctx, event, x, y, button)) {
 
       } else if (
          n_x >= 0 && n_y >= 0
-         && n_x <= this.appCanvasWidth
-         && n_y <= this.appCanvasHeight
+         && n_x <= this.drawCanvasWidth
+         && n_y <= this.drawCanvasHeight
       ) {
-         this.appCanvas.handleCanvasMouseEvent(event, n_x, n_y, button);
-      }10
+         this.drawCanvas.handleCanvasMouseEvent(event, n_x, n_y, button);
+      }
 
       return true;
    }
    handleCanvasWheelEvent(event: CanvasEventTypes, deltaX: number, deltaY: number, deltaZ: number, deltaMode: number) {
-      this.appCanvas.handleCanvasWheelEvent(event, deltaX, deltaY, deltaZ, deltaMode);
+      this.drawCanvas.handleCanvasWheelEvent(event, deltaX, deltaY, deltaZ, deltaMode);
       return true;
    }
 
    handleCanvasAnimationFrameEvent(event: CanvasEventTypes, delta: number) {
-      this.appCanvas.handleCanvasAnimationFrameEvent(event, delta);
+      this.drawCanvas.handleCanvasAnimationFrameEvent(event, delta);
 
       this.ctx.reset();
       //draw "app" canvas
-      this.ctx.drawImage(this.appCanvas.element, BORDER_SIZE, TOP_BAR_SIZE);
+      this.ctx.drawImage(this.drawCanvas.element, BORDER_SIZE, TOP_BAR_SIZE);
 
       const SELECT_GREY = "#D0D0D0";
       //draw border around it
@@ -1744,8 +1793,8 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       this.manager.handleCanvasAnimationFrameEvent(this.ctx, event, delta);
    }
 
-   twrGetAppCanvasJSID(mod:IWasmModule|IWasmModuleAsync) {
-      return this.appCanvas.id;
+   twrGetDrawCanvasJSID(mod:IWasmModule|IWasmModuleAsync) {
+      return this.drawCanvas.id;
    }
 
    twrWindowAddMenu(mod: IWasmModuleAsync | IWasmModule, textPtr: number) {
@@ -1998,12 +2047,12 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    }
 
 
-   private checkValiditity(propType: PropType, propName: string, typ: PropBaseType, widget: [WidgetType, Widget]) {
-      if (propType[0] == typ)
+   private checkValiditity(propType: PropBaseType, propName: string, typ: PropBaseType, widget: [WidgetType, Widget]) {
+      if ((propType & typ) != 0)
          return;
-      else if (propType[0] == PropBaseType.Combination && propType.includes(typ)) {
-         return;
-      } else {
+      // else if (propType[0] == PropBaseType.Combination && propType.includes(typ)) {
+      //    return;
+      /*}*/ else {
          throw new Error(`twrWindowMenuWidgetSetProp: Property "${propName}" does not accept type ${PropBaseType[typ] ?? typ} in widget ${widget[1].id} of type ${WidgetType[widget[0]] ?? widget[0]}`);
       }
    }
@@ -2185,15 +2234,15 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       const propField = widget[1].getPublicProperties()[propName];
       if (propField == undefined) throw new Error(`twrWindowMenuWidgetGetPropDetails: Couldn't find prop name "${propName}" in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
 
-      let typ = 0;
-      if (propField[1][0] == PropBaseType.Combination) {
-         for (let i = 1; i < propField[1].length; i++) {
-            typ |= propField[1][i];
-         }
-      } else {
-         typ = propField[1][0];
-      }
-      mod.wasmMem.setLong(typePtr, typ);
+      // let typ = 0;
+      // if (propField[1][0] == PropBaseType.Combination) {
+      //    for (let i = 1; i < propField[1].length; i++) {
+      //       typ |= propField[1][i];
+      //    }
+      // } else {
+      //    typ = propField[1][0];
+      // }
+      mod.wasmMem.setLong(typePtr, propField[1]);
 
       // mod.wasmMem.setLong(accessPtr, propField[0]);
       const canGet = propField[0][0] != undefined;
@@ -2226,7 +2275,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       const typeOffset = 4;
       const accessOffset = 8;
       
-      const props: [Uint8Array<ArrayBufferLike>, PropPerms, PropType][] = [];
+      const props: [Uint8Array<ArrayBufferLike>, PropPerms, PropBaseType][] = [];
       let totalSize = 0;
       for (const name in widget[1].getPublicProperties()) {
          const ru8=mod.wasmMem.stringToU8(name);
@@ -2265,15 +2314,15 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             mod.wasmMem.setLong(structPtr + accessOffset, propAccess);
             
             //set type
-            let typ = 0;
-            if (propType[0] != PropBaseType.Combination) {
-               typ = propType[0];
-            } else {
-               for (let i = 1; i < propType.length; i++) {
-                  typ |= propType[i];
-               }
-            }
-            mod.wasmMem.setLong(structPtr + typeOffset, typ);
+            // let typ = 0;
+            // if (propType[0] != PropBaseType.Combination) {
+            //    typ = propType[0];
+            // } else {
+            //    for (let i = 1; i < propType.length; i++) {
+            //       typ |= propType[i];
+            //    }
+            // }
+            mod.wasmMem.setLong(structPtr + typeOffset, propType);
          }
          return alloc;
       }));
@@ -2494,4 +2543,13 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       }
    }
 
+   resizeWindow(width: number, height: number) {
+      this.element.width = width;
+      this.element.height = height;
+      [this.drawCanvasWidth, this.drawCanvasHeight] = this.calculatedrawCanvasDims();
+
+      this.drawCanvas.resizeCanvas(this.drawCanvasWidth, this.drawCanvasHeight);
+
+      this.internalSendEvent(WindowEventTypes.WindowResize, width, height);
+   }
 }

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -141,7 +141,7 @@ interface GlobalWidgetProperties {
    checkBoxCheckedPrefix: string;
    checkBoxUncheckedPrefix: string;
    radioMenuCheckedPrefix: string;
-   radioMenuUncheckedPrefix?: string;
+   radioMenuUncheckedPrefix: string;
 };
 enum PropBaseType {
    String = 1,
@@ -201,19 +201,6 @@ interface Widget {
    delete: (ctx: CanvasRenderingContext2D) => Widget[];
 
    fullUpdate: (ctx: CanvasRenderingContext2D) => void;
-}
-///"deep" clones a json object
-///doesn't clone classes, etc. Just clones sub-JSON objects
-function cloneJSONObject<T>(to_copy: T): T {
-   if (typeof to_copy == "object") {
-      const obj: {[val: string]: any} = {};
-      for (const [key, value] of Object.entries(to_copy as {[val: string]: any})) {
-         obj[key] = cloneJSONObject(value);
-      }
-      return obj as T;
-   } else {
-      return to_copy;
-   }
 }
 
 type PublicPropertiesType = { [propName: string]: [PropPerms, PropType]; };
@@ -345,8 +332,6 @@ abstract class ButtonBase extends WidgetImpl {
          "text": [PropPerms.ReadAndSet, [PropBaseType.String]]
       }
    };
-
-
 
    private mousedOver: boolean = false;
 
@@ -1615,7 +1600,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       emptyMenuHeight: 20,
       emptyMenuWidth: 20,
       radioMenuCheckedPrefix: "*",
-      radioMenuUncheckedPrefix: undefined,
+      radioMenuUncheckedPrefix: "",
       checkBoxCheckedPrefix: "[*]",
       checkBoxUncheckedPrefix: "[  ]"
    };
@@ -1632,6 +1617,8 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       twrWindowMenuWidgetGetProp: {isAsyncFunction: true},
       twrWindowMenuWidgetListProps: {isAsyncFunction: true},
       twrWindowMenuWidgetGetPropDetails: {},
+      twrWindowMenuListProps: {isAsyncFunction: true},
+      
    };
 
    // every library should have this line
@@ -2258,6 +2245,78 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          return await ret;
       } else {
          throw new Error(`internal error`);
+      }
+   }
+
+   twrWindowMenuListPropsHelper(mod: IWasmModuleAsync | IWasmModule, lengthPtr: number) {
+      /*
+      struct window_menu_prop {
+         const char* name;
+         enum WindowWidgetPropVal type;
+      }
+      */
+      const baseStructSize = 4 + 4;
+      const nameOffset = 0;
+      const typeOffset = 4;
+
+      let returnArraySize = 0;
+      const props: [Uint8Array, PropBaseType][] = [];
+      for (const [propName, val] of Object.entries(this.widgetSettings)) {
+         let typ: PropBaseType;
+         switch (typeof val) {
+            case "string":
+               typ = PropBaseType.String;
+            break;
+            case "number":
+               typ = PropBaseType.Number;
+            break;
+            case "boolean":
+               typ = PropBaseType.Boolean;
+            break;
+            default:
+               throw new Error(`twrWindowMenuListPropHelper found invalid widget setting type: ${typeof val}!`);
+         }
+         const u8StringName = mod.wasmMem.stringToU8(propName);
+         props.push([u8StringName, typ]);
+
+         returnArraySize += baseStructSize + u8StringName.length + 1;
+      }
+
+      mod.wasmMem.setLong(lengthPtr, props.length);
+
+      return unwrapPossibleSync(wrapPossibleSync(mod.wasmMem.malloc(returnArraySize)).then((alloc) => {
+         let nameStringOffset = baseStructSize * props.length + alloc;
+         for (let i = 0; i < props.length; i++) {
+            const [propName, propTyp] = props[i];
+
+            const structBase = baseStructSize * i + alloc;
+            mod.wasmMem.setLong(structBase + nameOffset, nameStringOffset);
+            mod.wasmMem.setLong(structBase + typeOffset, propTyp);
+
+            mod.wasmMem.mem8u.set(propName, nameStringOffset);
+            mod.wasmMem.mem8u[nameStringOffset + propName.length + 1] = 0; //null character
+            nameStringOffset += propName.length + 1;
+         }
+
+         return alloc;
+      }));
+   }
+
+
+   twrWindowMenuListProps(mod: IWasmModule, lengthPtr: number) {
+      const ret = this.twrWindowMenuListPropsHelper(mod, lengthPtr);
+      if (ret instanceof Promise) {
+         throw new Error(`internal error!!!`);
+      } else {
+         return ret;
+      }
+   }
+   async twrWindowMenuListProps_async(mod: IWasmModuleAsync, lengthPtr: number) {
+      const ret = this.twrWindowMenuListPropsHelper(mod, lengthPtr);
+      if (ret instanceof Promise) {
+         return await ret;
+      } else {
+         throw new Error(`internal error!!!`);
       }
    }
 

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -1631,6 +1631,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       twrWindowMenuWidgetSetProp: {},
       twrWindowMenuWidgetGetProp: {isAsyncFunction: true},
       twrWindowMenuWidgetListProps: {isAsyncFunction: true},
+      twrWindowMenuWidgetGetPropDetails: {},
    };
 
    // every library should have this line
@@ -1916,16 +1917,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             //     * defaults to Lorem Ipsum
             //     */
             //    const char* text;
-            //    /**
-            //     * Text prefix used to indicate that the check box is clicked
-            //     * defaults to *
-            //     */
-            //    const char* checked_symbol;
-            //    /**
-            //     * text prefix used to indicate that the check box is not clicked
-            //     * defaults to ""
-            //     */
-            //    const char* unchecked_symbol;
             // };
 
             const props: CheckBoxWidgetConstructor = {
@@ -2173,92 +2164,30 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       }
    }
 
-   twrWindowMenuWidgetGetPropTypes(mod: IWasmModuleAsync | IWasmModule, widgetID: number, propNamePtr: number) {
-      const widget = this.widgets.get(widgetID);
-      if (widget == undefined) throw new Error(`twrWindowMenuWidgetGetPropTypes: Error! was given an invalid widgetID (${widgetID})`);
-      
-      const propName = mod.getString(propNamePtr);
-      const propField = widget[1].publicProperties[propName];
-      if (propField == undefined) throw new Error(`twrWindowMenuWidgetGetPropTypes: Couldn't find prop name "${propName}" in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
-      
-      function getPropTypes(propType: PropType): number {
-         switch (propType[0]) {
-            case PropBaseType.Combination:
-            {
-               let out = 0;
-               for (let i = 1; i < propType.length; i++) {
-                  const typ = propType[i];
-                  if (typ == PropBaseType.Undefined) {
-                     out &= PropBaseType.Undefined;
-                  } else {
-                     out &= getPropTypes([typ]);
-                  }
-               }
-               return out;
-            }
+   //takes in a a pointer to a twr_widget_prop_details struct with the name already filled out
+   twrWindowMenuWidgetGetPropDetails(mod: IWasmModule, widgetID: number, detailsStructPtr: number) {
+      const namePtr = 0 + detailsStructPtr;
+      const typePtr = 4 + detailsStructPtr;
+      const accessPtr = 8 + detailsStructPtr;
 
-            case PropBaseType.Boolean:
-            case PropBaseType.Number:
-            case PropBaseType.String:
-            {
-               return propType[0] as number;
-            }
-            
-            default:
-               throw new Error(`twrWindowMenuWidgetGetPropTypes: Error! was given unexpected prop type: ${PropBaseType[propType[0]] ?? propType[0]}!`);
+      const widget = this.widgets.get(widgetID);
+      if (widget == undefined) throw new Error(`twrWindowMenuWidgetGetPropDetails: Error! was given an invalid widgetID (${widgetID})`);
+
+      const propName = mod.wasmMem.getString(namePtr);
+      const propField = widget[1].publicProperties[propName];
+      if (propField == undefined) throw new Error(`twrWindowMenuWidgetGetPropDetails: Couldn't find prop name "${propName}" in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
+
+      let typ = 0;
+      if (propField[1][0] == PropBaseType.Combination) {
+         for (let i = 1; i < propField[1].length; i++) {
+            typ |= propField[1][i];
          }
+      } else {
+         typ = propField[1][0];
       }
+      mod.wasmMem.setLong(typePtr, typ);
 
-      return getPropTypes(propField[1]);
-   }
-
-   twrWindowMenuWidgetGetPropType(mod: IWasmModuleAsync | IWasmModule, widgetID: number, propNamePtr: number) {
-      const widget = this.widgets.get(widgetID);
-      if (widget == undefined) throw new Error(`twrWindowMenuWidgetGetPropType: Error! was given an invalid widgetID (${widgetID})`);
-      
-      const propName = mod.getString(propNamePtr);
-      const propField = widget[1].publicProperties[propName];
-      if (propField == undefined) throw new Error(`twrWindowMenuWidgetGetPropType: Couldn't find prop name "${propName}" in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
-      if (propField[0] == PropPerms.SetOnly) throw new Error(`twrWindowMenuWidgetGetPropType: Property "${propName}" is set only in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
-      
-      function assertFine(typ: PropBaseType) {
-         if (!(
-            propField[1][0] == typ
-            || (
-               propField[1][0] == PropBaseType.Combination
-               && propField[1].includes(typ)
-            )
-         )) {
-            throw new Error(`twrWindowMenuWidgetGetPropType: Internal error! Widget property was of type ${PropBaseType[typ] ?? typ} but was expecting: ${propField[1]}`);
-         }
-      }
-      switch (typeof (widget as any)[propName]) {
-         case "boolean":
-            assertFine(PropBaseType.Boolean);
-            return PropBaseType.Boolean;
-         case "string":
-            assertFine(PropBaseType.String);
-            return PropBaseType.String;
-         case "undefined":
-            assertFine(PropBaseType.Undefined);
-            return PropBaseType.Undefined;
-         case "number":
-            assertFine(PropBaseType.Number);
-            return PropBaseType.Number;
-         default:
-            throw new Error(`twrWindowMenuWidgetGetPropType: Internal error! property was of type: ${typeof (widget as any)[propName]}`)
-      }
-   }
-
-   twrWindowMenuWidgetGetPropAccess(mod: IWasmModuleAsync | IWasmModule, widgetID: number, propNamePtr: number) {
-      const widget = this.widgets.get(widgetID);
-      if (widget == undefined) throw new Error(`twrWindowMenuWidgetGetPropAccess: Error! was given an invalid widgetID (${widgetID})`);
-      
-      const propName = mod.wasmMem.getString(propNamePtr);
-      const propField = widget[1].publicProperties[propName];
-      if (propField == undefined) throw new Error(`twrWindowMenuWidgetGetPropAccess: Couldn't find prop name "${propName}" in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
-      
-      return propField[0] as number;
+      mod.wasmMem.setLong(accessPtr, propField[0]);
    }
 
    private twrWindowMenuWidgetListPropsHelper(mod: IWasmModuleAsync | IWasmModule, widgetID: number, lengthPtr: number) {
@@ -2312,11 +2241,10 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             }
             mod.wasmMem.setLong(structPtr + typeOffset, typ);
          }
-         console.log(`JS Alloc: ${alloc}`);
          return alloc;
       }));
    } 
-   twrWindowMenuWidgetListProps(mod: IWasmModuleAsync | IWasmModule, widgetID: number, lengthPtr: number) {
+   twrWindowMenuWidgetListProps(mod: IWasmModule, widgetID: number, lengthPtr: number) {
       const ret = this.twrWindowMenuWidgetListPropsHelper(mod, widgetID, lengthPtr);
       if (!(ret instanceof Promise)) {
          return ret;
@@ -2324,7 +2252,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          throw new Error(`internal error`);
       }
    }
-   async twrWindowMenuWidgetListProps_async(mod: IWasmModuleAsync | IWasmModule, widgetID: number, lengthPtr: number) {
+   async twrWindowMenuWidgetListProps_async(mod: IWasmModuleAsync, widgetID: number, lengthPtr: number) {
       const ret = this.twrWindowMenuWidgetListPropsHelper(mod, widgetID, lengthPtr);
       if (ret instanceof Promise) {
          return await ret;

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -74,6 +74,11 @@ interface Widget {
    readonly handledEvents: MenuItemEvents[];
    set visible(val: boolean);
    get visible(): boolean;
+   // set width(val: number|undefined);
+   // get width(): number|undefined;
+   // set height(val: number|undefined);
+   // get height(): number|undefined;
+   
    getMinSize: () => [number, number];
    render: (ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) => void;
    handleMenuEvent: (ctx: CanvasRenderingContext2D, event: MenuItemEventData) => void;
@@ -84,6 +89,63 @@ interface Widget {
    // isVisible: () => boolean;
 
    fullUpdate: (ctx: CanvasRenderingContext2D) => void;
+}
+
+let NEXT_WIDGET_ID: number = 0;
+abstract class WidgetImpl implements Widget {
+   readonly globalProps: GlobalWidgetProperties;
+   readonly parent: WidgetManager;
+   readonly id: number;
+   abstract readonly handledEvents: MenuItemEvents[];
+
+   protected _width?: number = undefined;
+   protected _height?: number = undefined;
+   protected _visible: boolean = true;
+
+   constructor(globalProps: GlobalWidgetProperties, parent: WidgetManager) {
+      this.id = ++NEXT_WIDGET_ID;
+      this.parent = parent;
+      this.globalProps = globalProps;
+   }
+   abstract getMinSize(): [number, number];
+   abstract render(ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number): void;
+   abstract handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData): void;
+   abstract delete(ctx: CanvasRenderingContext2D): Widget[];
+   abstract fullUpdate(ctx: CanvasRenderingContext2D): void;
+   protected abstract propograteUpdate(ctx?: CanvasRenderingContext2D): void;
+
+   set visible(val: boolean) {
+      if (this._visible != val) {
+         this._visible = val;
+         this.propograteUpdate();
+      }
+   }
+   get visible() {return this._visible};
+
+   set width(val: number|undefined) {
+      if (this._width != val) {
+         this._width = val;
+         this.propograteUpdate();
+      }
+   }
+   get width() {return this._width};
+
+   set height(val: number|undefined) {
+      if (this._height != val) {
+         this._height = val;
+         this.propograteUpdate();
+      }
+   }
+
+
+}
+
+//constructor fields in interfaces are ... weird
+//They aren't implemented on classes themselves, instead,
+// they are sort of auto implemented on any class that match their requirements
+// So this is "automatically" implemented on any class that implements the given constructor fields
+interface WidgetCreation<T extends Widget, U extends WidgetConstructor> {
+   new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, cons: U, globalProps: GlobalWidgetProperties): T
 }
 
 interface WidgetConstructor {
@@ -469,10 +531,9 @@ abstract class WidgetContainer implements Widget, WidgetManager {
       }
    }
    protected addChild<
-      T extends Widget, 
-      U, 
-      O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U, globalProps: GlobalWidgetProperties) => T
-   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U, x: number, y: number): T {
+      T extends Widget,
+      U extends WidgetConstructor,
+   >(ctx: CanvasRenderingContext2D, id: number, cons: WidgetCreation<T, U>, props: U, x: number, y: number): T {
       const widget: T = new cons(ctx, this, id, props, this.globalProps);
 
       this.children.push({
@@ -753,161 +814,11 @@ class Menu extends WidgetContainer {
       }
    }
    addChild<
-      T extends Widget, 
-      U, 
-      O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U, globalProps: GlobalWidgetProperties) => T
-   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
+      T extends Widget,
+      U extends WidgetConstructor,
+   >(ctx: CanvasRenderingContext2D, id: number, cons: WidgetCreation<T, U>, props: U): T {
       return super.addChild(ctx, id, cons, props, this.globalProps.menuBorderWidth, 0);
    }
-}
-
-interface RadioMenuWidgetConstructor extends MenuWidgetConstructor {
-   optionHeight?: number;
-}
-
-class RadioMenu implements Widget, WidgetManager, WidgetEvents {
-   readonly globalProps: GlobalWidgetProperties;
-   readonly parent: WidgetManager;
-   readonly id: number;
-   readonly handledEvents: MenuItemEvents[];
-
-   private menu: Menu;
-   private _optionHeight: number;
-   set optionHeight(val: number) {
-      for (const [_, widget] of this.options) {
-         widget.setDimensions(undefined, val);
-      }
-   }
-   get optionHeight(): number {return this._optionHeight};
-   
-   private options: Map<string, Button> = new Map();
-   private selected?: string;
-
-   private events: Set<(ctx: CanvasRenderingContext2D, opt: string) => void> = new Set();
-
-   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: RadioMenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
-      this.globalProps = globalProps;
-      // console.log(`Creating new radiomenu: ${props.height}, ${props.width}`);
-      this.menu = new Menu(ctx, this, 0, props, globalProps);
-      this.parent = parent;
-      this.id = id;
-
-      this._optionHeight = props.optionHeight ?? 20;
-      
-      this.handledEvents = this.menu.handledEvents;
-   }
-   getCtx() {
-      return this.parent.getCtx();
-   }
-   fullUpdate(ctx: CanvasRenderingContext2D) {
-      if (this.selected != undefined)
-         // this.options.get(this.selected)!.setButtonPrefixText(ctx, this.globalProps.radioMenuPrefix);
-         this.options.get(this.selected)!.prefixText = this.globalProps.radioMenuCheckedPrefix;
-      this.menu.fullUpdate(ctx);
-   }
-   set visible(visible: boolean) {
-      this.menu.visible = visible;
-   }
-   get visible() {
-      return this.menu.visible;
-   }
-
-   addOption(ctx: CanvasRenderingContext2D, opt: string) {
-      if (this.options.has(opt))
-         throw new Error(`RadioMenu: addOption already has the ${opt} option!`);
-
-      let prefix = undefined;
-      if (this.selected == undefined) {
-         this.selected = opt;
-         prefix = this.globalProps.radioMenuCheckedPrefix;
-      }
-
-      // console.log(`Radio menu adding button: Menu width is: ${this.menu.getDimensions()[0]}`);
-      const buttonOpts: ButtonWidgetConstructor = {
-         width: 20,
-         height: this._optionHeight,
-         text: opt,
-         prefixText: prefix,
-      };
-      const button: Button = this.menu.addChild(ctx, 0, Button, buttonOpts);
-
-      this.options.set(opt, button);
-
-      button.addEvent(((ctx: CanvasRenderingContext2D) => {
-         this.changeSelected(ctx, opt);
-      }).bind(this));
-
-      this.childUpdated(ctx, this);
-   }
-
-   changeSelected(ctx: CanvasRenderingContext2D, opt: string) {
-      if (this.selected != opt) {
-         if (this.selected != undefined) {
-            let button = this.options.get(this.selected)!;
-
-            // button.setButtonPrefixText(ctx, undefined);
-            button.prefixText = undefined;
-         }
-         this.selected = opt;
-         // this.options.get(this.selected)!.setButtonPrefixText(ctx, this.globalProps.radioMenuPrefix);
-         this.options.get(this.selected)!.prefixText = this.globalProps.radioMenuCheckedPrefix;
-
-         for (const event of this.events) {
-            event(ctx, this.selected);
-         }
-         this.menu.childUpdated(ctx);
-      }
-   }
-
-   getMinSize(): [number, number] {
-      return this.menu.getMinSize();
-   }
-   render(ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) {
-      this.menu.render(ctx, offsetX, offsetY);
-   }
-   handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
-      this.menu.handleMenuEvent(ctx, event);
-   }
-   getDimensions(): [number, number] {
-      // console.log(`Getting radio menu dimensions: ${this.menu.getDimensions()}`);
-      return this.menu.getDimensions();
-   }
-   setDimensions(width?: number, height?: number) {
-      return this.menu.setDimensions(width, height);
-   }
-
-   childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) {
-      // console.log("radio menu updated!!!");
-      this.parent.childUpdated(ctx, widget == this.menu ? this : widget, sendToRoot);
-   }
-
-   openPopup(ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) {
-      this.parent.openPopup(ctx, widget, x, y, relativeChild);
-   }
-   closePopup(ctx: CanvasRenderingContext2D, widget: Widget) {
-      this.parent.closePopup(ctx, widget);
-   }
-
-   private supressDeleteHandle: boolean = false;
-   delete(ctx: CanvasRenderingContext2D) {
-      this.supressDeleteHandle = true;
-      this.parent.handleDelete(ctx, this);
-      this.menu.delete(ctx);
-      this.supressDeleteHandle = false;
-      return [this];
-   }
-   handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
-      if (this.supressDeleteHandle) return;
-      throw new Error("RadialMenu shouldn't be handling an delete events!!!");
-   }
-
-   addEvent(callback: (ctx: CanvasRenderingContext2D, opt: string) => void) {
-      this.events.add(callback);
-   }
-   removeEvent(callback: (ctx: CanvasRenderingContext2D, opt: string) => void) {
-      this.events.delete(callback);
-   }
-
 }
 
 class MenuBar extends WidgetContainer {
@@ -958,10 +869,9 @@ class MenuBar extends WidgetContainer {
       this.supressChildUpdates = false;
    }
    addChild<
-      T extends Widget, 
-      U, 
-      O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U, globalProps: GlobalWidgetProperties) => T
-   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
+      T extends Widget,
+      U extends WidgetConstructor,
+   >(ctx: CanvasRenderingContext2D, id: number, cons: WidgetCreation<T, U>, props: U): T {
       return super.addChild(
          ctx, id, cons, props,
          0, super.drawOutline ? this.globalProps.menuBorderWidth/2 : 0
@@ -1008,10 +918,9 @@ class RootWidgetManager implements WidgetManager {
    }
 
    addChild<
-      T extends Widget, 
-      U, 
-      O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U, globalProps: GlobalWidgetProperties) => T
-   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U, globalProps: GlobalWidgetProperties, x: number, y: number): T {
+      T extends Widget,
+      U extends WidgetConstructor,
+   >(ctx: CanvasRenderingContext2D, id: number, cons: WidgetCreation<T, U>, props: U, globalProps: GlobalWidgetProperties, x: number, y: number): T {
       const widget: T = new cons(ctx, this, id, props, globalProps);
       
       this.boundWidgets.push([widget, x, y]);
@@ -1231,10 +1140,9 @@ class MenuButton extends Button implements WidgetManager {
       this.parent.childUpdated(ctx, widget, sendToRoot);   
    }
    addChild<
-      T extends Widget, 
-      U, 
-      O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U, globalProps: GlobalWidgetProperties) => T
-   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
+      T extends Widget,
+      U extends WidgetConstructor,
+   >(ctx: CanvasRenderingContext2D, id: number, cons: WidgetCreation<T, U>, props: U): T {
       return this.menu.addChild(ctx, id, cons, props);
    }
    openPopup(ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) {
@@ -1356,12 +1264,6 @@ class Seperator implements Widget {
    }
 }
 
-///gets a union of all the keys of an object that are of type U
-// for instance, if I had {a: string, b: number, c: number} and filtered by number, it would return
-//    a type union of "b"|"c"
-type FilteredKeys<T, U> = {
-   [K in keyof T]: T[K] extends U ? K : never;
- }[keyof T];
 
 interface CheckBoxWidgetConstructor extends WidgetConstructor {
    text: string;
@@ -1395,26 +1297,37 @@ class CheckBox extends Button {
 }
 
 class RadioItemGroup {
-   private items: Set<[RadioItem, (ctx: CanvasRenderingContext2D)=>void, (group: RadioItemGroup)=>void]> = new Set();
+   private items: Map<RadioItem, {
+      deselect: (ctx: CanvasRenderingContext2D)=>void, 
+      setRadioGroup: (group: RadioItemGroup)=>void
+   }> = new Map();
+
+   private selected: RadioItem;
    constructor(item: RadioItem, deselect: (ctx: CanvasRenderingContext2D)=>void, setRadioGroup: (group: RadioItemGroup)=>void) {
-      this.items.add([item, deselect, setRadioGroup]);
+      this.items.set(item, {
+         deselect: deselect,
+         setRadioGroup: setRadioGroup
+      });
+      this.selected = item;
    }
 
    optionSeleted(item: RadioItem, ctx: CanvasRenderingContext2D) {
-      for (const [n_item,  deselect,] of this.items) {
-         if (n_item == item)
-            continue;
-         deselect(ctx);
+      if (this.selected != item) {
+         this.items.get(this.selected)!.deselect(ctx);
+         this.selected = item;
       }
    }
 
-   mergeGroups(oth: RadioItemGroup) {
+   mergeGroups(oth: RadioItemGroup, ctx: CanvasRenderingContext2D) {
       if (oth == this) return;
-
-      
+      for (const [item, funcs] of oth.items) {
+         if (this.items.has(item))
+            throw new Error(`Somehow merged item twice??`);
+         this.items.set(item, funcs);
+         funcs.deselect(ctx);
+         funcs.setRadioGroup(this);
+      }
    }
-   
-   
 }
 class RadioItem extends Button {
    private callbacks: Set<(ctx: CanvasRenderingContext2D, selected: boolean) => void> = new Set();
@@ -1431,12 +1344,7 @@ class RadioItem extends Button {
       
       super.addEvent((ctx) => {
          if (!this._selected) {
-            this._selected = true;
-            this.radioGroup.optionSeleted(this, ctx);
-            super.prefixText = globalProps.radioMenuCheckedPrefix;
-            for (const callback of this.callbacks) {
-               callback(ctx, this._selected);
-            }
+            this.makeSelected(true, ctx);
          }
       });
    }
@@ -1452,8 +1360,20 @@ class RadioItem extends Button {
       this.radioGroup = group;
    }
 
-   makeSelected() {
+   makeSelected(sendEvent: boolean = true, ctx?: CanvasRenderingContext2D) {
+      const n_ctx = ctx ?? this.parent.getCtx();
+      this.radioGroup.optionSeleted(this, this.parent.getCtx());
+      this.prefixText = this.globalProps.radioMenuCheckedPrefix;
+      this._selected = true;
+      if (sendEvent) {
+         for (const callback of this.callbacks) {
+            callback(n_ctx, true);
+         }
+      }
+   }
 
+   mergeGroups(oth: RadioItem) {
+      this.radioGroup.mergeGroups(oth.radioGroup, this.parent.getCtx());
    }
 
    addEvent(callback: (ctx: CanvasRenderingContext2D, selected: boolean) => void) {
@@ -1462,6 +1382,159 @@ class RadioItem extends Button {
    removeEvent(callback: (ctx: CanvasRenderingContext2D, selected: boolean) => void) {
       return this.callbacks.delete(callback);
    }
+}
+
+
+interface RadioMenuWidgetConstructor extends MenuWidgetConstructor {
+   optionHeight?: number;
+}
+
+class RadioItem2 {
+
+}
+class RadioMenu implements Widget, WidgetManager, WidgetEvents {
+   readonly globalProps: GlobalWidgetProperties;
+   readonly parent: WidgetManager;
+   readonly id: number;
+   readonly handledEvents: MenuItemEvents[];
+
+   private menu: Menu;
+   private _optionHeight: number;
+   set optionHeight(val: number) {
+      for (const [_, widget] of this.options) {
+         widget.setDimensions(undefined, val);
+      }
+   }
+   get optionHeight(): number {return this._optionHeight};
+   
+   private options: Map<string, Button> = new Map();
+   private selected?: string;
+
+   private events: Set<(ctx: CanvasRenderingContext2D, opt: string) => void> = new Set();
+
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: RadioMenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
+      this.globalProps = globalProps;
+      // console.log(`Creating new radiomenu: ${props.height}, ${props.width}`);
+      this.menu = new Menu(ctx, this, 0, props, globalProps);
+      this.parent = parent;
+      this.id = id;
+
+      this._optionHeight = props.optionHeight ?? 20;
+      
+      this.handledEvents = this.menu.handledEvents;
+   }
+   getCtx() {
+      return this.parent.getCtx();
+   }
+   fullUpdate(ctx: CanvasRenderingContext2D) {
+      if (this.selected != undefined)
+         // this.options.get(this.selected)!.setButtonPrefixText(ctx, this.globalProps.radioMenuPrefix);
+         this.options.get(this.selected)!.prefixText = this.globalProps.radioMenuCheckedPrefix;
+      this.menu.fullUpdate(ctx);
+   }
+   set visible(visible: boolean) {
+      this.menu.visible = visible;
+   }
+   get visible() {
+      return this.menu.visible;
+   }
+
+   addOption(ctx: CanvasRenderingContext2D, opt: string) {
+      if (this.options.has(opt))
+         throw new Error(`RadioMenu: addOption already has the ${opt} option!`);
+
+      let prefix = undefined;
+      if (this.selected == undefined) {
+         this.selected = opt;
+         prefix = this.globalProps.radioMenuCheckedPrefix;
+      }
+
+      // console.log(`Radio menu adding button: Menu width is: ${this.menu.getDimensions()[0]}`);
+      const buttonOpts: ButtonWidgetConstructor = {
+         width: 20,
+         height: this._optionHeight,
+         text: opt,
+         prefixText: prefix,
+      };
+      const button: Button = this.menu.addChild(ctx, 0, Button, buttonOpts);
+
+      this.options.set(opt, button);
+
+      button.addEvent(((ctx: CanvasRenderingContext2D) => {
+         this.changeSelected(ctx, opt);
+      }).bind(this));
+
+      this.childUpdated(ctx, this);
+   }
+
+   changeSelected(ctx: CanvasRenderingContext2D, opt: string) {
+      if (this.selected != opt) {
+         if (this.selected != undefined) {
+            let button = this.options.get(this.selected)!;
+
+            // button.setButtonPrefixText(ctx, undefined);
+            button.prefixText = undefined;
+         }
+         this.selected = opt;
+         // this.options.get(this.selected)!.setButtonPrefixText(ctx, this.globalProps.radioMenuPrefix);
+         this.options.get(this.selected)!.prefixText = this.globalProps.radioMenuCheckedPrefix;
+
+         for (const event of this.events) {
+            event(ctx, this.selected);
+         }
+         this.menu.childUpdated(ctx);
+      }
+   }
+
+   getMinSize(): [number, number] {
+      return this.menu.getMinSize();
+   }
+   render(ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) {
+      this.menu.render(ctx, offsetX, offsetY);
+   }
+   handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
+      this.menu.handleMenuEvent(ctx, event);
+   }
+   getDimensions(): [number, number] {
+      // console.log(`Getting radio menu dimensions: ${this.menu.getDimensions()}`);
+      return this.menu.getDimensions();
+   }
+   setDimensions(width?: number, height?: number) {
+      return this.menu.setDimensions(width, height);
+   }
+
+   childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) {
+      // console.log("radio menu updated!!!");
+      this.parent.childUpdated(ctx, widget == this.menu ? this : widget, sendToRoot);
+   }
+
+   openPopup(ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) {
+      this.parent.openPopup(ctx, widget, x, y, relativeChild);
+   }
+   closePopup(ctx: CanvasRenderingContext2D, widget: Widget) {
+      this.parent.closePopup(ctx, widget);
+   }
+
+   private supressDeleteHandle: boolean = false;
+   delete(ctx: CanvasRenderingContext2D) {
+      this.supressDeleteHandle = true;
+      this.parent.handleDelete(ctx, this);
+      this.menu.delete(ctx);
+      this.supressDeleteHandle = false;
+      return [this];
+   }
+   handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
+      if (this.supressDeleteHandle) return;
+      throw new Error("RadialMenu shouldn't be handling an delete events!!!");
+   }
+
+   addEvent(callback: (ctx: CanvasRenderingContext2D, opt: string) => void) {
+      this.events.add(callback);
+   }
+   removeEvent(callback: (ctx: CanvasRenderingContext2D, opt: string) => void) {
+      this.events.delete(callback);
+   }
+
 }
 
 interface WidgetEvents {

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -52,6 +52,40 @@ class FakePromise<T> {
       }
    }
 }
+/// meant to fake the promise notation so that they can be written together
+/// main downside is that it requires chains of callbacks since await isn't
+///   really compatible with FakePromise
+function wrapPossibleSync<T>(val: Promise<T>|T): Promise<T>|FakePromise<T> {
+   if (val instanceof Promise) {
+      return val;
+   } else {
+      return new FakePromise(val);
+   }
+}
+
+/// simply unwraps the fake promise. If it's a promise, it leaves it be
+function unwrapPossibleSync<T>(val: Promise<T>|FakePromise<T>): Promise<T>|T {
+   if (val instanceof FakePromise) {
+      return val.extractVal();
+   } else {
+      return val;
+   }
+}
+
+/// takes in a list of FakePromise or a list of Promise and 
+///   either returns a promise that returns the internal list,
+///   or, it returns a FakePromise that does the same
+function waitForAll<T extends any[]>(
+   vals: (FakePromise<T[number]> | Promise<T[number]>)[]
+): Promise<T> | FakePromise<T> {
+   if (vals[0] instanceof Promise) {
+      return Promise.all(vals) as Promise<T>;
+   } else if (vals[0] instanceof FakePromise) {
+      return new FakePromise((vals as FakePromise<any>[]).map((val) => val.extractVal())) as FakePromise<T>;
+   }
+   throw new Error('internal error!');
+}
+
 enum MenuItemEvents {
    HOVERING,
    UNHOVERED,
@@ -125,15 +159,6 @@ type PropType = [PropBaseType.String]
    | [PropBaseType.Boolean]
    | [PropBaseType.Number]
    | [PropBaseType.Combination, ...PropPrimitiveType[]];
-
-type GetPropVal = [PropBaseType.String, string]
-   | [PropBaseType.Boolean, boolean]
-   | [PropBaseType.Number, number]
-   | [PropBaseType.Undefined];
-type AllocGetPropVal = [PropBaseType.String, string, number]
-   | [PropBaseType.Boolean, boolean]
-   | [PropBaseType.Number, number]
-   | [PropBaseType.Undefined];
 enum PropPerms {
    ReadOnly = 1,   //0b01
    SetOnly = 2,    //0b10
@@ -1602,11 +1627,10 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       twrWindowMenuAddWidget: {},
       twrWindowMenuWidgetAddCallback: {},
       twrWindowMenuDeleteWidget: {},
-      twrWindowMenuWidgetSetVisibility: {},
       twrWindowMenuRadioItemMerge: {},
       twrWindowMenuWidgetSetProp: {},
       twrWindowMenuWidgetGetProp: {isAsyncFunction: true},
-      twrWindowMenuWidgetListProps: {},
+      twrWindowMenuWidgetListProps: {isAsyncFunction: true},
    };
 
    // every library should have this line
@@ -1987,13 +2011,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    }
 
 
-   twrWindowMenuWidgetSetVisibility(mod: IWasmModuleAsync | IWasmModule, widgetID: number, visibility: number) {
-      if (!this.widgets.has(widgetID)) throw new Error(`twrWindowMenuWidgetSetVisibility: Error! was given an invalid widgetID (${widgetID})`);
-      const widget = this.widgets.get(widgetID)!;
-
-      widget[1].isVisible = visibility > 0 ? true : false;
-   }
-
    private checkValiditity(propField: [PropPerms, PropType], propName: string, typ: PropBaseType, widget: [WidgetType, Widget]) {
       if (propField[1][0] == typ)
          return;
@@ -2067,7 +2084,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       }
    }
 
-   private twrWindowMenuWidgetGetPropPart1(mod: IWasmModuleAsync | IWasmModule, widgetID: number, propNamePtr: number): GetPropVal {
+   private twrWindowMenuWidgetGetPropHelper(mod: IWasmModule | IWasmModuleAsync, widgetID: number, propNamePtr: number) {
       /* struct JSPropVal {
          enum JSPropValType type;
          const void* val;
@@ -2081,80 +2098,79 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       if (propField[0] == PropPerms.SetOnly) throw new Error(`twrWindowMenuWidgetGetProp: Property "${propName}" is set only in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
 
       const val = (widget[1] as any)[propName];
+      let propType: [PropBaseType.String, Uint8Array]
+         | [PropBaseType.Number, number]
+         | [PropBaseType.Boolean, boolean]
+         | [PropBaseType.Undefined];
+      //in struct, max unioned type is a double (8 bytes)
+      //and the type enum is a long (4 bytes)
+      const baseStructSize = 8 + 4;
+      let structSize = baseStructSize;
       switch (typeof val) {
          case "string":
-            return [PropBaseType.String, val];
+            const u8Str = mod.wasmMem.stringToU8(val);
+            //string + null character will be appended to end of struct allocation
+            structSize += u8Str.length + 1;
+            propType = [PropBaseType.String, u8Str];
+         break;
          case "number":
-            return [PropBaseType.Number, val];
+            propType = [PropBaseType.Number, val];
+         break;
          case "boolean":
-            return [PropBaseType.Boolean, val];
+            propType = [PropBaseType.Boolean, val];
+         break;
          case "undefined":
-            return [PropBaseType.Undefined];
+            propType = [PropBaseType.Undefined];
+         break;
          default:
             throw new Error(`twrWindowMenuWidgetGetProp: Internal Error! Got unexpected type from property "${propName}" in Widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
       }
-   }
 
-   private twrWindowMenuWidgetGetPropPart2(mod: IWasmModuleAsync | IWasmModule, retPtr: number, data: AllocGetPropVal) {
-      const valPtr = retPtr + 0;
-      const typePtr = retPtr + 8;
-      switch (data[0]) {
-         case PropBaseType.String:
-         {
-            mod.setLong(valPtr, data[2]);
+      return unwrapPossibleSync(wrapPossibleSync(mod.wasmMem.malloc(structSize)).then((alloc) => {
+         const valPtr = alloc + 0;
+         const typePtr = alloc + 8;
+         switch (propType[0]) {
+            case PropBaseType.String:
+            {
+               mod.wasmMem.mem8u.set(propType[1], alloc + baseStructSize);
+               mod.wasmMem.mem8u[alloc + baseStructSize + propType[1].length] = 0;
+               mod.setLong(valPtr, alloc + baseStructSize);
+            }
+            break;
+            case PropBaseType.Number:
+            {
+               mod.setDouble(valPtr, propType[1]);
+            }
+            break;
+            case PropBaseType.Undefined:
+            break;
+            case PropBaseType.Boolean:
+            {
+               mod.setLong(valPtr, propType[1] ? 1 : 0);
+            }
+            break;
+            default:
+               throw new Error(`internal error, shouldn't be possible`);
          }
-         break;
-         case PropBaseType.Number:
-         {
-            mod.setDouble(valPtr, data[1]);
-         }
-         break;
-         case PropBaseType.Undefined:
-         break;
-         case PropBaseType.Boolean:
-         {
-            mod.setLong(valPtr, data[1] ? 1 : 0);
-         }
-         break;
-         default:
-            throw new Error(`internal error, shouldn't be possible`);
-      }
-      mod.setLong(typePtr, data[0]);
+         mod.setLong(typePtr, propType[0]);
+         return alloc;
+      }));
    }
-
    twrWindowMenuWidgetGetProp(mod: IWasmModule, widgetID: number, propNamePtr: number) {
-      const val = this.twrWindowMenuWidgetGetPropPart1(mod, widgetID, propNamePtr);
-      
-      let alloc: AllocGetPropVal;
-      if (val[0] == PropBaseType.String)
-         alloc = [val[0], val[1], mod.putString(val[1])]
-      else
-         alloc = val;
-
-      //in struct, max unioned type is a double (8 bytes)
-      //and the type enum is a long (4 bytes)
-      const retPtr = mod.malloc(8 + 4);
-
-      this.twrWindowMenuWidgetGetPropPart2(mod, retPtr, alloc);
-
-      return retPtr;
+      const ret = this.twrWindowMenuWidgetGetPropHelper(mod, widgetID, propNamePtr);
+      if (!(ret instanceof Promise)) {
+         return ret;
+      } else {
+         throw new Error(`internal error!`);
+      }
    }
    async twrWindowMenuWidgetGetProp_async(mod: IWasmModuleAsync, widgetID: number, propNamePtr: number) {
-      const val = this.twrWindowMenuWidgetGetPropPart1(mod, widgetID, propNamePtr);
-   
-      let alloc: AllocGetPropVal;
-      if (val[0] == PropBaseType.String)
-         alloc = [val[0], val[1], await mod.putString(val[1])]
-      else
-         alloc = val;
-
-      //in struct, max unioned type is a double (8 bytes)
-      //and the type enum is a long (4 bytes)
-      const retPtr = await mod.malloc(8 + 4);
-
-      this.twrWindowMenuWidgetGetPropPart2(mod, retPtr, alloc);
-
-      return retPtr;
+      const ret = this.twrWindowMenuWidgetGetPropHelper(mod, widgetID, propNamePtr);
+      if (ret instanceof Promise) {
+         return await ret;
+      } else {
+         throw new Error(`internal error!`);
+      }
    }
 
    twrWindowMenuWidgetGetPropTypes(mod: IWasmModuleAsync | IWasmModule, widgetID: number, propNamePtr: number) {
@@ -2245,76 +2261,76 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       return propField[0] as number;
    }
 
-   private wrapPossibleSync<T>(val: Promise<T>|T): Promise<T>|FakePromise<T> {
-      if (val instanceof Promise) {
-         return val;
-      } else {
-         return new FakePromise(val);
-      }
-   }
-
-   private unwrapPossibleSync<T>(val: Promise<T>|FakePromise<T>): Promise<T>|T {
-      if (val instanceof FakePromise) {
-         return val.extractVal();
-      } else {
-         return val;
-      }
-   }
-   // private waitForAll<
-   //    // U,
-   //    // Fns extends ((...args: any[]) => any)[],
-   //    // FinalFn extends (...args: Parameters<Fns[number]>) => U
-   //    T extends any[]
-   // >(...args: AsyncLikeSyncInterface<T[number]>[]): AsyncLikeSyncInterface<T> {
-   //    let isAsync = false;
-   //    for (let i = 0; i < args.length; i++) {
-   //       if (args instanceof Promise)
-   //    }
-   //    return {
-   //       then: <U>(n_func: (...args: T) => U): U | Promise<U> => {
-
-   //       }
-   //    }
-   // }
-   waitForAll<T extends any[]>(
-      vals: (FakePromise<T[number]> | Promise<T[number]>)[]
-   ): Promise<T> | FakePromise<T> {
-      if (vals[0] instanceof Promise) {
-         return Promise.all(vals) as Promise<T>;
-      } else if (vals[0] instanceof FakePromise) {
-         return new FakePromise((vals as FakePromise<any>[]).map((val) => val.extractVal())) as FakePromise<T>;
-      }
-      throw new Error('internal error!');
-   }
-   twrWindowMenuWidgetListProps(mod: IWasmModuleAsync | IWasmModule, widgetID: number, lengthPtr: number) {
+   private twrWindowMenuWidgetListPropsHelper(mod: IWasmModuleAsync | IWasmModule, widgetID: number, lengthPtr: number) {
       const widget = this.widgets.get(widgetID);
       if (widget == undefined) throw new Error(`twrWindowMenuWidgetListProps: Error! was given an invalid widgetID (${widgetID})`);
 
-      const props: Uint8Array<ArrayBufferLike>[] = [];
+      // struct twr_widget_prop_details {
+      //    const char* name;
+      //    enum WindowWidgetPropVal type;
+      //    enum WindowWidgetPropAccess access;
+      // };
+      const baseStructSize = 4*3;
+      const nameOffset = 0;
+      const typeOffset = 4;
+      const accessOffset = 8;
+      
+      const props: [Uint8Array<ArrayBufferLike>, PropPerms, PropType][] = [];
       let totalSize = 0;
       for (const name in widget[1].publicProperties) {
          const ru8=mod.wasmMem.stringToU8(name);
-   
-         totalSize += ru8.length + 1;
-         props.push(ru8);
+         totalSize += baseStructSize + ru8.length + 1;
+
+         const [propPerms, propType] = widget[1].publicProperties[name];
+         props.push([ru8, propPerms, propType]);
       }
-      totalSize += props.length * 4;
       mod.wasmMem.setLong(lengthPtr, props.length);
 
 
-      return this.unwrapPossibleSync(this.wrapPossibleSync(mod.malloc(totalSize)).then((alloc) => {
-         let offset = props.length*4;
+      return unwrapPossibleSync(wrapPossibleSync(mod.malloc(totalSize)).then((alloc) => {
+         let offset = baseStructSize * props.length + alloc;
          for (let i = 0; i < props.length; i++) {
-            mod.wasmMem.setLong(i * 4, offset);
-            mod.wasmMem.mem8u.set(props[i], offset);
-            mod.wasmMem.mem8u[offset+props[i].length] = 0; //null ptr at end
-            offset += props[i].length + 1;
+            const [propName, propAccess, propType] = props[i];
+            const structPtr = baseStructSize * i + alloc;
+            //set name, strings are put after the list of structs in the allocation
+            mod.wasmMem.setLong(structPtr + nameOffset, offset);
+            mod.wasmMem.mem8u.set(propName, offset);
+            mod.wasmMem.mem8u[offset+propName.length] = 0; //null ptr at end
+            offset += propName.length + 1;
+
+            //set access
+            mod.wasmMem.setLong(structPtr + accessOffset, propAccess);
+            
+            //set type
+            let typ = 0;
+            if (propType[0] != PropBaseType.Combination) {
+               typ = propType[0];
+            } else {
+               for (let i = 1; i < propType.length; i++) {
+                  typ |= propType[i];
+               }
+            }
+            mod.wasmMem.setLong(structPtr + typeOffset, typ);
          }
+         console.log(`JS Alloc: ${alloc}`);
          return alloc;
       }));
-
-      // return alloc
+   } 
+   twrWindowMenuWidgetListProps(mod: IWasmModuleAsync | IWasmModule, widgetID: number, lengthPtr: number) {
+      const ret = this.twrWindowMenuWidgetListPropsHelper(mod, widgetID, lengthPtr);
+      if (!(ret instanceof Promise)) {
+         return ret;
+      } else {
+         throw new Error(`internal error`);
+      }
+   }
+   async twrWindowMenuWidgetListProps_async(mod: IWasmModuleAsync | IWasmModule, widgetID: number, lengthPtr: number) {
+      const ret = this.twrWindowMenuWidgetListPropsHelper(mod, widgetID, lengthPtr);
+      if (ret instanceof Promise) {
+         return await ret;
+      } else {
+         throw new Error(`internal error`);
+      }
    }
 
 }
-

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -1,5 +1,5 @@
 import { bindCanvasEvents, CanvasEventTypes, ICanvasEvents } from "./twrcanvasevents.js";
-import { IConsole, IConsoleEvents } from "./twrcon.js";
+import { IConsole, IConsoleBaseProps, IConsoleEvents, IConsoleWindow } from "./twrcon.js";
 import twrConsoleCanvas from "./twrconcanvas.js";
 import { TLibImports, twrLibrary, twrLibraryInstanceRegistry } from "./twrlibrary.js";
 import { IWasmModule } from "./twrmod";
@@ -16,16 +16,28 @@ function calculateID(mod:IWasmModule|IWasmModuleAsync, id: number): FullID {
    return ((mod.id & (2**20 - 1)) * 2**32 + id) as FullID;
 }
 
-export default class twrConsoleWindow extends twrLibrary implements ICanvasEvents {
+enum twrWindowEvents {
+   CLOSE,
+   
+}
+
+export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, IConsoleWindow {
    id: number;
+   props: IConsoleBaseProps;
 
    element: HTMLCanvasElement;
    ctx: CanvasRenderingContext2D;
-   readonly borderSizes: [number, number];
+   readonly topBarSize: number;
+   readonly borderSize: number;
+   
+   appCanvasWidth: number;
+   appCanvasHeight: number;
    readonly appCanvas: twrConsoleCanvas;
 
+   appCanvasConNames: { [modID: number]: string } = {};
+
    imports: TLibImports = {
-      
+      twrGetAppCanvasJSID: {},
    };
 
    // every library should have this line
@@ -39,28 +51,62 @@ export default class twrConsoleWindow extends twrLibrary implements ICanvasEvent
       this.element = canvas;
       this.ctx = canvas.getContext("2d")!;
 
-      const perimiterThickness = Math.min(canvas.height, canvas.width) * 0.05;
+      const perimiterThickness = Math.min(canvas.height, canvas.width) * 0.025;
       const menuThickness = Math.min(canvas.height, canvas.width) * 0.1;
 
-      const appCanvasHeight = Math.floor(canvas.height - perimiterThickness - menuThickness);
-      const appCanvasWidth = Math.floor(canvas.width - menuThickness*2.0);
+      this.appCanvasHeight = Math.floor(canvas.height - perimiterThickness - menuThickness);
+      this.appCanvasWidth = Math.floor(canvas.width - perimiterThickness*2.0);
 
-      this.borderSizes = [perimiterThickness, menuThickness];
+      this.topBarSize = menuThickness;
+      this.borderSize = perimiterThickness;
 
-      const appCanvas = new HTMLCanvasElement();
-      appCanvas.height = appCanvasHeight;
-      appCanvas.width = appCanvasWidth;
+      const appCanvas = document.createElement("canvas");
+      appCanvas.height = this.appCanvasHeight;
+      appCanvas.width = this.appCanvasWidth;
 
-      this.appCanvas = new twrConsoleCanvas(appCanvas, false);
+      this.appCanvas = new twrConsoleCanvas(appCanvas, undefined, false);
 
-      bindCanvasEvents(this, this.element);
+      if (selfRegisterEvents)
+         bindCanvasEvents(this, this.element);
+
+      this.props = {
+         //TODO: Figure out what type to add/use here
+         type: 0
+      };
+   }
+   getProp(propName: string) {
+      return this.props[propName];
+   };
+
+   twrConGetProp(callingMod: IWasmModule | IWasmModuleAsync, pn: number) {
+      const propName=callingMod.wasmMem.getString(pn);
+      return this.getProp(propName);
+   };
+
+   twrRegisterEvent(callingMod: IWasmModuleAsync | IWasmModule, eventType: number, eventID: number) {
+
+   }
+   twrUnregisterEvent(callingMod: IWasmModuleAsync | IWasmModule, eventType: number, eventID: number) {
+
+   }
+   twrUnregisterAllEvents(callingMod: IWasmModuleAsync | IWasmModule) {
+
    }
 
    handleCanvasKeyEvent(event: CanvasEventTypes, key: number) {
       this.appCanvas.handleCanvasKeyEvent(event, key);
    }
    handleCanvasMouseEvent(event: CanvasEventTypes, x: number, y: number) {
-      this.appCanvas.handleCanvasMouseEvent(event, x, y);
+      const n_x = x - this.borderSize;
+      const n_y = y - this.topBarSize;
+      if (
+         n_x >= 0 && n_y >= 0
+         && n_x <= this.appCanvasWidth
+         && n_y <= this.appCanvasHeight
+      ) {
+         this.appCanvas.handleCanvasMouseEvent(event, n_x, n_y);
+      }
+         
    }
    handleCanvasWheelEvent(event: CanvasEventTypes, deltaX: number, deltaY: number, deltaZ: number, deltaMode: number) {
       this.appCanvas.handleCanvasWheelEvent(event, deltaX, deltaY, deltaZ, deltaMode);
@@ -68,19 +114,20 @@ export default class twrConsoleWindow extends twrLibrary implements ICanvasEvent
    handleCanvasAnimationFrameEvent(event: CanvasEventTypes, delta: number) {
       this.appCanvas.handleCanvasAnimationFrameEvent(event, delta);
 
+      this.ctx.reset();
       //draw "app" canvas
-      this.ctx.drawImage(this.appCanvas.element, this.borderSizes[0], this.borderSizes[1]);
+      this.ctx.drawImage(this.appCanvas.element, this.borderSize, this.topBarSize);
 
       //draw border around it
       this.ctx.fillStyle = "blue";
-      this.ctx.fillRect(0, 0, this.borderSizes[1], this.element.height);
-      this.ctx.fillRect(this.element.width - this.borderSizes[1], 0, this.element.width, this.element.height);
-      this.ctx.fillRect(0, this.element.height - this.borderSizes[1], this.element.width, this.element.height);
+      this.ctx.fillRect(0, 0, this.borderSize, this.element.height);
+      this.ctx.fillRect(this.element.width - this.borderSize, 0, this.element.width, this.element.height);
+      this.ctx.fillRect(0, this.element.height - this.borderSize, this.element.width, this.element.height);
       
-      this.ctx.fillRect(0, 0, this.element.width, this.borderSizes[0]);
+      this.ctx.fillRect(0, 0, this.element.width, this.topBarSize);
    }
 
-   twrGetAppCanvas(mod:IWasmModule|IWasmModuleAsync) {
+   twrGetAppCanvasJSID(mod:IWasmModule|IWasmModuleAsync) {
       return this.appCanvas.id;
    }
 

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -21,57 +21,135 @@ enum twrWindowEvents {
    
 }
 
+enum MenuItemEvents {
+   HOVERING,
+   UNHOVERED,
+   CLICKED,
+   MOUSE_MOVE,
+}
+type MenuItemEventData = [ MenuItemEvents.HOVERING ]
+   | [ MenuItemEvents.UNHOVERED ]
+   | [ MenuItemEvents.CLICKED ]
+   | [ MenuItemEvents.MOUSE_MOVE, number, number ];
+
+interface MenuItem {
+   id: number;
+   getMinSize: (ctx: CanvasRenderingContext2D) => [number, number];
+   render: (ctx: CanvasRenderingContext2D, x: number, y: number, width: number, height: number) => void;
+   getRequiredMenuEvents: () => MenuItemEvents[];
+   handleMenuEvent: (event: MenuItemEventData) => void;
+}
+
+interface WidgetEvents {
+   addEvent: (callback: () => void) => void;
+   removeEvent: (callback: () => void) => void;
+}
 const BUTTON_FONT = "16px Serif";
 const BUTTON_PADDING_Y = 2.5;
 const BUTTON_PADDING_X = 5;
 const BUTTON_HEIGHT = 5;
-class Button {
-   text: string;
-   minWidth: number;
-   events: Map<number, [IWasmModule|IWasmModuleAsync, Map<number, number>]> = new Map();
+class Button implements MenuItem, WidgetEvents {
+   id: number;
 
-   constructor(text: string, ctx: CanvasRenderingContext2D) {
+   text: string;
+   font: string;
+   text_color: string;
+   background_color: string;
+   selected_color: string;
+   minWidth: number;
+   minHeight: number;
+   events: (() => void)[] = [];
+
+   constructor(
+      id: number,
+      ctx: CanvasRenderingContext2D, 
+      text: string, 
+      font: string = "16px Serif", 
+      text_color: string = "white", 
+      background_color: string = "light_gray", 
+      selected_color: string = "gray"
+   ) {
+      this.id = id;
       this.text = text;
+      this.font = font;
+      this.text_color = text_color;
+      this.background_color = background_color;
+      this.selected_color = selected_color;
 
       ctx.save();
       
-      ctx.font = BUTTON_FONT;
+      ctx.font = this.font;
       const measure = ctx.measureText(text);
-      this.minWidth = measure.width + BUTTON_PADDING_X*2.0;
+      this.minWidth = measure.width;
+      this.minHeight = measure.actualBoundingBoxAscent;
 
       ctx.restore();
    }
+   getRequiredMenuEvents() {
+      return [
+         MenuItemEvents.CLICKED,
+         MenuItemEvents.HOVERING,
+         MenuItemEvents.UNHOVERED,
+      ];
+   }
 
-   addEvent(mod: IWasmModule|IWasmModuleAsync, eventID: number, extraPtr: number) {
-      if (!(mod.id in this.events))
-         this.events.set(mod.id, [mod, new Map()]);
+   selected: boolean = false;
+   handleMenuEvent(event: MenuItemEventData) {
+      switch (event[0]) {
+         case MenuItemEvents.CLICKED:
+         {
+            for (const handler of this.events) {
+               handler();
+            }
+         }
+         break;
 
-      const [_, event_map] = this.events.get(mod.id)!;
+         case MenuItemEvents.HOVERING:
+         {
+            this.selected = true;
+         }
+         break;
 
-      if (eventID in event_map)
-         throw new Error(`Error: button addEvent was given an eventID (${eventID}) that's already been registered!`);
+         case MenuItemEvents.UNHOVERED:
+         {
+            this.selected = false;
+         }
+         break;
+         
+         default:
+         {
+            throw new Error(`Button handleMenuEvent was given an unexpected event (${event})!`);
+         }
+         break;
+      } 
+   };
+   addEvent(callback: () => void) {
+      this.events.push(callback);
+   }
+   removeEvent(callback: () => void) {
+      const index = this.events.findIndex(callback);
+      if (index == -1) throw new Error(`Error: Button removeEvent was given a callback that wasn't registered!`);
+      this.events.splice(index, 1);
+   }
+
+   getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
+      return [this.minWidth, this.minHeight];
+   };
+
+   render(ctx: CanvasRenderingContext2D, x: number, y: number, width: number, height: number) {
+      ctx.save();
+      ctx.font = this.font;
       
-      event_map.set(eventID, extraPtr);
+      console.log(this.text, this.selected);
+      ctx.fillStyle = this.selected ? this.selected_color : this.background_color ;
+      ctx.fillRect(x, y, width, height);
+
+      ctx.fillStyle = this.text_color;
+      ctx.fillText(this.text, x + (width - this.minWidth)/2, y + (height + this.minHeight)/2);
+
+      ctx.restore();
    }
-
-   removeEvent(mod: IWasmModule|IWasmModuleAsync, eventID: number) {
-      if (!(mod.id in this.events))
-         throw new Error(`Error: button removeEvent tried to remove event from a module (${mod.id}) that's never registered one!`);
-      
-      const [_, event_map] = this.events.get(mod.id)!;
-
-      if (!(eventID in event_map))
-         throw new Error(`Error: button removeEvent tried to remove an eventID (${eventID}) that isn't registered!`);
-
-      event_map.delete(eventID);
-   }
-
-   removeAllModEvents(mod: IWasmModule|IWasmModuleAsync) {
-      if (!(mod.id in this.events))
-         throw new Error(`Error: button removeAllModEvents trying to remove events from a module (${mod.id}) that's never registered any!`);
-
-      this.events.delete(mod.id);
-   }
+   
 }
 
 const MENU_TEXT_FONT = "20px Serif";
@@ -81,36 +159,46 @@ const TOP_BAR_SIZE: number = 30;
 const BORDER_SIZE: number = 5;
 const MENU_START_X = BORDER_SIZE;
 class Menu {
-   text: string;
-   buttons: number[] = [];
+   items: MenuItem[] = [];
    
-   xOffset = MENU_PADDING_X;
-   width: number;
-   yOffset: number;
+   constructor() {
 
-   hovering: boolean = false;
-   selected: boolean = false;
+   }
 
-   constructor(text: string, ctx: CanvasRenderingContext2D) {
-      this.text = text;
+   render(ctx: CanvasRenderingContext2D, x: number, y: number) {
       ctx.save();
-      
-      ctx.font = MENU_TEXT_FONT;
-      const measure = ctx.measureText(text);
+
+      let maxWidth = 0;
+      let maxHeight = 0;
+      for (const item of this.items) {
+         const [width, height] = item.getMinSize(ctx);
+         if (width > maxWidth)
+            maxWidth = width;
+         if (height > maxHeight)
+            maxHeight = height;
+      }
+      const width = maxWidth + MENU_PADDING_X*2;
+      const height = (maxHeight + MENU_PADDING_Y)*this.items.length - MENU_PADDING_Y;
+
+      ctx.fillStyle = "light_gray";
+      ctx.fillRect(x, y, width, height);
+
+      let currentHeight = 0;
+      for (const item of this.items) {
+         item.render(ctx, x+MENU_PADDING_X, currentHeight, maxWidth, maxHeight);
+         currentHeight += maxHeight + MENU_PADDING_Y;
+      }
 
       ctx.restore();
-
-      this.width = MENU_PADDING_X*2 + measure.width;
-      // console.log(`menu: ${measure.actualBoundingBoxAscent}, ${measure.actualBoundingBoxDescent}`);
-      this.yOffset = (TOP_BAR_SIZE + measure.actualBoundingBoxAscent)/2;
    }
 
-   addButton(buttonID: number, buttons: Map<number, Button>) {
-      if (!(buttonID in buttons))
-         throw new Error(`Error! Menu addButton was given an unregisted buttonID ${buttonID}!`);
-
-
+   addItem(menuItem: MenuItem) {
+      if (this.items.indexOf(menuItem) != -1)
+         throw new Error(`Menu addItem was given a MenuItem that's already on the menu!`);
+      this.items.push(menuItem);
    }
+
+   
 
 }
 
@@ -125,10 +213,10 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    appCanvasHeight: number;
    readonly appCanvas: twrConsoleCanvas;
 
-   buttons: Map<number, Button> = new Map();
-   nextButtonID: number = 0;
+   menuItems: Map<number, MenuItem> = new Map();
+   nextMenuItem: number = 0;
 
-   menus: Map<number, Menu> = new Map();
+   menus: Map<number, [Button, Menu]> = new Map();
    nextMenuID: number = 0;
    
 
@@ -212,18 +300,25 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          this.mouseWasOnTopBar = true;
          let widthOffset = MENU_START_X;
          for (const menu of this.menus.values()) {
-            menu.hovering = x >= widthOffset
-               && x < widthOffset+menu.width;
-            // console.log(`${x >= widthOffset}, ${x < widthOffset+menu.width}, ${menu.hovering}`);
+            // menu.hovering = x >= widthOffset
+            //    && x < widthOffset+menu.width;
+            const width = menu[0].getMinSize(this.ctx)[0] + MENU_PADDING_X*2;
+            
+            if (
+               x >= widthOffset
+               && x < widthOffset+width
+            ) {
+               menu[0].handleMenuEvent([MenuItemEvents.HOVERING]);
+            }
 
-            widthOffset += menu.width;
+            widthOffset += width;
          }
       }
 
       if (!topBar && this.mouseWasOnTopBar) {
          this.mouseWasOnTopBar = false;
          for (const menu of this.menus.values()) {
-            menu.hovering = false;
+            menu[0].handleMenuEvent([MenuItemEvents.UNHOVERED]);
          }
       }
       return true;
@@ -257,30 +352,39 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       this.ctx.stroke();
       this.ctx.closePath();
 
-      this.ctx.fillStyle = "black";
-      this.ctx.font = MENU_TEXT_FONT;
-      let widthOffset = MENU_START_X; 
+      // this.ctx.fillStyle = "black";
+      // this.ctx.font = MENU_TEXT_FONT;
+      // let widthOffset = MENU_START_X; 
+      // for (const menu of this.menus.values()) {
+      //    // console.log(`${widthOffset + menu.xOffset}, ${menu.yOffset}`);
+      //    if (menu.hovering ) {
+      //       this.ctx.save();
+      //       this.ctx.fillStyle = SELECT_GREY;
+
+      //       this.ctx.beginPath();
+      //       this.ctx.roundRect(widthOffset, MENU_PADDING_Y, menu.width, TOP_BAR_SIZE - MENU_PADDING_Y*2.0, Math.PI);
+      //       this.ctx.fill();
+      //       this.ctx.closePath();
+
+      //       this.ctx.restore();
+      //    }
+      //    this.ctx.fillText(
+      //       menu.text, 
+      //       widthOffset + menu.xOffset,
+      //       menu.yOffset,
+      //    );
+
+      //    widthOffset += menu.width;
+      // }
+      let widthOffset = MENU_START_X;
       for (const menu of this.menus.values()) {
-         // console.log(`${widthOffset + menu.xOffset}, ${menu.yOffset}`);
-         if (menu.hovering ) {
-            this.ctx.save();
-            this.ctx.fillStyle = SELECT_GREY;
+         const width = menu[0].getMinSize(this.ctx)[0] + MENU_PADDING_X*2;
 
-            this.ctx.beginPath();
-            this.ctx.roundRect(widthOffset, MENU_PADDING_Y, menu.width, TOP_BAR_SIZE - MENU_PADDING_Y*2.0, Math.PI);
-            this.ctx.fill();
-            this.ctx.closePath();
+         menu[0].render(this.ctx, widthOffset, 0, width, TOP_BAR_SIZE);
 
-            this.ctx.restore();
-         }
-         this.ctx.fillText(
-            menu.text, 
-            widthOffset + menu.xOffset,
-            menu.yOffset,
-         );
-
-         widthOffset += menu.width;
+         widthOffset += width;
       }
+
    }
 
    twrGetAppCanvasJSID(mod:IWasmModule|IWasmModuleAsync) {
@@ -290,9 +394,9 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    twrWindowAddMenu(mod: IWasmModuleAsync | IWasmModule, textPtr: number) {
       const text = mod.getString(textPtr);
 
-      const id = ++this.nextButtonID;
+      const id = ++this.nextMenuID;
 
-      this.menus.set(id, new Menu(text, this.ctx));
+      this.menus.set(id, [new Button(id, this.ctx, text), new Menu()]);
 
       return id;
    }

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -71,14 +71,16 @@ interface Widget {
    readonly parent: WidgetManager; 
    readonly id: number;
    readonly handledEvents: MenuItemEvents[];
+   set visible(val: boolean);
+   get visible(): boolean;
    getMinSize: () => [number, number];
    render: (ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) => void;
    handleMenuEvent: (ctx: CanvasRenderingContext2D, event: MenuItemEventData) => void;
    getDimensions: () => [number, number];
    setDimensions: (width?: number, height?: number) => void;
    delete: (ctx: CanvasRenderingContext2D) => Widget[];
-   setVisibility: (visibility: boolean) => void;
-   isVisible: () => boolean;
+   // setVisibility: (visibility: boolean) => void;
+   // isVisible: () => boolean;
 
    fullUpdate: (ctx: CanvasRenderingContext2D) => void;
 }
@@ -95,7 +97,7 @@ interface ButtonWidgetConstructor extends WidgetConstructor {
 
    reservedPrefixSpace?: number;
 }
-
+ 
 class Button implements Widget, WidgetEvents {
    readonly globalProps: GlobalWidgetProperties;
    readonly parent: WidgetManager; 
@@ -111,25 +113,38 @@ class Button implements Widget, WidgetEvents {
 
    private textOffsets: [number, number, number];
 
+   private updateProperty() {
+      const ctx = this.parent.getCtx();
+      this.textOffsets = this.getTextOffsets(ctx);
+      this.parent.childUpdated(ctx, this);
+   }
    private _text: string;
-   set text(val: string) {this._text = val; this.fullUpdate};
-   private prefixText?: string;
-   private suffixText?: string;
+   private _prefixText?: string;
+   private _suffixText?: string;
    private centeredHorizontally: boolean;
    private reservedPrefixSpace: number;
+
+   set text(val: string) {this._text = this.text; this.updateProperty()};
+   get text(): string {return this._text};
+   set prefixText(val: string|undefined) {this._prefixText = val; this.updateProperty()};
+   get prefixText(): string|undefined {return this._prefixText};
+   set suffixText(val: string|undefined) {this._suffixText = val; this.updateProperty()};
+   get suffixText(): string|undefined {return this._suffixText};
+
+
 
    private selected: boolean = false;
    private events: Set<((ctx: CanvasRenderingContext2D) => void)> = new Set();
 
-   private visibility: boolean = true;
+   private _visible: boolean = true;
 
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, cons: ButtonWidgetConstructor, globalProps: GlobalWidgetProperties) {
       this.parent = parent;
       this.id = id;
 
       this._text = cons.text;
-      this.prefixText = cons.prefixText;
-      this.suffixText = cons.suffixText;
+      this._prefixText = cons.prefixText;
+      this._suffixText = cons.suffixText;
       this.centeredHorizontally = cons.centeredHorizontally ?? false;
       this.reservedPrefixSpace = cons.reservedPrefixSpace ?? 0;
       this.globalProps = globalProps;
@@ -153,16 +168,14 @@ class Button implements Widget, WidgetEvents {
       return this.globalProps.widgetTextFont;
    }
 
-   setVisibility(visibility: boolean) {
-      if (this.visibility != visibility) {
-         this.visibility = visibility;
+   set visible(visible: boolean) {
+      if (this._visible != visible) {
+         this._visible = visible;
          this.parent.childUpdated(this.parent.getCtx(), this, false);
-         if (!this.visibility)
-            this.visibility = false;
       }
    }
-   isVisible() {
-      return this.visibility;
+   get visible() {
+      return this._visible;
    }
 
    getDimensions(): [number, number] {
@@ -180,16 +193,6 @@ class Button implements Widget, WidgetEvents {
       if (height != undefined || width != undefined)
          this.parent.childUpdated(ctx);
    }
-   setButtonText(ctx: CanvasRenderingContext2D, newText: string) {
-      this._text = newText;
-      this.textOffsets = this.getTextOffsets(ctx);
-      this.parent.childUpdated(ctx, this);
-   }
-   setButtonPrefixText(ctx: CanvasRenderingContext2D, newText?: string) {
-      this.prefixText = newText;
-      this.textOffsets = this.getTextOffsets(ctx);
-      this.parent.childUpdated(ctx, this);
-   }
 
    private getFullMinSize(ctx: CanvasRenderingContext2D): [number, number, number, number] {
       ctx.save();
@@ -199,13 +202,13 @@ class Button implements Widget, WidgetEvents {
       const spaceMeasure = ctx.measureText(" ");
       const spaceWidth = spaceMeasure.width;
       let minPrefix = this.reservedPrefixSpace;
-      if (this.prefixText != undefined) {
-         const prefixMeasure = ctx.measureText(this.prefixText);
+      if (this._prefixText != undefined) {
+         const prefixMeasure = ctx.measureText(this._prefixText);
          minPrefix = Math.max(minPrefix, prefixMeasure.width + spaceWidth);
       }
       let minSuffix = 0;
-      if (this.suffixText != undefined) {
-         const suffixMeasure = ctx.measureText(this.suffixText);
+      if (this._suffixText != undefined) {
+         const suffixMeasure = ctx.measureText(this._suffixText);
          minSuffix = suffixMeasure.width + spaceWidth;
       }
 
@@ -241,7 +244,7 @@ class Button implements Widget, WidgetEvents {
       ];
    }
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
-      if (!this.visibility)
+      if (!this._visible)
          return;
 
       ctx.save();
@@ -253,9 +256,9 @@ class Button implements Widget, WidgetEvents {
       // ctx.font = this.globalProps.widgetTextFont;
       ctx.font = this.getFont();
       ctx.fillStyle = this.globalProps.textColor;
-      if (this.prefixText != undefined) {
+      if (this._prefixText != undefined) {
          ctx.fillText(
-            this.prefixText,
+            this._prefixText,
             offsetX,
             this.textOffsets[1] + offsetY
          );
@@ -265,9 +268,9 @@ class Button implements Widget, WidgetEvents {
          this.textOffsets[0] + offsetX,
          this.textOffsets[1] + offsetY
       );
-      if (this.suffixText != undefined) {
+      if (this._suffixText != undefined) {
          ctx.fillText(
-            " " + this.suffixText,
+            " " + this._suffixText,
             offsetX + (this.width - this.textOffsets[2]),
             this.textOffsets[1] + offsetY
          );
@@ -276,7 +279,7 @@ class Button implements Widget, WidgetEvents {
       ctx.restore();
    }
    handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
-      if (!this.visibility)
+      if (!this._visible)
          return;
 
       switch (event[0]) {
@@ -343,7 +346,7 @@ class Menu implements Widget, WidgetManager {
    //resets to undefined on menu update or UNHOVERED event
    private selectedItem?: [Widget, number];
 
-   private visibility: boolean = true;
+   private _visible: boolean = true;
    
    
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
@@ -367,18 +370,18 @@ class Menu implements Widget, WidgetManager {
       this.selectedItem = undefined;
    }
 
-   setVisibility(visibility: boolean) {
+   set visible(visible: boolean) {
       const ctx = this.parent.getCtx();
-      if (this.visibility != visibility) {
-         if (!visibility)
+      if (this._visible != visible) {
+         if (!visible)
             this.handleMenuEvent(ctx, [MenuItemEvents.CLICKED_OFF]);
 
-         this.visibility = visibility;
+         this._visible = visible;
          this.parent.childUpdated(ctx, this, false);
       }
    }
-   isVisible() {
-      return this.visibility;
+   get visible() {
+      return this._visible;
    }
 
    pauseDeleteHandle: boolean = false;
@@ -443,7 +446,7 @@ class Menu implements Widget, WidgetManager {
       // let maxChildHeight = this.minChildHeight;
       let childHeight = 0;
       for (const [widget,] of this.children) {
-         if (!widget.isVisible())
+         if (!widget.visible)
             continue;
          const [width, ] = widget.getMinSize();
          childWidth = Math.max(childWidth, width);
@@ -474,7 +477,7 @@ class Menu implements Widget, WidgetManager {
          
          let curHeight = this.globalProps.menuBorderWidth;
          for (const widget of this.children) {
-            if (!widget[0].isVisible())
+            if (!widget[0].visible)
                continue;
             const [, height] = widget[0].getDimensions();
             this.supressChildUpdates = true;
@@ -519,7 +522,7 @@ class Menu implements Widget, WidgetManager {
    }
 
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0): void {
-      if (!this.visibility)
+      if (!this._visible)
          return;
 
 		ctx.save();
@@ -558,7 +561,7 @@ class Menu implements Widget, WidgetManager {
 	}
    
    private dispatchEvent(ctx: CanvasRenderingContext2D, widget: Widget, event: MenuItemEventData) {
-      if (widget.handledEvents.includes(event[0]) && widget.isVisible()) {
+      if (widget.handledEvents.includes(event[0]) && widget.visible) {
          widget.handleMenuEvent(ctx, event);
       }
    }
@@ -575,7 +578,7 @@ class Menu implements Widget, WidgetManager {
    private updateSelectedObject(ctx: CanvasRenderingContext2D,x: number, y: number) {
       //check if hovering over selected item
       if (this.selectedItem) {
-         if (this.mouseInWidgetBounds(this.selectedItem[0], this.selectedItem[1], x, y) && this.selectedItem[0].isVisible()) {
+         if (this.mouseInWidgetBounds(this.selectedItem[0], this.selectedItem[1], x, y) && this.selectedItem[0].visible) {
             return; //the selected item is in bounds
          } else {
             //selected item is out of bounds
@@ -586,7 +589,7 @@ class Menu implements Widget, WidgetManager {
       //otherwise, find what object (if any) are hovered over
       for (const child of this.children) {
          //found child it's hovering over
-         if (this.mouseInWidgetBounds(child[0], child[1], x, y) && child[0].isVisible()) {
+         if (this.mouseInWidgetBounds(child[0], child[1], x, y) && child[0].visible) {
             this.selectedItem = child;
             this.dispatchEvent(ctx, child[0], [MenuItemEvents.HOVERING]);
             //break early
@@ -595,7 +598,7 @@ class Menu implements Widget, WidgetManager {
       }
    }
    handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData): void {
-      if (!this.visibility)
+      if (!this._visible)
          return;
 		switch (event[0]) {
          case MenuItemEvents.MOUSE_MOVE:
@@ -702,7 +705,13 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
    readonly handledEvents: MenuItemEvents[];
 
    private menu: Menu;
-   private optionHeight: number;
+   private _optionHeight: number;
+   set optionHeight(val: number) {
+      for (const [_, widget] of this.options) {
+         widget.setDimensions(undefined, val);
+      }
+   }
+   get optionHeight(): number {return this._optionHeight};
    
    private options: Map<string, Button> = new Map();
    private selected?: string;
@@ -716,7 +725,7 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
       this.parent = parent;
       this.id = id;
 
-      this.optionHeight = props.optionHeight ?? 20;
+      this._optionHeight = props.optionHeight ?? 20;
       
       this.handledEvents = this.menu.handledEvents;
    }
@@ -725,14 +734,15 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
    }
    fullUpdate(ctx: CanvasRenderingContext2D) {
       if (this.selected != undefined)
-         this.options.get(this.selected)!.setButtonPrefixText(ctx, this.globalProps.radioMenuPrefix);
+         // this.options.get(this.selected)!.setButtonPrefixText(ctx, this.globalProps.radioMenuPrefix);
+         this.options.get(this.selected)!.prefixText = this.globalProps.radioMenuPrefix;
       this.menu.fullUpdate(ctx);
    }
-   setVisibility(visible: boolean) {
-      this.menu.setVisibility(visible);
+   set visible(visible: boolean) {
+      this.menu.visible = visible;
    }
-   isVisible() {
-      return this.menu.isVisible();
+   get visible() {
+      return this.menu.visible;
    }
 
    addOption(ctx: CanvasRenderingContext2D, opt: string) {
@@ -748,7 +758,7 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
       console.log(`Radio menu adding button: Menu width is: ${this.menu.getDimensions()[0]}`);
       const buttonOpts: ButtonWidgetConstructor = {
          width: 20,
-         height: this.optionHeight,
+         height: this._optionHeight,
          text: opt,
          prefixText: prefix,
          reservedPrefixSpace: this.globalProps.reservedPrefixLen,
@@ -769,11 +779,13 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
          if (this.selected != undefined) {
             let button = this.options.get(this.selected)!;
 
-            button.setButtonPrefixText(ctx, undefined);
+            // button.setButtonPrefixText(ctx, undefined);
+            button.prefixText = undefined;
          }
          this.selected = opt;
-         this.options.get(this.selected)!.setButtonPrefixText(ctx, this.globalProps.radioMenuPrefix);
-         
+         // this.options.get(this.selected)!.setButtonPrefixText(ctx, this.globalProps.radioMenuPrefix);
+         this.options.get(this.selected)!.prefixText = this.globalProps.radioMenuPrefix;
+
          for (const event of this.events) {
             event(ctx, this.selected);
          }
@@ -856,7 +868,7 @@ class MenuBar implements Widget, WidgetManager {
 
    private supressChildUpdates = false;
 
-   private visible: boolean = true;
+   private _visible: boolean = true;
 
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuBarWidgetConstructor, globalProps: GlobalWidgetProperties) {
       this.globalProps = globalProps;
@@ -879,24 +891,24 @@ class MenuBar implements Widget, WidgetManager {
       }
    }
 
-   setVisibility(visible: boolean) {
+   set visible(visible: boolean) {
       const ctx = this.parent.getCtx();
-      if (!this.visible != visible) {
+      if (!this._visible != visible) {
          if (!visible)
             this.handleMenuEvent(ctx, [MenuItemEvents.CLICKED_OFF]);
-         this.visible = visible;
+         this._visible = visible;
          this.parent.childUpdated(ctx, this, false);
       }
    }
-   isVisible() {
-      return this.visible;
+   get visible() {
+      return this._visible;
    }
 
    getMinSize(): [number, number] {
       return [this.calcWidth, this.calcHeight];
    }
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
-      if (!this.visible)
+      if (!this._visible)
          return;
 
       for (let i = this.children.length-1; i >= 0; i--) {
@@ -922,7 +934,7 @@ class MenuBar implements Widget, WidgetManager {
    }
    private updateSelected(ctx: CanvasRenderingContext2D, x: number, y: number) {
       if (this.selected) {
-         if (this.mouseInWidgetBounds(this.selected[0], this.selected[1], x, y) && this.selected[0].isVisible()) {
+         if (this.mouseInWidgetBounds(this.selected[0], this.selected[1], x, y) && this.selected[0].visible) {
             return;
          } else {
             this.dispatchEvent(ctx, this.selected[0], [MenuItemEvents.UNHOVERED]);
@@ -931,7 +943,7 @@ class MenuBar implements Widget, WidgetManager {
       }
 
       for (const widget of this.children) {
-         if (this.mouseInWidgetBounds(widget[0], widget[1], x, y) && widget[0].isVisible()) {
+         if (this.mouseInWidgetBounds(widget[0], widget[1], x, y) && widget[0].visible) {
             this.selected = widget;
             this.dispatchEvent(ctx, widget[0], [MenuItemEvents.HOVERING]);
             return;
@@ -939,7 +951,7 @@ class MenuBar implements Widget, WidgetManager {
       }
    }
    handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
-      if (!this.visible)
+      if (!this._visible)
          return;
 
       switch (event[0]) {
@@ -1020,7 +1032,7 @@ class MenuBar implements Widget, WidgetManager {
       let minHeight = this.globalProps.emptyMenuWidth;
       let width = 0;
       for (const [widget,] of this.children) {
-         if (!widget.isVisible())
+         if (!widget.visible)
             continue;
 
          const [widgetWidth, widgetHeight] = widget.getDimensions();
@@ -1040,7 +1052,7 @@ class MenuBar implements Widget, WidgetManager {
       let pos = 0;
       this.supressChildUpdates = true;
       for (const widget of this.children) {
-         if (!widget[0].isVisible())
+         if (!widget[0].visible)
             continue;
 
          const [widgetWidth, widgetHeight] = widget[0].getDimensions();
@@ -1184,7 +1196,7 @@ class RootWidgetManager implements WidgetManager {
    }
    private updateSelected(ctx: CanvasRenderingContext2D, x: number, y: number) {
       if (this.selectedWidget) {
-         if (this.widgetInBounds(this.selectedWidget[0], this.selectedWidget[1], this.selectedWidget[2], x, y) && this.selectedWidget[0].isVisible()) {
+         if (this.widgetInBounds(this.selectedWidget[0], this.selectedWidget[1], this.selectedWidget[2], x, y) && this.selectedWidget[0].visible) {
             return;
          } else {
             this.dispatchEvent(ctx, this.selectedWidget[0], [MenuItemEvents.UNHOVERED]);
@@ -1207,7 +1219,7 @@ class RootWidgetManager implements WidgetManager {
       for (let i = this.boundWidgets.length-1; i >= 0; i--) {
          const [widget, widgetX, widgetY] = this.boundWidgets[i];
 
-         if (this.widgetInBounds(widget, widgetX, widgetY, x, y) && widget.isVisible()) {
+         if (this.widgetInBounds(widget, widgetX, widgetY, x, y) && widget.visible) {
             this.selectedWidget = [widget, widgetX, widgetY];
             this.dispatchEvent(ctx, widget, [MenuItemEvents.HOVERING]);
             return;
@@ -1382,11 +1394,14 @@ class Seperator implements Widget {
    private height: number;
    private minHeight: number = 0;
 
-   private text: string = "";
+   private _text: string = "";
    private textXOffset: number = 0;
    private textYOffset: number = 0;
 
-   private visible: boolean = true;
+   set text(val: string) {this._text = val; this.fullUpdate(this.parent.getCtx())};
+   get text(): string {return this._text};
+
+   private _visible: boolean = true;
 
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: SeperatorWidgetConstructor, globalProps: GlobalWidgetProperties) {
       this.globalProps = globalProps;
@@ -1404,14 +1419,14 @@ class Seperator implements Widget {
       this.updateText(ctx);
    }
 
-   setVisibility(visible: boolean) {
-      if (this.visible != visible) {
-         this.visible = visible;
+   set visible(visible: boolean) {
+      if (this._visible != visible) {
+         this._visible = visible;
          this.parent.childUpdated(this.parent.getCtx(), this, false);
       }
    }
-   isVisible() {
-      return this.visible;
+   get visible() {
+      return this._visible;
    }
 
    delete(ctx: CanvasRenderingContext2D) {
@@ -1429,7 +1444,7 @@ class Seperator implements Widget {
       const width = repeats*metrics.width;
       const height = metrics.actualBoundingBoxAscent;
 
-      this.text = this.seperatorText.repeat(repeats);
+      this._text = this.seperatorText.repeat(repeats);
 
       this.textXOffset = (this.width - width)/2.0;
       // console.log(width, this.width, this.textXOffset);
@@ -1443,7 +1458,7 @@ class Seperator implements Widget {
       return [0, this.minHeight];
    }
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
-      if (!this.visible)
+      if (!this._visible)
          return;
 
       ctx.save();
@@ -1453,7 +1468,7 @@ class Seperator implements Widget {
 
       // console.log(this.x, offsetX, this.textXOffset, this.x + offsetX + this.textXOffset);
       ctx.fillText(
-         this.text,
+         this._text,
          offsetX + this.textXOffset,
          offsetY + this.textYOffset
       );
@@ -1487,6 +1502,9 @@ class CheckBox implements Widget, WidgetManager, WidgetEvents {
    private changeEventHandlers: Set<(ctx: CanvasRenderingContext2D, selected: boolean) => void> = new Set();
    private selected = false;
 
+   get text(): string {return this.button.text};
+   set text(val: string) {this.button.text = val;};
+
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: CheckBoxWidgetConstructor, globalProps: GlobalWidgetProperties) {
       this.globalProps = globalProps;
       this.parent = parent;
@@ -1505,9 +1523,11 @@ class CheckBox implements Widget, WidgetManager, WidgetEvents {
       this.button.addEvent((ctx) => {
          this.selected = !this.selected;
          if (this.selected) {
-            this.button.setButtonPrefixText(ctx, this.globalProps.checkBoxCheckedPrefix);
+            // this.button.setButtonPrefixText(ctx, this.globalProps.checkBoxCheckedPrefix);
+            this.button.prefixText = this.globalProps.checkBoxCheckedPrefix;
          } else {
-            this.button.setButtonPrefixText(ctx, this.globalProps.checkBoxUncheckedPrefix);
+            // this.button.setButtonPrefixText(ctx, this.globalProps.checkBoxUncheckedPrefix);
+            this.button.prefixText = this.globalProps.checkBoxUncheckedPrefix;
          }
          for (const callback of this.changeEventHandlers) {
             callback(ctx, this.selected);
@@ -1519,18 +1539,21 @@ class CheckBox implements Widget, WidgetManager, WidgetEvents {
    }
    fullUpdate(ctx: CanvasRenderingContext2D) {
       this.button.fullUpdate(ctx);
-      this.button.setButtonPrefixText(
-         ctx,
-         this.selected
-            ? this.globalProps.checkBoxCheckedPrefix
-            : this.globalProps.checkBoxUncheckedPrefix
-      );
+      // this.button.setButtonPrefixText(
+      //    ctx,
+      //    this.selected
+      //       ? this.globalProps.checkBoxCheckedPrefix
+      //       : this.globalProps.checkBoxUncheckedPrefix
+      // );
+      this.button.prefixText = this.selected
+         ? this.globalProps.checkBoxCheckedPrefix
+         : this.globalProps.checkBoxUncheckedPrefix;
    }
-   setVisibility(visibility: boolean) {
-      this.button.setVisibility(visibility);
+   set visible(visibility: boolean) {
+      this.button.visible = visibility;
    }
-   isVisible() {
-      return this.button.isVisible();
+   get visible() {
+      return this.button.visible;
    }
    addEvent(callback: (ctx: CanvasRenderingContext2D, selected: boolean) => void) {
       this.changeEventHandlers.add(callback);
@@ -2130,7 +2153,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       if (!this.widgets.has(widgetID)) throw new Error(`twrWindowMenuWidgetSetVisibility: Error! was given an invalid widgetID (${widgetID})`);
       const widget = this.widgets.get(widgetID)!;
 
-      widget[1].setVisibility(visibility > 0 ? true : false);
+      widget[1].visible = visibility > 0 ? true : false;
    }
 
 }

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -34,14 +34,6 @@ type MenuItemEventData = [ MenuItemEvents.HOVERING ]
    | [ MenuItemEvents.MOUSE_MOVE, number, number ]
    | [ MenuItemEvents.CLICKED_OFF];
 
-interface MenuItem {
-   id: number;
-   getMinSize: (ctx: CanvasRenderingContext2D) => [number, number];
-   render: (ctx: CanvasRenderingContext2D, x: number, y: number, width: number, height: number) => void;
-   getRequiredMenuEvents: () => MenuItemEvents[];
-   handleMenuEvent: (event: MenuItemEventData) => void;
-}
-
 interface WidgetManager {
    childUpdated: (ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) => void;
    //really, really long type. Basically accepts any class constructor that created a Widget
@@ -49,7 +41,7 @@ interface WidgetManager {
    // the idea is that you give the manager a widget and it constructs it internally.
    // addChild: <T extends Widget, U, O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U) => T>(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U) => T;
 
-   openPopup: (ctx: CanvasRenderingContext2D, widget: Widget) => void;
+   openPopup: (ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) => void;
    closePopup: (ctx: CanvasRenderingContext2D, widget: Widget) => void;
    handleDelete: (ctx: CanvasRenderingContext2D, widget: Widget) => void;
 }
@@ -144,14 +136,14 @@ class Button implements Widget, WidgetEvents {
    getDimensions(): [number, number] {
       return [this.width, this.height];
    }
-   setDimensions(ctx: CanvasRenderingContext2D, x?: number, y?: number, width?: number, height?: number) {
+   setDimensions(ctx: CanvasRenderingContext2D, width?: number, height?: number) {
       this.height = height ?? this.height;
       this.width = width ?? this.width;
 
       if (height != undefined || width != undefined)
          this.textOffsets = this.getTextOffsets(ctx);
       
-      if (x != undefined || y != undefined || height != undefined || width != undefined)
+      if (height != undefined || width != undefined)
          this.parent.childUpdated(ctx);
    }
    setButtonText(ctx: CanvasRenderingContext2D, newText: string) {
@@ -238,6 +230,8 @@ interface MenuWidgetConstructor extends WidgetConstructor {
    menuColor?: string;
    yPadding?: number;
    minChildHeight?: number;
+   borderColor?: string;
+   borderWidth?: number;
 }
 
 class Menu implements Widget, WidgetManager {
@@ -273,6 +267,9 @@ class Menu implements Widget, WidgetManager {
    //the currently hovered over/selected item 
    //resets to undefined on menu update or UNHOVERED event
    private selectedItem?: [Widget, number];
+
+   private borderColor: string;
+   private borderWidth: number;
    
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuWidgetConstructor) {
       this.parent = parent;
@@ -288,6 +285,9 @@ class Menu implements Widget, WidgetManager {
       this.height = props.height;
       this.yPadding = props.yPadding ?? 10;
 
+      this.borderColor = props.borderColor ?? "black";
+      this.borderWidth = props.borderWidth ?? 0.0;
+
       this.menuColor = props.menuColor ?? "gray";
    }
    pauseDeleteHandle: boolean = false;
@@ -295,11 +295,15 @@ class Menu implements Widget, WidgetManager {
       if (this.pauseDeleteHandle)
          return;
 
-      let i = this.children.indexOf(widget);
-      if (i >= 0) {
-         this.children.splice(i, 1);
-         this.childUpdated(ctx);
-      }
+      // let i = this.children.indexOf(widget);
+      for (let i = 0; i < this.children.length; i++) {
+         if (this.children[i][0] == widget) {
+            if (i >= 0) {
+               this.children.splice(i, 1);
+               this.childUpdated(ctx);
+            }
+         }
+      }  
    }
    delete(ctx: CanvasRenderingContext2D) {
       this.parent.handleDelete(ctx, this);
@@ -307,7 +311,7 @@ class Menu implements Widget, WidgetManager {
       this.pauseDeleteHandle = true;
       let deleted: Widget[] = [];
       for (const widget of this.children) {
-         deleted = deleted.concat(widget.delete(ctx));
+         deleted = deleted.concat(widget[0].delete(ctx));
       }
       //push self to list
       deleted.push(this);
@@ -317,8 +321,24 @@ class Menu implements Widget, WidgetManager {
       return deleted;
 
    }
-   openPopup(ctx: CanvasRenderingContext2D, widget: Widget) {
-      this.parent.openPopup(ctx, widget);
+   openPopup(ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) {
+      let [nX, nY] = [x, y];
+      let nextRelative = relativeChild;
+      if (relativeChild != undefined) {
+         for (const child of this.children) {
+            if (child[0] == relativeChild) {
+               nY += child[1];
+               if (nX > 0)
+                  nX += this.borderWidth * 2;
+               else
+                  nX -= this.borderWidth;
+               nextRelative = this;
+               break;
+            }
+         }
+      }
+      console.log(`open popup (Menu): (${x}, ${y}); (${nX}, ${nY})`);
+      this.parent.openPopup(ctx, widget, nX, nY, nextRelative);
    }
    closePopup(ctx: CanvasRenderingContext2D, widget: Widget) {
       this.parent.closePopup(ctx, widget);
@@ -338,6 +358,8 @@ class Menu implements Widget, WidgetManager {
          const [, height] = widget.getDimensions();
          childHeight += height + this.yPadding;
       }
+      childWidth += this.borderWidth * 2;
+      childHeight += this.borderWidth * 2;
 
       // console.log(childWidth, childHeight);
 
@@ -352,15 +374,16 @@ class Menu implements Widget, WidgetManager {
 
       // console.log(newWidth, newHeight, this.childWidth, this.childHeight);
 
+      console.log(`updating width: ${newWidth}`);
       if (this.lastWidth != newWidth || this.lastHeight != newHeight || forceRun) {
          this.lastWidth = newWidth;
          this.lastHeight = newHeight;
          
-         let curHeight = 0;
+         let curHeight = this.borderWidth;
          for (const widget of this.children) {
             const [, height] = widget[0].getDimensions();
             this.supressChildUpdates = true;
-            widget[0].setDimensions(ctx, newWidth, undefined);
+            widget[0].setDimensions(ctx, newWidth - this.borderWidth * 2, undefined);
             widget[1] = curHeight;
             this.supressChildUpdates = false;
             // curHeight += maxChildHeight;
@@ -403,16 +426,33 @@ class Menu implements Widget, WidgetManager {
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0): void {
 		ctx.save();
 
+      const width = this.width ?? this.childWidth;
+      const height = this.height ?? this.childHeight;
+
       ctx.fillStyle = this.menuColor;
       ctx.fillRect(
          offsetX,
          offsetY,
-         this.width ?? this.childWidth,
-         this.height ?? this.childHeight,
+         width,
+         height,
       );
 
+      if (this.borderWidth > 0) {
+         ctx.strokeStyle = this.borderColor;
+         ctx.lineWidth = this.borderWidth;
+         ctx.beginPath();
+         ctx.rect(
+            offsetX + this.borderWidth/2.0, 
+            offsetY + this.borderWidth/2.0, 
+            width - this.borderWidth,
+            height - this.borderWidth
+         );
+         ctx.stroke();
+         ctx.closePath();
+      }
+
       for (const widget of this.children) {
-         widget[0].render(ctx, offsetX, offsetY + widget[1]);
+         widget[0].render(ctx, offsetX + this.borderWidth, offsetY + widget[1] + this.borderWidth);
       }
 
       ctx.restore();
@@ -426,7 +466,7 @@ class Menu implements Widget, WidgetManager {
 
    private mouseInWidgetBounds(widget: Widget, widgetY: number, x: number, y: number) {
       const [widgetWidth, widgetHeight] = widget.getDimensions();
-      return 0 <= x && x <= widgetWidth
+      return this.borderWidth <= x && x <= this.borderWidth + widgetWidth
             && widgetY <= y && y <= widgetY + widgetHeight;
    }
 
@@ -461,7 +501,7 @@ class Menu implements Widget, WidgetManager {
             const [, eX, eY] = event;
             this.updateSelectedObject(ctx, eX, eY);
             if (this.selectedItem) {
-               const [x, y] = [eX, eY - this.selectedItem[1]];
+               const [x, y] = [eX - this.borderWidth, eY - this.selectedItem[1]];
                this.dispatchEvent(ctx, this.selectedItem[0], [MenuItemEvents.MOUSE_MOVE, x, y]);
             }
          }
@@ -470,9 +510,14 @@ class Menu implements Widget, WidgetManager {
          {
             const [, eX, eY] = event;
             this.updateSelectedObject(ctx, eX, eY);
-            if (this.selectedItem) {
-               const [x, y] = [eX, eY - this.selectedItem[1]];
-               this.dispatchEvent(ctx, this.selectedItem[0], [MenuItemEvents.CLICKED, x, y]);
+            const selected = this.selectedItem;
+            if (selected) {
+               const [x, y] = [eX - this.borderWidth, eY - selected[1]];
+               this.dispatchEvent(ctx, selected[0], [MenuItemEvents.CLICKED, x, y]);
+            }
+            for (const [widget,] of this.children) {
+               if (selected == undefined || widget != selected[0])
+                  this.dispatchEvent(ctx, widget, [MenuItemEvents.CLICKED_OFF]);
             }
          }
          break;
@@ -492,6 +537,8 @@ class Menu implements Widget, WidgetManager {
             for (const handler of this.clickedOffHandlers) {
                handler();
             }
+            for (const widget of this.children)
+               this.dispatchEvent(ctx, widget[0], [MenuItemEvents.CLICKED_OFF]);
          }
          break;
       }
@@ -594,8 +641,6 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
       }
 
       const buttonOpts: ButtonWidgetConstructor = {
-         x: 0,
-         y: 0,
          width: -1,
          height: this.optionHeight,
          text: prefix + opt,
@@ -651,8 +696,8 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
       this.parent.childUpdated(ctx, widget, sendToRoot);
    }
 
-   openPopup(ctx: CanvasRenderingContext2D, widget: Widget) {
-      this.parent.openPopup(ctx, widget);
+   openPopup(ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) {
+      this.parent.openPopup(ctx, widget, x, y, relativeChild);
    }
    closePopup(ctx: CanvasRenderingContext2D, widget: Widget) {
       this.parent.closePopup(ctx, widget);
@@ -801,6 +846,20 @@ class MenuBar implements Widget, WidgetManager {
          }
          break;
 
+         case MenuItemEvents.CLICKED_OFF:
+         {
+            if (this.selected) {
+               this.dispatchEvent(ctx, this.selected[0], [MenuItemEvents.UNHOVERED]);
+            }
+            this.selected = undefined;
+
+            for (const widget of this.children) {
+               this.dispatchEvent(ctx, widget[0], [MenuItemEvents.CLICKED_OFF]);
+            }
+
+         }
+         break;
+
          default:
          {
             throw new Error(`MenuBar HandleMenuEvent: Error! Was given an unhandled event (${MenuItemEvents[event[0]]})!`);
@@ -886,8 +945,20 @@ class MenuBar implements Widget, WidgetManager {
       return widget;
    }
 
-   openPopup(ctx: CanvasRenderingContext2D, widget: Widget) {
-      this.parent.openPopup(ctx, widget);
+   openPopup(ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) {
+      let [nX, nY] = [x, y];
+      let nextRelative = relativeChild;
+      if (relativeChild != undefined) {
+         for (const child of this.children) {
+            if (child[0] == relativeChild) {
+               nX += child[1];
+               nextRelative = this;
+               break;
+            }
+         }
+      }
+      console.log(`open popup (MenuBar): (${x}, ${y}); (${nX}, ${nY})`);
+      this.parent.openPopup(ctx, widget, nX, nY, nextRelative);
    }
    closePopup(ctx: CanvasRenderingContext2D, widget: Widget) {
       this.parent.closePopup(ctx, widget);
@@ -908,7 +979,7 @@ class MenuBar implements Widget, WidgetManager {
 
 class RootWidgetManager implements WidgetManager {
    private boundWidgets: [Widget, number, number][] = [];
-   private popupWidgets: Set<Widget> = new Set();
+   private popupWidgets: Map<Widget, [number, number]> = new Map();
 
    private selectedWidget?: [Widget, number, number];
 
@@ -940,8 +1011,22 @@ class RootWidgetManager implements WidgetManager {
       this.selectedWidget = undefined;
    }
 
-   openPopup(ctx: CanvasRenderingContext2D, widget: Widget) {
-      this.popupWidgets.add(widget);
+   openPopup(ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) {
+      let [nX, nY] = [x, y];
+      if (relativeChild != undefined) {
+         let fromPopups = this.popupWidgets.get(relativeChild);
+         if (fromPopups) {
+            nX += fromPopups[0];
+            nY += fromPopups[1];
+         } else {
+            for (const child of this.boundWidgets) {
+               nX += child[1];
+               nY += child[2];
+            }
+         }
+      }
+      console.log(`open popup (Root): (${x}, ${y}); (${nX}, ${nY})`);
+      this.popupWidgets.set(widget, [nX, nY]);
       this.childUpdated(ctx, widget);
    }
    closePopup(ctx: CanvasRenderingContext2D, widget: Widget) {
@@ -953,10 +1038,10 @@ class RootWidgetManager implements WidgetManager {
       return false;
    }
 
-   private widgetInBounds(widget: Widget, x: number, y: number): boolean {
-      const [wX, wY, wW, wH] = widget.getDimensions();
-      return wX <= x && x <= wX + wW
-         && wY <= y && y <= wY + wH;
+   private widgetInBounds(widget: Widget, widgetX: number, widgetY: number, x: number, y: number): boolean {
+      const [wW, wH] = widget.getDimensions();
+      return widgetX <= x && x <= widgetX + wW
+         && widgetY <= y && y <= widgetY + wH;
    }
    private dispatchEvent(ctx: CanvasRenderingContext2D, widget: Widget, event: MenuItemEventData) {
       if (widget.handledEvents.includes(event[0])) {
@@ -965,30 +1050,30 @@ class RootWidgetManager implements WidgetManager {
    }
    private updateSelected(ctx: CanvasRenderingContext2D, x: number, y: number) {
       if (this.selectedWidget) {
-         if (this.widgetInBounds(this.selectedWidget, x, y)) {
+         if (this.widgetInBounds(this.selectedWidget[0], this.selectedWidget[1], this.selectedWidget[2], x, y)) {
             return;
          } else {
-            this.dispatchEvent(ctx, this.selectedWidget, [MenuItemEvents.UNHOVERED]);
+            this.dispatchEvent(ctx, this.selectedWidget[0], [MenuItemEvents.UNHOVERED]);
             this.selectedWidget = undefined;
          }
       }
 
       //most recently added is on top in order of popups -> bound
 
-      const widgetList = Array.from(this.popupWidgets.keys());
+      const widgetList = Array.from(this.popupWidgets.entries());
       for (let i = widgetList.length-1; i >= 0; i--) {
-         const widget = widgetList[i];
-         if (this.widgetInBounds(widget, x, y)) {
-            this.selectedWidget = widget;
+         const [widget, [widgetX, widgetY]] = widgetList[i];
+         if (this.widgetInBounds(widget, widgetX, widgetY, x, y)) {
+            this.selectedWidget = [widget, widgetX, widgetY];
             this.dispatchEvent(ctx, widget, [MenuItemEvents.HOVERING]);
             return;
          }
       }
 
       for (let i = this.boundWidgets.length-1; i >= 0; i--) {
-         const widget = this.boundWidgets[i];
-         if (this.widgetInBounds(widget, x, y)) {
-            this.selectedWidget = widget;
+         const [widget, widgetX, widgetY] = this.boundWidgets[i];
+         if (this.widgetInBounds(widget, widgetX, widgetY, x, y)) {
+            this.selectedWidget = [widget, widgetX, widgetY];
             this.dispatchEvent(ctx, widget, [MenuItemEvents.HOVERING]);
             return;
          }
@@ -999,7 +1084,7 @@ class RootWidgetManager implements WidgetManager {
       this.updateSelected(ctx, x, y);
       if (!this.selectedWidget) {
          if (event == CanvasEventTypes.MOUSE_CLICK) {
-            for (const popup of this.popupWidgets) {
+            for (const [popup, ] of this.popupWidgets) {
                this.dispatchEvent(ctx, popup, [MenuItemEvents.CLICKED_OFF]);
             }
          }
@@ -1008,17 +1093,24 @@ class RootWidgetManager implements WidgetManager {
 
       switch (event) {
          case CanvasEventTypes.MOUSE_MOVE:
-            this.dispatchEvent(ctx, this.selectedWidget, [MenuItemEvents.MOUSE_MOVE, x, y]);
+         {
+            const [nX, nY] = [x - this.selectedWidget[1], y - this.selectedWidget[2]];
+            this.dispatchEvent(ctx, this.selectedWidget[0], [MenuItemEvents.MOUSE_MOVE, nX, nY]);
+         }
          break;
 
          case CanvasEventTypes.MOUSE_CLICK:
+         {
             const selected = this.selectedWidget;
-            for (const popup of this.popupWidgets) {
-               if (selected != popup)
-                  this.dispatchEvent(ctx, popup, [MenuItemEvents.CLICKED_OFF]);
+            if (!this.popupWidgets.has(selected[0])) {
+               for (const popup of this.popupWidgets) {
+                  if (selected[0] != popup[0])
+                     this.dispatchEvent(ctx, popup[0], [MenuItemEvents.CLICKED_OFF]);
+               }
             }
-            this.dispatchEvent(ctx, selected, [MenuItemEvents.CLICKED, x, y]);
-            
+            const [nX, nY] = [x - selected[1], y - selected[2]];
+            this.dispatchEvent(ctx, selected[0], [MenuItemEvents.CLICKED, nX, nY]);
+         }
          break;
       }
 
@@ -1032,43 +1124,63 @@ class RootWidgetManager implements WidgetManager {
    handleCanvasAnimationFrameEvent(ctx: CanvasRenderingContext2D, event: CanvasEventTypes, delta: number) {
       //render in reverse order of the way events are handled
       //that way top most items are drawn last so they appear on top
-      for (const widget of this.popupWidgets)
-         widget.render(ctx);
-      for (const widget of this.boundWidgets)
-         widget.render(ctx);
+      for (const [widget, [x, y]] of this.popupWidgets)
+         widget.render(ctx, x, y);
+      for (const [widget, x, y] of this.boundWidgets)
+         widget.render(ctx, x, y);
    }
 }
 
-interface MenuButtonwidgetConstructor extends ButtonWidgetConstructor {
-   menuOptions: MenuWidgetConstructor
+interface MenuButtonWidgetConstructor extends ButtonWidgetConstructor {
+   menuOptions: MenuWidgetConstructor,
+   openToRight?: boolean,
+   offset?: number,
 }
 class MenuButton implements Widget, WidgetManager {
    readonly parent: WidgetManager;
    readonly id: number;
-   readonly handledEvents: MenuItemEvents[];
+   readonly handledEvents: MenuItemEvents[] = [
+      MenuItemEvents.CLICKED,
+      MenuItemEvents.HOVERING,
+      MenuItemEvents.UNHOVERED,
+      MenuItemEvents.CLICKED_OFF
+   ];
 
    readonly button: Button;
    readonly menu: Menu;
-   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuButtonwidgetConstructor) {
+
+   private openToRight: boolean;
+   private offset: number;
+
+   private menuOpened: boolean = false;
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuButtonWidgetConstructor) {
       this.parent = parent;
       this.id = id;
+
+      this.openToRight = props.openToRight ?? false;
+      this.offset = props.offset ?? 0;
 
       this.button = new Button(ctx, this, 0, props);
 
       const menuOptions = structuredClone(props.menuOptions);
-      const [, , width, _] = this.button.getDimensions();
+      const [width, ] = this.button.getDimensions();
 
       menuOptions.minimumWidth = menuOptions.minimumWidth ?? width; 
       this.menu = new Menu(ctx, this, 1, menuOptions);
 
       this.button.addEvent((() => {
-         this.parent.openPopup(ctx, this.menu);
+         const [width,height] = this.button.getDimensions();
+         let x = this.openToRight ? width + this.offset : 0;
+         let y = this.openToRight ? 0 : height + this.offset;
+         console.log(`spawning menu at: (${x}, ${y})`)
+         this.parent.openPopup(ctx, this.menu, x, y, this);
+         this.menuOpened = true;
       }).bind(this));
       this.menu.bindClickedOffEvent((() => {
          this.parent.closePopup(ctx, this.menu);
+         this.menuOpened = false;
       }).bind(this));
 
-      this.handledEvents = this.button.handledEvents;
    }
    private supressHandleDelete: boolean = false;
    handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
@@ -1100,13 +1212,20 @@ class MenuButton implements Widget, WidgetManager {
       this.button.render(ctx, offsetX, offsetY);
    }
    handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
-      this.button.handleMenuEvent(ctx, event);
+      if (event[0] == MenuItemEvents.CLICKED_OFF) {
+         if (this.menuOpened) {
+            this.menu.handleMenuEvent(ctx, [MenuItemEvents.CLICKED_OFF]);
+            this.parent.closePopup(ctx, this.menu);
+         }
+      } else {
+         this.button.handleMenuEvent(ctx, event);
+      }
    }
-   getDimensions(): [number, number, number, number] {
+   getDimensions(): [number, number] {
       return this.button.getDimensions();
    }
-   setDimensions(ctx: CanvasRenderingContext2D, x?: number, y?: number, width?: number, height?: number) {
-      this.button.setDimensions(ctx, x, y, width, height);
+   setDimensions(ctx: CanvasRenderingContext2D, width?: number, height?: number) {
+      this.button.setDimensions(ctx, width, height);
    }
 
    childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) {
@@ -1119,8 +1238,8 @@ class MenuButton implements Widget, WidgetManager {
    >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
       return this.menu.addChild(ctx, id, cons, props);
    }
-   openPopup(ctx: CanvasRenderingContext2D, widget: Widget) {
-      this.parent.openPopup(ctx, widget);
+   openPopup(ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) {
+      this.parent.openPopup(ctx, widget, x, y, relativeChild);
    }
    closePopup(ctx: CanvasRenderingContext2D, widget: Widget) {
       this.parent.closePopup(ctx, widget);
@@ -1141,8 +1260,6 @@ class Seperator implements Widget {
    private seperatorFont: string;
    private seperatorColor: string;
 
-   private x: number;
-   private y: number;
    private width: number;
    private height: number;
    private minHeight: number = 0;
@@ -1158,8 +1275,6 @@ class Seperator implements Widget {
       this.seperatorColor = props.seperatorColor ?? "black";
       this.seperatorFont = props.seperatorFont ?? "16px Seriph";
 
-      this.x = props.x;
-      this.y = props.y;
       this.width = props.width ?? 0;
       this.height = props.height ?? 0;
       
@@ -1202,8 +1317,8 @@ class Seperator implements Widget {
       // console.log(this.x, offsetX, this.textXOffset, this.x + offsetX + this.textXOffset);
       ctx.fillText(
          this.text,
-         this.x + offsetX + this.textXOffset,
-         this.y + offsetY + this.textYOffset
+         offsetX + this.textXOffset,
+         offsetY + this.textYOffset
       );
 
       ctx.restore();
@@ -1211,12 +1326,10 @@ class Seperator implements Widget {
    handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
       throw new Error(`Seperator widget doesn't accept events!!`);
    }
-   getDimensions(): [number, number, number, number] {
-      return [this.x, this.y, this.width, this.height];
+   getDimensions(): [number, number] {
+      return [this.width, this.height];
    }
-   setDimensions(ctx: CanvasRenderingContext2D, x?: number, y?: number, width?: number, height?: number) {
-      this.x = x ?? this.x;
-      this.y = y ?? this.y;
+   setDimensions(ctx: CanvasRenderingContext2D, width?: number, height?: number) {
       this.width = width ?? this.width;
       this.height = height ?? this.height;
       if (width != undefined || height != undefined) {
@@ -1322,14 +1435,12 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       // };
       // this.manager.addChild(this.ctx, -10, Button, buttonOpts);
       const menuBarCons: MenuBarWidgetConstructor = {
-         x: 0,
-         y: 0,
          minChildWidth: 10,
          menuColor: "#B0B0B0",
-         height: TOP_BAR_SIZE,
+         height: TOP_BAR_SIZE - 0.5,
          xPadding: MENU_PADDING_X,
       };
-      this.menu = this.manager.addChild(this.ctx, 0, MenuBar, menuBarCons);
+      this.menu = this.manager.addChild(this.ctx, 0, MenuBar, menuBarCons, BORDER_SIZE + MENU_PADDING_X, 0);
    }
 
    getProp(propName: string) {
@@ -1418,26 +1529,43 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       const id = ++this.nextMenuID;
 
       const menuOptions: MenuWidgetConstructor = {
-         x: 0,
-         y: TOP_BAR_SIZE,
          menuColor: "#B0B0B0",
          minimumHeight: TOP_BAR_SIZE/2.0,
          yPadding: 2,
+         borderWidth: 1.0,
+         borderColor: "black"
       };
 
       const button: MenuButton = this.menu.addChild(this.ctx, id, MenuButton, {
-         // x: maxX,
-         x: 0, 
-         y: 0,
          height: TOP_BAR_SIZE - 0.5,
          text: text,
          textColor: "black",
          buttonColor: "#B0B0B0",
          selectedButtonColor: "#D0D0D0",
-         menuOptions: menuOptions
+         menuOptions: menuOptions,
+         offset: 0.5,
       });
 
       this.menus.set(id, button);
+
+      const subMenuOpts: MenuButtonWidgetConstructor = {
+         menuOptions: menuOptions,
+         height: TOP_BAR_SIZE - 0.5,
+         text: "hello there",
+         textColor: "black",
+         buttonColor: "#B0B0B0",
+         selectedButtonColor: "#D0D0D0",
+         openToRight: true,
+      };
+      const subMenu: MenuButton = button.addChild(this.ctx, 0, MenuButton, subMenuOpts);
+      subMenu.addChild(this.ctx, 0, Button, {
+         height: TOP_BAR_SIZE - 0.5,
+         text: text,
+         textColor: "black",
+         buttonColor: "#B0B0B0",
+         selectedButtonColor: "#D0D0D0",
+      });
+      subMenu.addChild(this.ctx, 0, MenuButton, subMenuOpts);
 
       return id;
    }
@@ -1502,8 +1630,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             //    const char* selected_button_color;
             // };
             let button: ButtonWidgetConstructor = {
-               x: x,
-               y: y,
                width: width,
                height: height,
                text: getStringOrDef(extraPtr + 0, "Lorem Ipsum"),
@@ -1530,8 +1656,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             //    const char* seperator_color;
             // };
             let seperator: SeperatorWidgetConstructor = {
-               x: x,
-               y: y,
                width: width,
                height: height,
                seperatorText: getStringOrDef(extraPtr + 0, "-"),
@@ -1574,8 +1698,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             //    const char* optionTextColor;
             // };
             const cons: RadioMenuWidgetConstructor = {
-               x: x,
-               y: y,
                width: width,
                height: height,
                minimumWidth: getLongOrDef(extraPtr + 0, 0),            

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -42,21 +42,23 @@ interface MenuItem {
 
 interface WidgetManager {
    childUpdated: (widget: Widget, ctx: CanvasRenderingContext2D) => void;
+   //really, really long type. Basically accepts any class constructor that created a Widget
+   // and accepts a CanvasRenderingContext2D, an id, a parent WidgetManager, and a set of properties of any type
+   // the idea is that you give the manager a widget and it constructs it internally.
+   addChild: <T extends Widget, U, O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U) => T>(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U) => T;
 }
 interface Widget {
    readonly parent: WidgetManager; 
    readonly id: number;
+   readonly handledEvents: MenuItemEvents[];
    getMinSize: (ctx: CanvasRenderingContext2D) => [number, number];
    render: (ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) => void;
-   getRequiredMenuEvents: () => MenuItemEvents[];
    handleMenuEvent: (event: MenuItemEventData) => void;
    getDimensions: () => [number, number, number, number];
-   setDimensions: (ctx: CanvasRenderingContext2D, x?: number, y?: number, height?: number, width?: number) => void;
+   setDimensions: (ctx: CanvasRenderingContext2D, x?: number, y?: number, width?: number, height?: number) => void;
 }
 
 interface WidgetConstructor {
-   parent: WidgetManager;
-   id: number;
    x: number;
    y: number;
    width?: number;
@@ -73,6 +75,12 @@ interface ButtonWidgetConstructor extends WidgetConstructor {
 class NewButton implements Widget, WidgetEvents {
    readonly parent: WidgetManager; 
    readonly id: number;
+   readonly handledEvents: MenuItemEvents[] = [
+      MenuItemEvents.CLICKED,
+      MenuItemEvents.HOVERING,
+      MenuItemEvents.UNHOVERED
+   ];
+
    private x: number;
    private y: number;
    private width: number;
@@ -89,9 +97,9 @@ class NewButton implements Widget, WidgetEvents {
    private selected: boolean = false;
    private events: Set<(() => void)> = new Set();
 
-   constructor(ctx: CanvasRenderingContext2D, cons: ButtonWidgetConstructor) {
-      this.parent = cons.parent;
-      this.id = cons.id;
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, cons: ButtonWidgetConstructor) {
+      this.parent = parent;
+      this.id = id;
       this.x = cons.x;
       this.y = cons.y;
 
@@ -112,7 +120,7 @@ class NewButton implements Widget, WidgetEvents {
    getDimensions(): [number, number, number, number] {
       return [this.x, this.y, this.width, this.height];
    }
-   setDimensions(ctx: CanvasRenderingContext2D, x?: number, y?: number, height?: number, width?: number) {
+   setDimensions(ctx: CanvasRenderingContext2D, x?: number, y?: number, width?: number, height?: number) {
       this.x = x ?? this.x;
       this.y = y ?? this.y;
       this.height = height ?? this.height;
@@ -162,13 +170,6 @@ class NewButton implements Widget, WidgetEvents {
 
       ctx.restore();
    }
-   getRequiredMenuEvents(): MenuItemEvents[] {
-      return [
-         MenuItemEvents.CLICKED,
-         MenuItemEvents.HOVERING,
-         MenuItemEvents.UNHOVERED
-      ];
-   }
    handleMenuEvent(event: MenuItemEventData) {
       switch (event[0]) {
          case MenuItemEvents.CLICKED:
@@ -204,7 +205,172 @@ class NewButton implements Widget, WidgetEvents {
    }
 }
 
+interface MenuWidgetConstructor extends WidgetConstructor {
+   minimumWidth?: number;
+   minimumHeight?: number;
+   menuColor?: string;
+}
+
+class NewMenu implements Widget, WidgetEvents, WidgetManager {
+   readonly parent: WidgetManager;
+   readonly id: number;
+
+   readonly handledEvents: MenuItemEvents[] = Object.values(MenuItemEvents)
+      .filter(item => typeof item == "number");
+
+   private absoluteMinWidth: number;
+   private absoluteMinHeight: number;
+   
+   private x: number;
+   private y: number;
+   private width?: number;
+   private height?: number;
+
+   private childWidth: number;
+   private childHeight: number;
+
+   private menuColor: string;
+
+   private children: Widget[] = [];
+   private childEvents: Map<MenuItemEvents, Widget[]> = new Map();
+   
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuWidgetConstructor) {
+      this.parent = parent;
+      this.id = id;
+      
+      this.x = props.x;
+      this.y = props.y;
+
+      this.absoluteMinWidth = props.minimumWidth ?? 5;
+      this.absoluteMinHeight = props.minimumHeight ?? 5;
+      this.childWidth = this.absoluteMinWidth;
+      this.childHeight = this.absoluteMinHeight;
+
+      this.width = props.width;
+      this.height = props.height;
+
+      this.menuColor = props.menuColor ?? "gray";
+   }
+
+   lastWidth: number = 0;
+   lastHeight: number = 0;
+   supressChildUpdates: boolean = false;
+   updateChildSize(ctx: CanvasRenderingContext2D, forceRun: boolean = false) {
+      let childWidth = 0;
+      let childHeight = 0;
+      for (const widget of this.children) {
+         const [width, height] = widget.getMinSize(ctx);
+         childWidth = Math.max(childWidth, width);
+         childHeight += height;
+      }
+
+      const newWidth = this.width ?? Math.min(childWidth, this.absoluteMinWidth);
+      const newHeight = this.height ?? Math.min(childHeight, this.absoluteMinHeight);
+      this.childHeight = childHeight;
+      this.childWidth = childWidth;
+
+      if (this.lastWidth != newWidth || this.lastHeight != newHeight || forceRun) {
+         this.lastWidth = newWidth;
+         this.lastHeight = newHeight;
+         
+         let curHeight = 0;
+         for (const widget of this.children) {
+            const [, height] = widget.getMinSize(ctx);
+
+            this.supressChildUpdates = true;
+            widget.setDimensions(ctx, 0, curHeight, newWidth, height);
+            this.supressChildUpdates = false;
+         }
+
+      }
+   }
+
+   childUpdated(widget: Widget, ctx: CanvasRenderingContext2D) {
+      if (!this.supressChildUpdates)
+         this.updateChildSize(ctx);
+   }
+   addChild<
+      T extends Widget, 
+      U, 
+      O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U) => T
+   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
+      const widget: T = new cons(ctx, this, id, props);
+
+      this.children.push(widget);
+      this.updateChildSize(ctx, true);
+      for (const event of widget.handledEvents) {
+         const handlers = this.childEvents.get(event) ?? (() => {
+            const tmp: Widget[] = [];
+            this.childEvents.set(event, tmp);
+            return tmp;
+         })();
+
+         handlers.push(widget);
+      }
+
+      return widget;
+   }
+
+   getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
+      return [
+         this.childWidth, 
+         this.childHeight
+      ];
+   }
+
+   render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0): void {
+		ctx.save();
+
+      ctx.fillStyle = this.menuColor;
+      ctx.fillRect(
+         this.x + offsetX,
+         this.y + offsetY,
+         this.width ?? this.childWidth,
+         this.height ?? this.childHeight,
+      );
+
+      for (const widget of this.children) {
+         widget.render(ctx, this.x + offsetX, this.y + offsetY);
+      }
+
+      ctx.restore();
+	}
+   
+   handleMenuEvent(event: MenuItemEventData): void {
+		
+	}
+
+   getDimensions(): [number, number, number, number] {
+      return [
+         this.x,
+         this.y,
+         this.width ?? this.childWidth,
+         this.height ?? this.childHeight
+      ];
+	}
+
+   setDimensions(ctx: CanvasRenderingContext2D, x?: number, y?: number, width?: number, height?: number): void {
+      
+	}
+
+   addEvent(callback: () => void) {
+      
+   }
+
+   removeEvent(callback: () => void) {
+
+   }
+
+}
+
 class TmpManager implements WidgetManager {
+   addChild<
+      T extends Widget, 
+      U, 
+      O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U) => T
+   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
+      return new cons(ctx, this as WidgetManager, id, props);
+   }
    childUpdated(widget: Widget, ctx: CanvasRenderingContext2D) {
 
    }
@@ -215,190 +381,12 @@ interface WidgetEvents {
    addEvent: (callback: () => void) => void;
    removeEvent: (callback: () => void) => void;
 }
-// const BUTTON_FONT = "16px Serif";
-// const BUTTON_PADDING_Y = 2.5;
-// const BUTTON_PADDING_X = 5;
-// const BUTTON_HEIGHT = 5;
-// class Button implements MenuItem, WidgetEvents {
-//    id: number;
 
-//    text: string;
-//    font: string;
-//    text_color: string;
-//    background_color: string;
-//    selected_color: string;
-//    minWidth: number;
-//    minHeight: number;
-//    events: (() => void)[] = [];
-
-//    constructor(
-//       id: number,
-//       ctx: CanvasRenderingContext2D, 
-//       text: string, 
-//       font: string = "16px Serif", 
-//       text_color: string = "white", 
-//       background_color: string = "light_gray", 
-//       selected_color: string = "blue"
-//    ) {
-//       this.id = id;
-//       this.text = text;
-//       this.font = font;
-//       this.text_color = text_color;
-//       this.background_color = background_color;
-//       this.selected_color = selected_color;
-
-//       ctx.save();
-      
-//       ctx.font = this.font;
-//       const measure = ctx.measureText(text);
-//       this.minWidth = measure.width;
-//       this.minHeight = measure.actualBoundingBoxAscent;
-
-//       ctx.restore();
-//    }
-//    getRequiredMenuEvents() {
-//       return [
-//          MenuItemEvents.CLICKED,
-//          MenuItemEvents.HOVERING,
-//          MenuItemEvents.UNHOVERED,
-//       ];
-//    }
-
-//    selected: boolean = false;
-//    handleMenuEvent(event: MenuItemEventData) {
-//       switch (event[0]) {
-//          case MenuItemEvents.CLICKED:
-//          {
-//             for (const handler of this.events) {
-//                handler();
-//             }
-//          }
-//          break;
-
-//          case MenuItemEvents.HOVERING:
-//          {
-//             this.selected = true;
-//          }
-//          break;
-
-//          case MenuItemEvents.UNHOVERED:
-//          {
-//             this.selected = false;
-//          }
-//          break;
-         
-//          default:
-//          {
-//             throw new Error(`Button handleMenuEvent was given an unexpected event (${event})!`);
-//          }
-//          break;
-//       } 
-//    };
-//    addEvent(callback: () => void) {
-//       this.events.push(callback);
-//    }
-//    removeEvent(callback: () => void) {
-//       const index = this.events.findIndex(callback);
-//       if (index == -1) throw new Error(`Error: Button removeEvent was given a callback that wasn't registered!`);
-//       this.events.splice(index, 1);
-//    }
-
-//    getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
-//       return [this.minWidth, this.minHeight];
-//    };
-
-//    render(ctx: CanvasRenderingContext2D, x: number, y: number, width: number, height: number) {
-//       ctx.save();
-//       ctx.font = this.font;
-      
-//       ctx.fillStyle = this.selected ? this.selected_color : this.background_color ;
-//       ctx.fillRect(x, y, width, height);
-
-//       ctx.fillStyle = this.text_color;
-//       ctx.fillText(this.text, x + (width - this.minWidth)/2, y + (height + this.minHeight)/2);
-
-//       ctx.restore();
-//    }
-   
-// }
-
-
-const MENU_TEXT_FONT = "20px Serif";
 const MENU_PADDING_X = 5;
 const MENU_PADDING_Y = 4;
 const TOP_BAR_SIZE: number = 30;
 const BORDER_SIZE: number = 5;
 const MENU_START_X = BORDER_SIZE;
-class Menu {
-   items: MenuItem[] = [];
-   events: Map<MenuItemEvents, Set<MenuItem>> = new Map();
-   
-   constructor() {
-
-   }
-
-   render(ctx: CanvasRenderingContext2D, x: number, y: number, minWidth: number, minHeight: number) {
-      ctx.save();
-
-      const [maxWidth, maxHeight] = this.getMaxItemSize(ctx, minWidth, minHeight);
-      const [width, height] = this.maxItemSizeToTotalSize(maxWidth, maxHeight);
-
-      ctx.fillStyle = "light_gray";
-      ctx.fillRect(x, y, width, height);
-
-      let currentHeight = 0;
-      for (const item of this.items) {
-         item.render(ctx, x+MENU_PADDING_X, currentHeight, maxWidth, maxHeight);
-         currentHeight += maxHeight + MENU_PADDING_Y;
-      }
-
-      ctx.restore();
-   }
-
-   addItem(menuItem: MenuItem) {
-      if (this.items.indexOf(menuItem) != -1)
-         throw new Error(`Menu addItem was given a MenuItem that's already on the menu!`);
-      this.items.push(menuItem);
-      for (const event of menuItem.getRequiredMenuEvents()) {
-         let eventSet = this.events.get(event) ?? (() => {
-            const set: Set<MenuItem> = new Set();
-            this.events.set(event, set);
-            return set;
-         })();
-
-         eventSet.add(menuItem);
-      }
-   }
-
-   getMaxItemSize(ctx: CanvasRenderingContext2D, minWidth: number, minHeight: number): [number, number] {
-      let maxWidth = minWidth;
-      let maxHeight = minHeight;
-      for (const item of this.items) {
-         const [width, height] = item.getMinSize(ctx);
-         if (width > maxWidth)
-            maxWidth = width;
-         if (height > maxHeight)
-            maxHeight = height;
-      }
-      return [maxWidth, maxHeight];
-   } 
-   maxItemSizeToTotalSize(maxWidth: number, maxHeight: number) {
-      const width = maxWidth + MENU_PADDING_X*2;
-      const height = (maxHeight + MENU_PADDING_Y)*Math.max(this.items.length, 1) - MENU_PADDING_Y;
-
-      return [width, height];
-   }
-
-   getSize(ctx: CanvasRenderingContext2D, minWidth: number, minHeight: number) {
-      const [maxWidth, maxHeight] = this.getMaxItemSize(ctx, minWidth, minHeight);
-      return this.maxItemSizeToTotalSize(maxWidth, maxHeight);
-   }
-
-   
-
-   
-
-}
 
 export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, IConsoleWindow {
    id: number;
@@ -414,10 +402,10 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    menuItems: Map<number, MenuItem> = new Map();
    nextMenuItem: number = 0;
 
-   menus: Map<number, [NewButton, Menu]> = new Map();
+   menus: Map<number, [NewButton, NewMenu]> = new Map();
    nextMenuID: number = 0;
 
-   openMenu: [Menu, number, number, number]|undefined = undefined;
+   openMenu: NewMenu|undefined = undefined;
 
    
 
@@ -490,15 +478,12 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       const n_x = x - BORDER_SIZE;
       const n_y = y - TOP_BAR_SIZE;
       let topBar = false;
-      let [menWidth, menHeight] = [0, 0];
-      if (this.openMenu) {
-         [menWidth, menHeight] = this.openMenu[0].getSize(this.ctx, this.openMenu[3], TOP_BAR_SIZE);
-      }
+      let [menX, menY, menWidth, menHeight] = this.openMenu?.getDimensions() ?? [0, 0, 0, 0];
 
       if (
          this.openMenu
-         && x >= this.openMenu[1] && x <= this.openMenu[1]+menWidth
-         && y >= this.openMenu[2] && y <= this.openMenu[2]+menHeight
+         && x >= menX && x <= menX+menWidth
+         && y >= menY && y <= menY+menHeight
       ) {
          console.log("on the menu!!!");
       } else if (
@@ -511,25 +496,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          topBar = true;
          this.mouseWasOnTopBar = true;
          let widthOffset = MENU_START_X;
-         // for (const menu of this.menus.values()) {
-         //    // menu.hovering = x >= widthOffset
-         //    //    && x < widthOffset+menu.width;
-         //    const width = menu[0].getMinSize(this.ctx)[0] + MENU_PADDING_X*2;
-            
-         //    if (
-         //       x >= widthOffset
-         //       && x < widthOffset+width
-         //    ) {
-         //       if (event == CanvasEventTypes.MOUSE_MOVE)
-         //          menu[0].handleMenuEvent([MenuItemEvents.HOVERING]);
-         //       else if (event == CanvasEventTypes.MOUSE_CLICK)
-         //          menu[0].handleMenuEvent([MenuItemEvents.CLICKED]);
-         //    } else if (event == CanvasEventTypes.MOUSE_MOVE) {
-         //       menu[0].handleMenuEvent([MenuItemEvents.UNHOVERED]);
-         //    }
 
-         //    widthOffset += width;
-         // }
          for (const [button, ] of this.menus.values()) {
             const [bX, bY, bWidth, bHeight] = button.getDimensions();
             const xInBounds = bX <= x && x <= bX + bWidth;
@@ -598,21 +565,11 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       this.ctx.stroke();
       this.ctx.closePath();
 
-      // let widthOffset = MENU_START_X;
-      // for (const menu of this.menus.values()) {
-      //    const width = menu[0].getMinSize(this.ctx)[0] + MENU_PADDING_X*2;
-
-      //    menu[0].render(this.ctx, widthOffset, 0, width, TOP_BAR_SIZE - this.ctx.lineWidth/2.0);
-
-      //    widthOffset += width;
-      // }
       for (const [button, ] of this.menus.values()) {
          button.render(this.ctx, 0, 0);
       }
 
-      if (this.openMenu) {
-         this.openMenu[0].render(this.ctx, this.openMenu[1], this.openMenu[2], this.openMenu[3], TOP_BAR_SIZE);
-      }
+      this.openMenu?.render(this.ctx);
 
    }
 
@@ -625,10 +582,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
 
       const id = ++this.nextMenuID;
 
-      // const button = new Button(id, this.ctx, text, undefined, "black", "#B0B0B0", "#D0D0D0");
-      // const menu = new Menu();
-      // this.menus.set(id, [button, menu]);
-
       let maxX = MENU_START_X;
       for (const [button, ] of this.menus.values()) {
          const [x, , width, ] = button.getDimensions();
@@ -637,35 +590,32 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          maxX = Math.max(maxX, rX);
       }
 
-      const button = new NewButton(this.ctx, {
-         id: id,
+      const button: NewButton = tmpManager.addChild(this.ctx, id, NewButton, {
          x: maxX,
          y: 0,
          height: TOP_BAR_SIZE - 0.5,
-         parent: tmpManager,
          text: text,
          textColor: "black",
          buttonColor: "#B0B0B0",
          selectedButtonColor: "#D0D0D0"
       });
-      const [, , width, ] = button.getDimensions();
-      button.setDimensions(this.ctx, undefined, undefined, undefined, width + MENU_PADDING_X);
 
-      const menu = new Menu();
+      const [, , width, ] = button.getDimensions();
+      button.setDimensions(this.ctx, undefined, undefined, width + MENU_PADDING_X, undefined);
+
+      const menuID = ++this.nextMenuID;
+      const menuOptions: MenuWidgetConstructor = {
+         x: maxX,
+         y: TOP_BAR_SIZE,
+         menuColor: "#B0B0B0",
+         minimumWidth: width + MENU_PADDING_X,
+         minimumHeight: TOP_BAR_SIZE/2.0,
+      };
+      const menu: NewMenu = tmpManager.addChild(this.ctx, menuID, NewMenu, menuOptions);
       this.menus.set(id, [button, menu]);
-      // button.addEvent((() => {
-      //    let widthOffset = MENU_START_X;
-      //    for (const menu2 of this.menus.values()) {
-      //       if (menu2[0].id == id)
-      //          break;
-      //       widthOffset += menu2[0].getMinSize(this.ctx)[0] + MENU_PADDING_X*2;
-      //    }
-      //    this.openMenu = [menu, widthOffset, TOP_BAR_SIZE, button.getMinSize(this.ctx)[0]];
-      // }).bind(this));
 
       button.addEvent((() => {
-         const [x, y, width, height] = button.getDimensions();
-         this.openMenu = [menu, x, y+height+0.5, width];
+         this.openMenu = menu;
       }).bind(this));
       return id;
    }

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -60,14 +60,12 @@ interface Widget {
    getMinSize: (ctx: CanvasRenderingContext2D) => [number, number];
    render: (ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) => void;
    handleMenuEvent: (ctx: CanvasRenderingContext2D, event: MenuItemEventData) => void;
-   getDimensions: () => [number, number, number, number];
-   setDimensions: (ctx: CanvasRenderingContext2D, x?: number, y?: number, width?: number, height?: number) => void;
+   getDimensions: () => [number, number];
+   setDimensions: (ctx: CanvasRenderingContext2D, width?: number, height?: number) => void;
    delete: (ctx: CanvasRenderingContext2D) => Widget[];
 }
 
 interface WidgetConstructor {
-   x: number;
-   y: number;
    width?: number;
    height?: number;
 }
@@ -107,8 +105,6 @@ class Button implements Widget, WidgetEvents {
       MenuItemEvents.UNHOVERED
    ];
 
-   private x: number;
-   private y: number;
    private width: number;
    private height: number;
 
@@ -126,8 +122,6 @@ class Button implements Widget, WidgetEvents {
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, cons: ButtonWidgetConstructor) {
       this.parent = parent;
       this.id = id;
-      this.x = cons.x;
-      this.y = cons.y;
 
       this.text = cons.text;
       this.textFont = cons.textFont ?? "16px Serif";
@@ -147,12 +141,10 @@ class Button implements Widget, WidgetEvents {
       return [this];
    }
 
-   getDimensions(): [number, number, number, number] {
-      return [this.x, this.y, this.width, this.height];
+   getDimensions(): [number, number] {
+      return [this.width, this.height];
    }
    setDimensions(ctx: CanvasRenderingContext2D, x?: number, y?: number, width?: number, height?: number) {
-      this.x = x ?? this.x;
-      this.y = y ?? this.y;
       this.height = height ?? this.height;
       this.width = width ?? this.width;
 
@@ -193,14 +185,14 @@ class Button implements Widget, WidgetEvents {
 
       const button_color = this.selected ? this.selectedButtonColor : this.buttonColor ;
       ctx.fillStyle = button_color;
-      ctx.fillRect(this.x + offsetX, this.y + offsetY, this.width, this.height);
+      ctx.fillRect(offsetX, offsetY, this.width, this.height);
 
       ctx.font = this.textFont;
       ctx.fillStyle = this.textColor;
       ctx.fillText(
          this.text,
-         this.x + this.textOffsets[0] + offsetX,
-         this.y + this.textOffsets[1] + offsetY
+         this.textOffsets[0] + offsetX,
+         this.textOffsets[1] + offsetY
       );
 
       ctx.restore();
@@ -263,8 +255,6 @@ class Menu implements Widget, WidgetManager {
    private absoluteMinHeight: number;
    private minChildHeight: number;
    
-   private x: number;
-   private y: number;
    private width?: number;
    private height?: number;
    private yPadding: number;
@@ -274,7 +264,7 @@ class Menu implements Widget, WidgetManager {
 
    private menuColor: string;
 
-   private children: Widget[] = [];
+   private children: [Widget, number][] = [];
 
    private unhoverHandlers: (() => void)[] = [];
    private clickedOffHandlers: (() => void)[] = [];
@@ -282,14 +272,11 @@ class Menu implements Widget, WidgetManager {
 
    //the currently hovered over/selected item 
    //resets to undefined on menu update or UNHOVERED event
-   private selectedItem?: Widget;
+   private selectedItem?: [Widget, number];
    
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuWidgetConstructor) {
       this.parent = parent;
       this.id = id;
-      
-      this.x = props.x;
-      this.y = props.y;
 
       this.absoluteMinWidth = props.minimumWidth ?? 5;
       this.absoluteMinHeight = props.minimumHeight ?? 5;
@@ -344,11 +331,11 @@ class Menu implements Widget, WidgetManager {
       let childWidth = 0;
       // let maxChildHeight = this.minChildHeight;
       let childHeight = 0;
-      for (const widget of this.children) {
+      for (const [widget,] of this.children) {
          const [width, ] = widget.getMinSize(ctx);
          childWidth = Math.max(childWidth, width);
          // maxChildHeight = Math.max(maxChildHeight, height+this.yPadding);
-         const [, , , height] = widget.getDimensions();
+         const [, height] = widget.getDimensions();
          childHeight += height + this.yPadding;
       }
 
@@ -371,9 +358,10 @@ class Menu implements Widget, WidgetManager {
          
          let curHeight = 0;
          for (const widget of this.children) {
-            const [, , , height] = widget.getDimensions();
+            const [, height] = widget[0].getDimensions();
             this.supressChildUpdates = true;
-            widget.setDimensions(ctx, 0, curHeight, newWidth, undefined);
+            widget[0].setDimensions(ctx, newWidth, undefined);
+            widget[1] = curHeight;
             this.supressChildUpdates = false;
             // curHeight += maxChildHeight;
             curHeight += height + this.yPadding;
@@ -398,7 +386,7 @@ class Menu implements Widget, WidgetManager {
    >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
       const widget: T = new cons(ctx, this, id, props);
 
-      this.children.push(widget);
+      this.children.push([widget, 0]);
       this.updateChildSize(ctx, true);
       this.parent.childUpdated(ctx, this);
 
@@ -417,14 +405,14 @@ class Menu implements Widget, WidgetManager {
 
       ctx.fillStyle = this.menuColor;
       ctx.fillRect(
-         this.x + offsetX,
-         this.y + offsetY,
+         offsetX,
+         offsetY,
          this.width ?? this.childWidth,
          this.height ?? this.childHeight,
       );
 
       for (const widget of this.children) {
-         widget.render(ctx, this.x + offsetX, this.y + offsetY);
+         widget[0].render(ctx, offsetX, offsetY + widget[1]);
       }
 
       ctx.restore();
@@ -436,10 +424,10 @@ class Menu implements Widget, WidgetManager {
       }
    }
 
-   private mouseInWidgetBounds(widget: Widget, x: number, y: number) {
-      const [wX, wY, wW, wH] = widget.getDimensions();
-      return wX <= x && x <= wX + wW
-            && wY <= y && y <= wY + wH;
+   private mouseInWidgetBounds(widget: Widget, widgetY: number, x: number, y: number) {
+      const [widgetWidth, widgetHeight] = widget.getDimensions();
+      return 0 <= x && x <= widgetWidth
+            && widgetY <= y && y <= widgetY + widgetHeight;
    }
 
    //updates the currently selected object using the given coords
@@ -447,20 +435,20 @@ class Menu implements Widget, WidgetManager {
    private updateSelectedObject(ctx: CanvasRenderingContext2D,x: number, y: number) {
       //check if hovering over selected item
       if (this.selectedItem) {
-         if (this.mouseInWidgetBounds(this.selectedItem, x, y)) {
+         if (this.mouseInWidgetBounds(this.selectedItem[0], this.selectedItem[1], x, y)) {
             return; //the selected item is in bounds
          } else {
             //selected item is out of bounds
-            this.dispatchEvent(ctx, this.selectedItem, [MenuItemEvents.UNHOVERED]);
+            this.dispatchEvent(ctx, this.selectedItem[0], [MenuItemEvents.UNHOVERED]);
             this.selectedItem = undefined;
          }
       }
       //otherwise, find what object (if any) are hovered over
       for (const child of this.children) {
          //found child it's hovering over
-         if (this.mouseInWidgetBounds(child, x, y)) {
+         if (this.mouseInWidgetBounds(child[0], child[1], x, y)) {
             this.selectedItem = child;
-            this.dispatchEvent(ctx, child, [MenuItemEvents.HOVERING]);
+            this.dispatchEvent(ctx, child[0], [MenuItemEvents.HOVERING]);
             //break early
             return;
          }
@@ -471,25 +459,27 @@ class Menu implements Widget, WidgetManager {
          case MenuItemEvents.MOUSE_MOVE:
          {
             const [, eX, eY] = event;
-            const [x, y] = [eX - this.x, eY - this.y];
-            this.updateSelectedObject(ctx, x, y);
-            if (this.selectedItem)
-               this.dispatchEvent(ctx, this.selectedItem, [MenuItemEvents.MOUSE_MOVE, x, y]);
+            this.updateSelectedObject(ctx, eX, eY);
+            if (this.selectedItem) {
+               const [x, y] = [eX, eY - this.selectedItem[1]];
+               this.dispatchEvent(ctx, this.selectedItem[0], [MenuItemEvents.MOUSE_MOVE, x, y]);
+            }
          }
          break;
          case MenuItemEvents.CLICKED:
          {
             const [, eX, eY] = event;
-            const [x, y] = [eX - this.x, eY - this.y];
-            this.updateSelectedObject(ctx, x, y);
-            if (this.selectedItem)
-               this.dispatchEvent(ctx, this.selectedItem, [MenuItemEvents.CLICKED, x, y]);
+            this.updateSelectedObject(ctx, eX, eY);
+            if (this.selectedItem) {
+               const [x, y] = [eX, eY - this.selectedItem[1]];
+               this.dispatchEvent(ctx, this.selectedItem[0], [MenuItemEvents.CLICKED, x, y]);
+            }
          }
          break;
          case MenuItemEvents.UNHOVERED:
          {
             if (this.selectedItem) {
-               this.dispatchEvent(ctx, this.selectedItem, [MenuItemEvents.UNHOVERED]);
+               this.dispatchEvent(ctx, this.selectedItem[0], [MenuItemEvents.UNHOVERED]);
                this.selectedItem = undefined;
             }
             for (const handler of this.unhoverHandlers) {
@@ -507,18 +497,14 @@ class Menu implements Widget, WidgetManager {
       }
 	}
 
-   getDimensions(): [number, number, number, number] {
+   getDimensions(): [number, number] {
       return [
-         this.x,
-         this.y,
          this.width ?? this.childWidth,
          this.height ?? this.childHeight
       ];
 	}
 
-   setDimensions(ctx: CanvasRenderingContext2D, x?: number, y?: number, width?: number, height?: number): void {
-      this.x = x ?? this.x;
-      this.y = y ?? this.y;
+   setDimensions(ctx: CanvasRenderingContext2D, width?: number, height?: number): void {
       if (width != undefined){
          if (width == 0)
             this.width = undefined;
@@ -654,11 +640,11 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
    handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
       this.menu.handleMenuEvent(ctx, event);
    }
-   getDimensions(): [number, number, number, number] {
+   getDimensions(): [number, number] {
       return this.menu.getDimensions();
    }
-   setDimensions(ctx: CanvasRenderingContext2D, x?: number, y?: number, width?: number, height?: number) {
-      return this.menu.setDimensions(ctx, x, y, width, height);
+   setDimensions(ctx: CanvasRenderingContext2D, width?: number, height?: number) {
+      return this.menu.setDimensions(ctx, width, height);
    }
 
    childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) {
@@ -712,8 +698,6 @@ class MenuBar implements Widget, WidgetManager {
       MenuItemEvents.MOUSE_MOVE
    ];
 
-   private x: number;
-   private y: number;
    private width?: number;
    private height?: number;
    private minimumWidth: number;
@@ -725,7 +709,7 @@ class MenuBar implements Widget, WidgetManager {
    private calcHeight;
    private calcWidth;
 
-   private children: Widget[] = [];
+   private children: [Widget, number][] = [];
 
    private supressChildUpdates = false;
 
@@ -733,8 +717,6 @@ class MenuBar implements Widget, WidgetManager {
       this.parent = parent;
       this.id = id;
 
-      this.x = props.x;
-      this.y = props.y;
       this.width = props.width;
       this.height = props.height;
 
@@ -751,40 +733,40 @@ class MenuBar implements Widget, WidgetManager {
    }
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
       for (let i = this.children.length-1; i >= 0; i--) {
-         const widget = this.children[i];
+         const [widget, widgetX] = this.children[i];
          widget.render(
             ctx,
-            this.x + offsetX,
-            this.y + offsetY
+            widgetX + offsetX,
+            offsetY
          );
       }
    };
 
-   private selected?: Widget;
+   private selected?: [Widget, number];
    private dispatchEvent(ctx: CanvasRenderingContext2D, widget: Widget, event: MenuItemEventData) {
       if (widget.handledEvents.includes(event[0])) {
          widget.handleMenuEvent(ctx, event);
       }
    }
-   private mouseInWidgetBounds(widget: Widget, x: number, y: number) {
-      const [wX, wY, wW, wH] = widget.getDimensions();
-      return wX <= x && x <= wX + wW
-            && wY <= y && y <= wY + wH;
+   private mouseInWidgetBounds(widget: Widget, widgetX: number, x: number, y: number) {
+      const [widgetWidth, widgetHeight] = widget.getDimensions();
+      return widgetX <= x && x <= widgetX + widgetWidth
+            && 0 <= y && y <= widgetHeight;
    }
    private updateSelected(ctx: CanvasRenderingContext2D, x: number, y: number) {
       if (this.selected) {
-         if (this.mouseInWidgetBounds(this.selected, x, y)) {
+         if (this.mouseInWidgetBounds(this.selected[0], this.selected[1], x, y)) {
             return;
          } else {
-            this.dispatchEvent(ctx, this.selected, [MenuItemEvents.UNHOVERED]);
+            this.dispatchEvent(ctx, this.selected[0], [MenuItemEvents.UNHOVERED]);
             this.selected = undefined;
          }
       }
 
       for (const widget of this.children) {
-         if (this.mouseInWidgetBounds(widget, x, y)) {
+         if (this.mouseInWidgetBounds(widget[0], widget[1], x, y)) {
             this.selected = widget;
-            this.dispatchEvent(ctx, widget, [MenuItemEvents.HOVERING]);
+            this.dispatchEvent(ctx, widget[0], [MenuItemEvents.HOVERING]);
             return;
          }
       }
@@ -794,25 +776,27 @@ class MenuBar implements Widget, WidgetManager {
          case MenuItemEvents.MOUSE_MOVE:
          {
             const [,eX, eY] = event;
-            const [x, y] = [eX - this.x, eY - this.y];
-            this.updateSelected(ctx, x, y);
-            if (this.selected)
-               this.dispatchEvent(ctx, this.selected, [MenuItemEvents.MOUSE_MOVE, x, y]);
+            this.updateSelected(ctx, eX, eY);
+            if (this.selected) {
+               const [x, y] = [eX - this.selected[1], eY];
+               this.dispatchEvent(ctx, this.selected[0], [MenuItemEvents.MOUSE_MOVE, x, y]);
+            }
          }
          break;
          case MenuItemEvents.CLICKED:
          {
             const [,eX, eY] = event;
-            const [x, y] = [eX - this.x, eY - this.y];
-            this.updateSelected(ctx, x, y);
-            if (this.selected)
-               this.dispatchEvent(ctx, this.selected, [MenuItemEvents.CLICKED, x, y]);
+            this.updateSelected(ctx, eX, eY);
+            if (this.selected) {
+               const [x, y] = [eX - this.selected[1], eY];
+               this.dispatchEvent(ctx, this.selected[0], [MenuItemEvents.CLICKED, x, y]);
+            }
          }
          break;
          case MenuItemEvents.UNHOVERED:
          {
             if (this.selected)
-               this.dispatchEvent(ctx, this.selected, [MenuItemEvents.UNHOVERED]);
+               this.dispatchEvent(ctx, this.selected[0], [MenuItemEvents.UNHOVERED]);
             this.selected = undefined;
          }
          break;
@@ -824,17 +808,13 @@ class MenuBar implements Widget, WidgetManager {
          break;
       }
    }
-   getDimensions(): [number, number, number, number] {
+   getDimensions(): [number, number] {
       return [
-         this.x,
-         this.y,
          this.width ?? this.calcWidth,
          this.height ?? this.calcHeight
       ];
    }
-   setDimensions(ctx: CanvasRenderingContext2D, x?: number, y?: number, width?: number, height?: number) {
-      this.x = x ?? this.x;
-      this.y = y ?? this.y;
+   setDimensions(ctx: CanvasRenderingContext2D, width?: number, height?: number) {
       this.width = width ?? this.width;
       this.height = height ?? this.height;
       this.parent.childUpdated(ctx, this);
@@ -843,22 +823,24 @@ class MenuBar implements Widget, WidgetManager {
       this.supressChildUpdates = true;
       let deleted: Widget[] = [this];
       for (const widget of this.children) {
-         deleted.push(...widget.delete(ctx));
+         deleted.push(...widget[0].delete(ctx));
       }
       this.children = [];
       this.supressChildUpdates = false;
       return deleted;
    }
    private updateChildren(ctx: CanvasRenderingContext2D) {
+      this.selected = undefined;
+
       let minHeight = this.minimumHeight;
       let width = 0;
-      for (const widget of this.children) {
-         const [,,widgetWidth, widgetHeight] = widget.getDimensions();
+      for (const [widget,] of this.children) {
+         const [widgetWidth, widgetHeight] = widget.getDimensions();
          const [widgetMinWidth, widgetMinHeight] = widget.getMinSize(ctx);
          
          minHeight = Math.max(minHeight, widgetHeight, widgetMinHeight);
          width += Math.max(this.minChildWidth, widgetWidth, widgetMinWidth) + this.xPadding;
-         console.log(`${widgetWidth}, ${widgetMinWidth}, ${Math.max(this.minChildWidth, widgetWidth, widgetMinWidth)}`);
+         // console.log(`${widgetWidth}, ${widgetMinWidth}, ${Math.max(this.minChildWidth, widgetWidth, widgetMinWidth)}`);
       }
 
       this.calcHeight = minHeight;
@@ -870,16 +852,15 @@ class MenuBar implements Widget, WidgetManager {
       let pos = 0;
       this.supressChildUpdates = true;
       for (const widget of this.children) {
-         const [,,widgetWidth, widgetHeight] = widget.getDimensions();
-         const [minWidgetWidth,] = widget.getMinSize(ctx);
+         const [widgetWidth, widgetHeight] = widget[0].getDimensions();
+         const [minWidgetWidth,] = widget[0].getMinSize(ctx);
          const nWidth = Math.max(this.minChildWidth, widgetWidth, minWidgetWidth);
-         widget.setDimensions(
+         widget[0].setDimensions(
             ctx,
-            pos,
-            0,
             nWidth,
             tmpHeight
          );
+         widget[1] = pos;
          pos += nWidth + this.xPadding;
       }
       this.supressChildUpdates = false;
@@ -899,7 +880,7 @@ class MenuBar implements Widget, WidgetManager {
    >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
       const widget: T = new cons(ctx, this, id, props);
       
-      this.children.push(widget);
+      this.children.push([widget, 0]);
       this.childUpdated(ctx, widget);
 
       return widget;
@@ -913,42 +894,45 @@ class MenuBar implements Widget, WidgetManager {
    }
    handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
       if (!this.supressChildUpdates) {
-         const i = this.children.indexOf(widget);
-         if (i < 0)
-            throw new Error(`MenuBar handleDelete was given an unregistered widget to delete!`);
-         
-         this.children.splice(i, 1);
-         this.updateChildren(ctx);
-            
+         for (let i = 0; i < this.children.length; i++) {
+            if (this.children[i][0] == widget) {
+               this.children.splice(i, 1);
+               this.updateChildren(ctx);
+               break;
+            }
+         }
+         throw new Error(`MenuBar handleDelete was given an unregistered widget to delete!`);   
       }
    }
 }
 
 class RootWidgetManager implements WidgetManager {
-   private boundWidgets: Widget[] = [];
+   private boundWidgets: [Widget, number, number][] = [];
    private popupWidgets: Set<Widget> = new Set();
 
-   private selectedWidget?: Widget;
+   private selectedWidget?: [Widget, number, number];
 
    constructor() {
 
    }
    handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
-      const i = this.boundWidgets.indexOf(widget);
-      if (i < 0)
-         return;
-      this.boundWidgets.splice(i, 1);
-      this.childUpdated(ctx);
+      for (let i = 0; i < this.boundWidgets.length; i++) {
+         if (this.boundWidgets[i][0] == widget) {
+            this.boundWidgets.splice(i, 1);
+            this.childUpdated(ctx);
+            return;
+         }
+      }
    }
 
    addChild<
       T extends Widget, 
       U, 
       O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U) => T
-   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
+   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U, x: number, y: number): T {
       const widget: T = new cons(ctx, this, id, props);
       
-      this.boundWidgets.push(widget);
+      this.boundWidgets.push([widget, x, y]);
 
       return widget;
    }

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -40,66 +40,141 @@ interface MenuItem {
    handleMenuEvent: (event: MenuItemEventData) => void;
 }
 
-interface WidgetEvents {
-   addEvent: (callback: () => void) => void;
-   removeEvent: (callback: () => void) => void;
+interface WidgetManager {
+   childUpdated: (widget: Widget, ctx: CanvasRenderingContext2D) => void;
 }
-const BUTTON_FONT = "16px Serif";
-const BUTTON_PADDING_Y = 2.5;
-const BUTTON_PADDING_X = 5;
-const BUTTON_HEIGHT = 5;
-class Button implements MenuItem, WidgetEvents {
+interface Widget {
+   readonly parent: WidgetManager; 
+   readonly id: number;
+   getMinSize: (ctx: CanvasRenderingContext2D) => [number, number];
+   render: (ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) => void;
+   getRequiredMenuEvents: () => MenuItemEvents[];
+   handleMenuEvent: (event: MenuItemEventData) => void;
+   getDimensions: () => [number, number, number, number];
+   setDimensions: (ctx: CanvasRenderingContext2D, x?: number, y?: number, height?: number, width?: number) => void;
+}
+
+interface WidgetConstructor {
+   parent: WidgetManager;
    id: number;
-
+   x: number;
+   y: number;
+   width?: number;
+   height?: number;
+}
+interface ButtonWidgetConstructor extends WidgetConstructor {
    text: string;
-   font: string;
-   text_color: string;
-   background_color: string;
-   selected_color: string;
-   minWidth: number;
-   minHeight: number;
-   events: (() => void)[] = [];
+   textFont?: string;
+   textColor?: string;
+   buttonColor?: string;
+   selectedButtonColor?: string;
+}
 
-   constructor(
-      id: number,
-      ctx: CanvasRenderingContext2D, 
-      text: string, 
-      font: string = "16px Serif", 
-      text_color: string = "white", 
-      background_color: string = "light_gray", 
-      selected_color: string = "gray"
-   ) {
-      this.id = id;
-      this.text = text;
-      this.font = font;
-      this.text_color = text_color;
-      this.background_color = background_color;
-      this.selected_color = selected_color;
+class NewButton implements Widget, WidgetEvents {
+   readonly parent: WidgetManager; 
+   readonly id: number;
+   private x: number;
+   private y: number;
+   private width: number;
+   private height: number;
 
-      ctx.save();
+   private textOffsets: [number, number];
+
+   private text: string;
+   private textFont: string;
+   private textColor: string;
+   private buttonColor: string;
+   private selectedButtonColor: string;
+
+   private selected: boolean = false;
+   private events: Set<(() => void)> = new Set();
+
+   constructor(ctx: CanvasRenderingContext2D, cons: ButtonWidgetConstructor) {
+      this.parent = cons.parent;
+      this.id = cons.id;
+      this.x = cons.x;
+      this.y = cons.y;
+
+      this.text = cons.text;
+      this.textFont = cons.textFont ?? "16px Serif";
+      this.textColor = cons.textColor ?? "white";
+      this.buttonColor = cons.buttonColor ?? "grey";
+      this.selectedButtonColor = cons.selectedButtonColor ?? "darkgrey";
+
+      const [minWidth, minHeight] = this.getMinSize(ctx);
+
+      this.width = cons.width ?? minWidth;
+      this.height = cons.height ?? minHeight;
       
-      ctx.font = this.font;
-      const measure = ctx.measureText(text);
-      this.minWidth = measure.width;
-      this.minHeight = measure.actualBoundingBoxAscent;
+      this.textOffsets = this.getTextOffsets(ctx);
+   }
+
+   getDimensions(): [number, number, number, number] {
+      return [this.x, this.y, this.width, this.height];
+   }
+   setDimensions(ctx: CanvasRenderingContext2D, x?: number, y?: number, height?: number, width?: number) {
+      this.x = x ?? this.x;
+      this.y = y ?? this.y;
+      this.height = height ?? this.height;
+      this.width = width ?? this.width;
+
+      if (height != undefined || width != undefined)
+         this.textOffsets = this.getTextOffsets(ctx);
+      
+      if (x != undefined || y != undefined || height != undefined || width != undefined)
+         this.parent.childUpdated(this, ctx);
+   }
+
+   getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
+      ctx.save();
+      ctx.font = this.textFont;
+
+      const measure = ctx.measureText(this.text);
+      const minWidth = measure.width;
+      const minHeight = measure.actualBoundingBoxAscent;
+
+      ctx.restore();
+
+      return [minWidth, minHeight];
+   }
+   getTextOffsets(ctx: CanvasRenderingContext2D): [number, number] {
+      const [minWidth, minHeight] = this.getMinSize(ctx);
+
+      return [
+         (this.width - minWidth)/2.0,
+         (this.height + minHeight)/2.0
+      ];
+   }
+   render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
+      ctx.save();
+
+      const button_color = this.selected ? this.selectedButtonColor : this.buttonColor ;
+      ctx.fillStyle = button_color;
+      ctx.fillRect(this.x + offsetX, this.y + offsetY, this.width, this.height);
+
+      ctx.font = this.textFont;
+      ctx.fillStyle = this.textColor;
+      ctx.fillText(
+         this.text,
+         this.x + this.textOffsets[0] + offsetX,
+         this.y + this.textOffsets[1] + offsetY
+      );
 
       ctx.restore();
    }
-   getRequiredMenuEvents() {
+   getRequiredMenuEvents(): MenuItemEvents[] {
       return [
          MenuItemEvents.CLICKED,
          MenuItemEvents.HOVERING,
-         MenuItemEvents.UNHOVERED,
+         MenuItemEvents.UNHOVERED
       ];
    }
-
-   selected: boolean = false;
    handleMenuEvent(event: MenuItemEventData) {
       switch (event[0]) {
          case MenuItemEvents.CLICKED:
          {
-            for (const handler of this.events) {
-               handler();
+            for (const callback of this.events.keys()) {
+               callback();
             }
          }
          break;
@@ -115,42 +190,138 @@ class Button implements MenuItem, WidgetEvents {
             this.selected = false;
          }
          break;
-         
+
          default:
-         {
-            throw new Error(`Button handleMenuEvent was given an unexpected event (${event})!`);
-         }
-         break;
-      } 
-   };
+            throw new Error(`Button handleMenuEvent was given an unrecognized event ${MenuItemEvents[event[0]] ?? event[0]}!`);
+      }
+   }
+
    addEvent(callback: () => void) {
-      this.events.push(callback);
+      this.events.add(callback);
    }
    removeEvent(callback: () => void) {
-      const index = this.events.findIndex(callback);
-      if (index == -1) throw new Error(`Error: Button removeEvent was given a callback that wasn't registered!`);
-      this.events.splice(index, 1);
+      return this.events.delete(callback);
    }
-
-   getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
-      return [this.minWidth, this.minHeight];
-   };
-
-   render(ctx: CanvasRenderingContext2D, x: number, y: number, width: number, height: number) {
-      ctx.save();
-      ctx.font = this.font;
-      
-      console.log(this.text, this.selected);
-      ctx.fillStyle = this.selected ? this.selected_color : this.background_color ;
-      ctx.fillRect(x, y, width, height);
-
-      ctx.fillStyle = this.text_color;
-      ctx.fillText(this.text, x + (width - this.minWidth)/2, y + (height + this.minHeight)/2);
-
-      ctx.restore();
-   }
-   
 }
+
+class TmpManager implements WidgetManager {
+   childUpdated(widget: Widget, ctx: CanvasRenderingContext2D) {
+
+   }
+}
+const tmpManager = new TmpManager();
+
+interface WidgetEvents {
+   addEvent: (callback: () => void) => void;
+   removeEvent: (callback: () => void) => void;
+}
+// const BUTTON_FONT = "16px Serif";
+// const BUTTON_PADDING_Y = 2.5;
+// const BUTTON_PADDING_X = 5;
+// const BUTTON_HEIGHT = 5;
+// class Button implements MenuItem, WidgetEvents {
+//    id: number;
+
+//    text: string;
+//    font: string;
+//    text_color: string;
+//    background_color: string;
+//    selected_color: string;
+//    minWidth: number;
+//    minHeight: number;
+//    events: (() => void)[] = [];
+
+//    constructor(
+//       id: number,
+//       ctx: CanvasRenderingContext2D, 
+//       text: string, 
+//       font: string = "16px Serif", 
+//       text_color: string = "white", 
+//       background_color: string = "light_gray", 
+//       selected_color: string = "blue"
+//    ) {
+//       this.id = id;
+//       this.text = text;
+//       this.font = font;
+//       this.text_color = text_color;
+//       this.background_color = background_color;
+//       this.selected_color = selected_color;
+
+//       ctx.save();
+      
+//       ctx.font = this.font;
+//       const measure = ctx.measureText(text);
+//       this.minWidth = measure.width;
+//       this.minHeight = measure.actualBoundingBoxAscent;
+
+//       ctx.restore();
+//    }
+//    getRequiredMenuEvents() {
+//       return [
+//          MenuItemEvents.CLICKED,
+//          MenuItemEvents.HOVERING,
+//          MenuItemEvents.UNHOVERED,
+//       ];
+//    }
+
+//    selected: boolean = false;
+//    handleMenuEvent(event: MenuItemEventData) {
+//       switch (event[0]) {
+//          case MenuItemEvents.CLICKED:
+//          {
+//             for (const handler of this.events) {
+//                handler();
+//             }
+//          }
+//          break;
+
+//          case MenuItemEvents.HOVERING:
+//          {
+//             this.selected = true;
+//          }
+//          break;
+
+//          case MenuItemEvents.UNHOVERED:
+//          {
+//             this.selected = false;
+//          }
+//          break;
+         
+//          default:
+//          {
+//             throw new Error(`Button handleMenuEvent was given an unexpected event (${event})!`);
+//          }
+//          break;
+//       } 
+//    };
+//    addEvent(callback: () => void) {
+//       this.events.push(callback);
+//    }
+//    removeEvent(callback: () => void) {
+//       const index = this.events.findIndex(callback);
+//       if (index == -1) throw new Error(`Error: Button removeEvent was given a callback that wasn't registered!`);
+//       this.events.splice(index, 1);
+//    }
+
+//    getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
+//       return [this.minWidth, this.minHeight];
+//    };
+
+//    render(ctx: CanvasRenderingContext2D, x: number, y: number, width: number, height: number) {
+//       ctx.save();
+//       ctx.font = this.font;
+      
+//       ctx.fillStyle = this.selected ? this.selected_color : this.background_color ;
+//       ctx.fillRect(x, y, width, height);
+
+//       ctx.fillStyle = this.text_color;
+//       ctx.fillText(this.text, x + (width - this.minWidth)/2, y + (height + this.minHeight)/2);
+
+//       ctx.restore();
+//    }
+   
+// }
+
 
 const MENU_TEXT_FONT = "20px Serif";
 const MENU_PADDING_X = 5;
@@ -160,25 +331,17 @@ const BORDER_SIZE: number = 5;
 const MENU_START_X = BORDER_SIZE;
 class Menu {
    items: MenuItem[] = [];
+   events: Map<MenuItemEvents, Set<MenuItem>> = new Map();
    
    constructor() {
 
    }
 
-   render(ctx: CanvasRenderingContext2D, x: number, y: number) {
+   render(ctx: CanvasRenderingContext2D, x: number, y: number, minWidth: number, minHeight: number) {
       ctx.save();
 
-      let maxWidth = 0;
-      let maxHeight = 0;
-      for (const item of this.items) {
-         const [width, height] = item.getMinSize(ctx);
-         if (width > maxWidth)
-            maxWidth = width;
-         if (height > maxHeight)
-            maxHeight = height;
-      }
-      const width = maxWidth + MENU_PADDING_X*2;
-      const height = (maxHeight + MENU_PADDING_Y)*this.items.length - MENU_PADDING_Y;
+      const [maxWidth, maxHeight] = this.getMaxItemSize(ctx, minWidth, minHeight);
+      const [width, height] = this.maxItemSizeToTotalSize(maxWidth, maxHeight);
 
       ctx.fillStyle = "light_gray";
       ctx.fillRect(x, y, width, height);
@@ -196,7 +359,42 @@ class Menu {
       if (this.items.indexOf(menuItem) != -1)
          throw new Error(`Menu addItem was given a MenuItem that's already on the menu!`);
       this.items.push(menuItem);
+      for (const event of menuItem.getRequiredMenuEvents()) {
+         let eventSet = this.events.get(event) ?? (() => {
+            const set: Set<MenuItem> = new Set();
+            this.events.set(event, set);
+            return set;
+         })();
+
+         eventSet.add(menuItem);
+      }
    }
+
+   getMaxItemSize(ctx: CanvasRenderingContext2D, minWidth: number, minHeight: number): [number, number] {
+      let maxWidth = minWidth;
+      let maxHeight = minHeight;
+      for (const item of this.items) {
+         const [width, height] = item.getMinSize(ctx);
+         if (width > maxWidth)
+            maxWidth = width;
+         if (height > maxHeight)
+            maxHeight = height;
+      }
+      return [maxWidth, maxHeight];
+   } 
+   maxItemSizeToTotalSize(maxWidth: number, maxHeight: number) {
+      const width = maxWidth + MENU_PADDING_X*2;
+      const height = (maxHeight + MENU_PADDING_Y)*Math.max(this.items.length, 1) - MENU_PADDING_Y;
+
+      return [width, height];
+   }
+
+   getSize(ctx: CanvasRenderingContext2D, minWidth: number, minHeight: number) {
+      const [maxWidth, maxHeight] = this.getMaxItemSize(ctx, minWidth, minHeight);
+      return this.maxItemSizeToTotalSize(maxWidth, maxHeight);
+   }
+
+   
 
    
 
@@ -216,8 +414,11 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    menuItems: Map<number, MenuItem> = new Map();
    nextMenuItem: number = 0;
 
-   menus: Map<number, [Button, Menu]> = new Map();
+   menus: Map<number, [NewButton, Menu]> = new Map();
    nextMenuID: number = 0;
+
+   openMenu: [Menu, number, number, number]|undefined = undefined;
+
    
 
    imports: TLibImports = {
@@ -289,7 +490,18 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       const n_x = x - BORDER_SIZE;
       const n_y = y - TOP_BAR_SIZE;
       let topBar = false;
+      let [menWidth, menHeight] = [0, 0];
+      if (this.openMenu) {
+         [menWidth, menHeight] = this.openMenu[0].getSize(this.ctx, this.openMenu[3], TOP_BAR_SIZE);
+      }
+
       if (
+         this.openMenu
+         && x >= this.openMenu[1] && x <= this.openMenu[1]+menWidth
+         && y >= this.openMenu[2] && y <= this.openMenu[2]+menHeight
+      ) {
+         console.log("on the menu!!!");
+      } else if (
          n_x >= 0 && n_y >= 0
          && n_x <= this.appCanvasWidth
          && n_y <= this.appCanvasHeight
@@ -299,19 +511,52 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          topBar = true;
          this.mouseWasOnTopBar = true;
          let widthOffset = MENU_START_X;
-         for (const menu of this.menus.values()) {
-            // menu.hovering = x >= widthOffset
-            //    && x < widthOffset+menu.width;
-            const width = menu[0].getMinSize(this.ctx)[0] + MENU_PADDING_X*2;
+         // for (const menu of this.menus.values()) {
+         //    // menu.hovering = x >= widthOffset
+         //    //    && x < widthOffset+menu.width;
+         //    const width = menu[0].getMinSize(this.ctx)[0] + MENU_PADDING_X*2;
             
-            if (
-               x >= widthOffset
-               && x < widthOffset+width
-            ) {
-               menu[0].handleMenuEvent([MenuItemEvents.HOVERING]);
-            }
+         //    if (
+         //       x >= widthOffset
+         //       && x < widthOffset+width
+         //    ) {
+         //       if (event == CanvasEventTypes.MOUSE_MOVE)
+         //          menu[0].handleMenuEvent([MenuItemEvents.HOVERING]);
+         //       else if (event == CanvasEventTypes.MOUSE_CLICK)
+         //          menu[0].handleMenuEvent([MenuItemEvents.CLICKED]);
+         //    } else if (event == CanvasEventTypes.MOUSE_MOVE) {
+         //       menu[0].handleMenuEvent([MenuItemEvents.UNHOVERED]);
+         //    }
 
-            widthOffset += width;
+         //    widthOffset += width;
+         // }
+         for (const [button, ] of this.menus.values()) {
+            const [bX, bY, bWidth, bHeight] = button.getDimensions();
+            const xInBounds = bX <= x && x <= bX + bWidth;
+            const yInBounds = bY <= y && y <= bY + bHeight;
+
+            const inBounds = xInBounds && yInBounds;
+
+            switch (event) {
+               case CanvasEventTypes.MOUSE_MOVE:
+               {
+                  if (inBounds)
+                     button.handleMenuEvent([MenuItemEvents.HOVERING])
+                  else
+                     button.handleMenuEvent([MenuItemEvents.UNHOVERED])
+               }
+               break;
+
+               case CanvasEventTypes.MOUSE_CLICK:
+               {
+                  if (inBounds) {
+                     button.handleMenuEvent([MenuItemEvents.CLICKED])
+                  }
+               }
+               break;
+            }
+               
+            
          }
       }
 
@@ -327,6 +572,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       this.appCanvas.handleCanvasWheelEvent(event, deltaX, deltaY, deltaZ, deltaMode);
       return true;
    }
+
    handleCanvasAnimationFrameEvent(event: CanvasEventTypes, delta: number) {
       this.appCanvas.handleCanvasAnimationFrameEvent(event, delta);
 
@@ -352,37 +598,20 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       this.ctx.stroke();
       this.ctx.closePath();
 
-      // this.ctx.fillStyle = "black";
-      // this.ctx.font = MENU_TEXT_FONT;
-      // let widthOffset = MENU_START_X; 
+      // let widthOffset = MENU_START_X;
       // for (const menu of this.menus.values()) {
-      //    // console.log(`${widthOffset + menu.xOffset}, ${menu.yOffset}`);
-      //    if (menu.hovering ) {
-      //       this.ctx.save();
-      //       this.ctx.fillStyle = SELECT_GREY;
+      //    const width = menu[0].getMinSize(this.ctx)[0] + MENU_PADDING_X*2;
 
-      //       this.ctx.beginPath();
-      //       this.ctx.roundRect(widthOffset, MENU_PADDING_Y, menu.width, TOP_BAR_SIZE - MENU_PADDING_Y*2.0, Math.PI);
-      //       this.ctx.fill();
-      //       this.ctx.closePath();
+      //    menu[0].render(this.ctx, widthOffset, 0, width, TOP_BAR_SIZE - this.ctx.lineWidth/2.0);
 
-      //       this.ctx.restore();
-      //    }
-      //    this.ctx.fillText(
-      //       menu.text, 
-      //       widthOffset + menu.xOffset,
-      //       menu.yOffset,
-      //    );
-
-      //    widthOffset += menu.width;
+      //    widthOffset += width;
       // }
-      let widthOffset = MENU_START_X;
-      for (const menu of this.menus.values()) {
-         const width = menu[0].getMinSize(this.ctx)[0] + MENU_PADDING_X*2;
+      for (const [button, ] of this.menus.values()) {
+         button.render(this.ctx, 0, 0);
+      }
 
-         menu[0].render(this.ctx, widthOffset, 0, width, TOP_BAR_SIZE);
-
-         widthOffset += width;
+      if (this.openMenu) {
+         this.openMenu[0].render(this.ctx, this.openMenu[1], this.openMenu[2], this.openMenu[3], TOP_BAR_SIZE);
       }
 
    }
@@ -396,8 +625,48 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
 
       const id = ++this.nextMenuID;
 
-      this.menus.set(id, [new Button(id, this.ctx, text), new Menu()]);
+      // const button = new Button(id, this.ctx, text, undefined, "black", "#B0B0B0", "#D0D0D0");
+      // const menu = new Menu();
+      // this.menus.set(id, [button, menu]);
 
+      let maxX = MENU_START_X;
+      for (const [button, ] of this.menus.values()) {
+         const [x, , width, ] = button.getDimensions();
+         const rX = x + width;
+
+         maxX = Math.max(maxX, rX);
+      }
+
+      const button = new NewButton(this.ctx, {
+         id: id,
+         x: maxX,
+         y: 0,
+         height: TOP_BAR_SIZE - 0.5,
+         parent: tmpManager,
+         text: text,
+         textColor: "black",
+         buttonColor: "#B0B0B0",
+         selectedButtonColor: "#D0D0D0"
+      });
+      const [, , width, ] = button.getDimensions();
+      button.setDimensions(this.ctx, undefined, undefined, undefined, width + MENU_PADDING_X);
+
+      const menu = new Menu();
+      this.menus.set(id, [button, menu]);
+      // button.addEvent((() => {
+      //    let widthOffset = MENU_START_X;
+      //    for (const menu2 of this.menus.values()) {
+      //       if (menu2[0].id == id)
+      //          break;
+      //       widthOffset += menu2[0].getMinSize(this.ctx)[0] + MENU_PADDING_X*2;
+      //    }
+      //    this.openMenu = [menu, widthOffset, TOP_BAR_SIZE, button.getMinSize(this.ctx)[0]];
+      // }).bind(this));
+
+      button.addEvent((() => {
+         const [x, y, width, height] = button.getDimensions();
+         this.openMenu = [menu, x, y+height+0.5, width];
+      }).bind(this));
       return id;
    }
 

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -289,11 +289,20 @@ interface WidgetConstructor {
    width?: number;
    height?: number;
 }
+enum ButtonWidgetVerticalCenteringMethod {
+   //don't center the widget vertically
+   None,
+   //center it based on the font so all strings of the same font will be centered the same
+   FontCentering,
+   //center it based on each individual string's minimum and maximum heights
+   StringCentering
+}
 interface ButtonWidgetConstructor extends WidgetConstructor {
    text: string;
    prefixText?: string;
    suffixText?: string;
    centeredHorizontally?: boolean;
+   verticalCentering?: ButtonWidgetVerticalCenteringMethod;
 
    reservePrefixSpace?: boolean;
 }
@@ -313,6 +322,7 @@ abstract class ButtonBase extends WidgetImpl {
    private _suffixText?: string;
    private centeredHorizontally: boolean;
    private reservePrefixSpace: boolean;
+   private _verticalCentering: ButtonWidgetVerticalCenteringMethod;
 
    setText(val: string) {this._text = val; this.propagateUpdate(undefined, true)};
    getText(): string {return this._text};
@@ -320,6 +330,7 @@ abstract class ButtonBase extends WidgetImpl {
    protected getPrefixText(): string|undefined {return this._prefixText};
    protected setSuffixText(val: string|undefined) {this._suffixText = val; this.propagateUpdate(undefined, true)};
    protected getSuffixText(): string|undefined {return this._suffixText};
+
 
    getPublicProperties(): PublicPropertiesType {
       return {
@@ -353,6 +364,8 @@ abstract class ButtonBase extends WidgetImpl {
       this._width = cons.width;
       this._height = cons.height;
 
+      this._verticalCentering = cons.verticalCentering ?? ButtonWidgetVerticalCenteringMethod.StringCentering;
+
       this.updateCalculatedFields(ctx);
    }
 
@@ -373,9 +386,10 @@ abstract class ButtonBase extends WidgetImpl {
 
       const calcFields = this.calculatedFields;
       calcFields.width = minWidth;
-      calcFields.height = minHeight;
+      calcFields.height = minHeight*1.1;
 
       const textOffsets = calcFields.textOffsets;
+
 
       function getHeight(ctx: CanvasRenderingContext2D, font: string): number {
          ctx.save();minHeight
@@ -387,10 +401,26 @@ abstract class ButtonBase extends WidgetImpl {
       }
 
       textOffsets.mainTextX = this.centeredHorizontally 
-         ? (this.getUsedWidth() - (minWidth - minPrefix - minSuffix))/2.0 
+         ? (this.getUsedWidth() - minWidth)/2.0
          : minPrefix;
-      
-      textOffsets.y = (this.getUsedHeight() + getHeight(ctx, this.getFont()))/2.0;
+      if (this.centeredHorizontally) {
+         console.log(`centered horizontally! ${this._text}`);
+      }
+      switch (this._verticalCentering) {
+         case ButtonWidgetVerticalCenteringMethod.None:
+            ctx.save();
+            ctx.font = this.getFont();
+            const below = ctx.measureText(this._text).actualBoundingBoxDescent;
+            ctx.restore();
+            textOffsets.y = this.getUsedHeight() - minHeight + below;
+         break;
+         case ButtonWidgetVerticalCenteringMethod.FontCentering:
+            textOffsets.y = (this.getUsedHeight() + getHeight(ctx, this.getFont()))/2.0;
+         break;
+         case ButtonWidgetVerticalCenteringMethod.StringCentering:
+            textOffsets.y = (this.getUsedHeight() + minHeight)/2.0;
+         break;
+      }
       textOffsets.suffixX = minSuffix;
    }
 
@@ -412,7 +442,7 @@ abstract class ButtonBase extends WidgetImpl {
       const spaceMeasure = ctx.measureText(" ");
       const spaceWidth = spaceMeasure.width;
 
-      ctx.textBaseline = "bottom";
+      // ctx.textBaseline = "top";
       let minWidth = 0;
       let minHeight = 0;
       const parts = [this._prefixText, this._suffixText, this._text];
@@ -456,6 +486,8 @@ abstract class ButtonBase extends WidgetImpl {
          return;
 
       ctx.save();
+
+      // ctx.textBaseline = "top";
 
       const textOffsets = this.calculatedFields.textOffsets;
 
@@ -1813,6 +1845,8 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          menuOptions: menuOptions,
          offset: 0.5,
          reservePrefixSpace: false,
+         verticalCentering: ButtonWidgetVerticalCenteringMethod.FontCentering,
+         centeredHorizontally: true,
       });
 
       this.widgets.set(button.id, [WidgetType.SubMenu, button]);
@@ -1852,10 +1886,10 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
 
       const type = mod.getLong(consPtr + 0) as WidgetType;
 
-      const width = getLongOrDef(consPtr + 4, undefined);
-      const height = getLongOrDef(consPtr + 8, undefined);
+      // const width = getLongOrDef(consPtr + 4, undefined);
+      const height = getLongOrDef(consPtr + 4, undefined);
 
-      const extraPtr = consPtr + 12;
+      const extraPtr = consPtr + 8;
 
       switch (type) {
          case WidgetType.Button:
@@ -1867,7 +1901,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             //    const char* text;
             // };
             let button: ButtonWidgetConstructor = {
-               width: width,
+               // width: width,
                height: height,
                text: getStringOrDef(extraPtr + 0, "Lorem Ipsum"),
             };
@@ -1888,7 +1922,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             //    const char* seperator_font;
             // };
             let seperator: SeperatorWidgetConstructor = {
-               width: width,
+               // width: width,
                height: height,
                seperatorText: getStringOrDef(extraPtr + 0, "-"),
             };
@@ -1908,7 +1942,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             // };
 
             const cons: ButtonWidgetConstructor = {
-               width: width,
+               // width: width,
                height: height,
                text: getStringOrDef(extraPtr + 0, "Lorem Ipsum"),
             };
@@ -1936,7 +1970,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             // };
 
             const cons: MenuButtonWidgetConstructor = {
-               width: width,
+               // width: width,
                height: height,
                text: getStringOrDef(extraPtr + 0, "Lorem Ipsum"),
                menuWidth: getLongOrDef(extraPtr + 4, undefined),

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -30,8 +30,8 @@ enum MenuItemEvents {
 }
 type MenuItemEventData = [ MenuItemEvents.HOVERING ]
    | [ MenuItemEvents.UNHOVERED ]
-   | [ MenuItemEvents.CLICKED, number, number ]
-   | [ MenuItemEvents.MOUSE_MOVE, number, number ]
+   | [ MenuItemEvents.CLICKED, number, number, number]
+   | [ MenuItemEvents.MOUSE_MOVE, number, number]
    | [ MenuItemEvents.CLICKED_OFF];
 
 interface WidgetManager {
@@ -194,7 +194,7 @@ class Button implements Widget, WidgetEvents {
       let minPrefix = this.reservedPrefixSpace;
       if (this.prefixText != undefined) {
          const prefixMeasure = ctx.measureText(this.prefixText);
-         minPrefix = Math.min(minPrefix, prefixMeasure.width + spaceWidth);
+         minPrefix = Math.max(minPrefix, prefixMeasure.width + spaceWidth);
       }
       let minSuffix = 0;
       if (this.suffixText != undefined) {
@@ -604,12 +604,12 @@ class Menu implements Widget, WidgetManager {
          break;
          case MenuItemEvents.CLICKED:
          {
-            const [, eX, eY] = event;
+            const [, eX, eY, button] = event;
             this.updateSelectedObject(ctx, eX, eY);
             const selected = this.selectedItem;
             if (selected) {
                const [x, y] = [eX - this.borderWidth, eY - selected[1]];
-               this.dispatchEvent(ctx, selected[0], [MenuItemEvents.CLICKED, x, y]);
+               this.dispatchEvent(ctx, selected[0], [MenuItemEvents.CLICKED, x, y, button]);
             }
             for (const [widget,] of this.children) {
                if (selected == undefined || widget != selected[0])
@@ -752,6 +752,8 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
          prefix = this.selectedSymbol;
       }
 
+      console.log("reservedPrefixLength: ", this.reservedPrefixLength);
+
       const buttonOpts: ButtonWidgetConstructor = {
          width: -1,
          height: this.optionHeight,
@@ -785,6 +787,7 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
          for (const event of this.events) {
             event(ctx, this.selected);
          }
+         this.menu.childUpdated(ctx);
       }
    }
 
@@ -963,11 +966,11 @@ class MenuBar implements Widget, WidgetManager {
          break;
          case MenuItemEvents.CLICKED:
          {
-            const [,eX, eY] = event;
+            const [,eX, eY, button] = event;
             this.updateSelected(ctx, eX, eY);
             if (this.selected) {
                const [x, y] = [eX - this.selected[1], eY];
-               this.dispatchEvent(ctx, this.selected[0], [MenuItemEvents.CLICKED, x, y]);
+               this.dispatchEvent(ctx, this.selected[0], [MenuItemEvents.CLICKED, x, y, button]);
             }
          }
          break;
@@ -1220,7 +1223,7 @@ class RootWidgetManager implements WidgetManager {
       }
    }
 
-   handleCanvasMouseEvent(ctx: CanvasRenderingContext2D, event: CanvasEventTypes, x: number, y: number): boolean {
+   handleCanvasMouseEvent(ctx: CanvasRenderingContext2D, event: CanvasEventTypes, x: number, y: number, button: number): boolean {
       this.updateSelected(ctx, x, y);
       if (!this.selectedWidget) {
          if (event == CanvasEventTypes.MOUSE_CLICK) {
@@ -1249,7 +1252,7 @@ class RootWidgetManager implements WidgetManager {
                }
             }
             const [nX, nY] = [x - selected[1], y - selected[2]];
-            this.dispatchEvent(ctx, selected[0], [MenuItemEvents.CLICKED, nX, nY]);
+            this.dispatchEvent(ctx, selected[0], [MenuItemEvents.CLICKED, nX, nY, button]);
          }
          break;
       }
@@ -1365,7 +1368,8 @@ class MenuButton implements Widget, WidgetManager {
       return this.button.getMinSize(ctx);
    }
    render(ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) {
-      this.button.render(ctx, offsetX, offsetY);
+      if (this.visible)
+         this.button.render(ctx, offsetX, offsetY);
    }
    handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
       if (event[0] == MenuItemEvents.CLICKED_OFF) {
@@ -1479,6 +1483,9 @@ class Seperator implements Widget {
       return [0, this.minHeight];
    }
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
+      if (!this.visible)
+         return;
+
       ctx.save();
 
       ctx.font = this.seperatorFont;
@@ -1660,9 +1667,9 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       menuOptionFont: "16px Seriph",
       widgetTextFont: "12px Seriph",
       menuOpenOffset: 5,
-      subMenuOpenOffset: 5,
+      subMenuOpenOffset: 1,
       textColor: "black",
-      reservedPrefixLen: 10,
+      reservedPrefixLen: 15,
       yPadding: 5,
       menuBorderWidth: 1.0,
       menuBorderColor: "Black",
@@ -1758,18 +1765,18 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
 
    mouseWasOnTopBar: boolean = false;
    mouseWasOnMenu: boolean = false;
-   handleCanvasMouseEvent(event: CanvasEventTypes, x: number, y: number) {
+   handleCanvasMouseEvent(event: CanvasEventTypes, x: number, y: number, button: number) {
       const n_x = x - BORDER_SIZE;
       const n_y = y - TOP_BAR_SIZE;10
 
-      if (this.manager.handleCanvasMouseEvent(this.ctx, event, x, y)) {
+      if (this.manager.handleCanvasMouseEvent(this.ctx, event, x, y, button)) {
 
       } else if (
          n_x >= 0 && n_y >= 0
          && n_x <= this.appCanvasWidth
          && n_y <= this.appCanvasHeight
       ) {
-         this.appCanvas.handleCanvasMouseEvent(event, n_x, n_y);
+         this.appCanvas.handleCanvasMouseEvent(event, n_x, n_y, button);
       }10
 
       return true;

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -29,7 +29,7 @@ enum MenuItemEvents {
 }
 type MenuItemEventData = [ MenuItemEvents.HOVERING ]
    | [ MenuItemEvents.UNHOVERED ]
-   | [ MenuItemEvents.CLICKED ]
+   | [ MenuItemEvents.CLICKED, number, number ]
    | [ MenuItemEvents.MOUSE_MOVE, number, number ];
 
 interface MenuItem {
@@ -41,7 +41,7 @@ interface MenuItem {
 }
 
 interface WidgetManager {
-   childUpdated: (widget: Widget, ctx: CanvasRenderingContext2D) => void;
+   childUpdated: (ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) => void;
    //really, really long type. Basically accepts any class constructor that created a Widget
    // and accepts a CanvasRenderingContext2D, an id, a parent WidgetManager, and a set of properties of any type
    // the idea is that you give the manager a widget and it constructs it internally.
@@ -70,6 +70,25 @@ interface ButtonWidgetConstructor extends WidgetConstructor {
    textColor?: string;
    buttonColor?: string;
    selectedButtonColor?: string;
+}
+
+//implementation of Map that will automatically
+// set a default value for a get on an unknown item
+class DefaultMap<K, V> extends Map<K, V> {
+   private readonly def: V;
+   constructor(def: V) {
+      super();
+      this.def = def;
+   }
+   
+   get(key: K): V {
+      const val = super.get(key);
+      if (val != undefined)
+         return val;
+      const newVal = structuredClone(this.def);
+      super.set(key, newVal);
+      return newVal;
+   }
 }
 
 class NewButton implements Widget, WidgetEvents {
@@ -130,7 +149,7 @@ class NewButton implements Widget, WidgetEvents {
          this.textOffsets = this.getTextOffsets(ctx);
       
       if (x != undefined || y != undefined || height != undefined || width != undefined)
-         this.parent.childUpdated(this, ctx);
+         this.parent.childUpdated(ctx);
    }
 
    getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
@@ -209,14 +228,18 @@ interface MenuWidgetConstructor extends WidgetConstructor {
    minimumWidth?: number;
    minimumHeight?: number;
    menuColor?: string;
+   yPadding?: number;
 }
 
-class NewMenu implements Widget, WidgetEvents, WidgetManager {
+class NewMenu implements Widget, WidgetManager {
    readonly parent: WidgetManager;
    readonly id: number;
 
-   readonly handledEvents: MenuItemEvents[] = Object.values(MenuItemEvents)
-      .filter(item => typeof item == "number");
+   readonly handledEvents: MenuItemEvents[] = [
+      MenuItemEvents.CLICKED,
+      MenuItemEvents.UNHOVERED,
+      MenuItemEvents.MOUSE_MOVE
+   ];
 
    private absoluteMinWidth: number;
    private absoluteMinHeight: number;
@@ -225,6 +248,7 @@ class NewMenu implements Widget, WidgetEvents, WidgetManager {
    private y: number;
    private width?: number;
    private height?: number;
+   private yPadding: number;
 
    private childWidth: number;
    private childHeight: number;
@@ -232,7 +256,13 @@ class NewMenu implements Widget, WidgetEvents, WidgetManager {
    private menuColor: string;
 
    private children: Widget[] = [];
-   private childEvents: Map<MenuItemEvents, Widget[]> = new Map();
+
+   private unhoverHandlers: (() => void)[] = [];
+
+
+   //the currently hovered over/selected item 
+   //resets to undefined on menu update or UNHOVERED event
+   private selectedItem?: Widget;
    
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuWidgetConstructor) {
       this.parent = parent;
@@ -248,6 +278,7 @@ class NewMenu implements Widget, WidgetEvents, WidgetManager {
 
       this.width = props.width;
       this.height = props.height;
+      this.yPadding = props.yPadding ?? 10;
 
       this.menuColor = props.menuColor ?? "gray";
    }
@@ -261,13 +292,20 @@ class NewMenu implements Widget, WidgetEvents, WidgetManager {
       for (const widget of this.children) {
          const [width, height] = widget.getMinSize(ctx);
          childWidth = Math.max(childWidth, width);
-         childHeight += height;
+         childHeight += height + this.yPadding;
       }
 
-      const newWidth = this.width ?? Math.min(childWidth, this.absoluteMinWidth);
-      const newHeight = this.height ?? Math.min(childHeight, this.absoluteMinHeight);
+      // console.log(childWidth, childHeight);
+
+      childWidth = Math.max(childWidth, this.absoluteMinWidth);
+      childHeight = Math.max(childHeight, this.absoluteMinHeight);
+
+      const newWidth = this.width ?? childWidth;
+      const newHeight = this.height ?? childHeight;
       this.childHeight = childHeight;
       this.childWidth = childWidth;
+
+      console.log(newWidth, newHeight, this.childWidth, this.childHeight);
 
       if (this.lastWidth != newWidth || this.lastHeight != newHeight || forceRun) {
          this.lastWidth = newWidth;
@@ -280,14 +318,20 @@ class NewMenu implements Widget, WidgetEvents, WidgetManager {
             this.supressChildUpdates = true;
             widget.setDimensions(ctx, 0, curHeight, newWidth, height);
             this.supressChildUpdates = false;
+            curHeight += height + this.yPadding;
          }
 
       }
    }
 
-   childUpdated(widget: Widget, ctx: CanvasRenderingContext2D) {
-      if (!this.supressChildUpdates)
+   childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot: boolean = false) {
+      if (sendToRoot) {
+         this.parent.childUpdated(ctx, widget, true);
+      } else if (!this.supressChildUpdates) {
          this.updateChildSize(ctx);
+         this.selectedItem = undefined;
+         this.parent.childUpdated(ctx, undefined, false);
+      }
    }
    addChild<
       T extends Widget, 
@@ -298,15 +342,6 @@ class NewMenu implements Widget, WidgetEvents, WidgetManager {
 
       this.children.push(widget);
       this.updateChildSize(ctx, true);
-      for (const event of widget.handledEvents) {
-         const handlers = this.childEvents.get(event) ?? (() => {
-            const tmp: Widget[] = [];
-            this.childEvents.set(event, tmp);
-            return tmp;
-         })();
-
-         handlers.push(widget);
-      }
 
       return widget;
    }
@@ -336,8 +371,75 @@ class NewMenu implements Widget, WidgetEvents, WidgetManager {
       ctx.restore();
 	}
    
+   private dispatchEvent(widget: Widget, event: MenuItemEventData) {
+      if (event[0] in widget.handledEvents) {
+         widget.handleMenuEvent(event);
+      }
+   }
+
+   private mouseInWidgetBounds(widget: Widget, x: number, y: number) {
+      const [wX, wY, wW, wH] = widget.getDimensions();
+      return wX <= x && x <= wX + wW
+            && wY <= y && y <= wY + wH;
+   }
+
+   //updates the currently selected object using the given coords
+   //also handles HOVERING and UNHOVERED events
+   private updateSelectedObject(x: number, y: number) {
+      //check if hovering over selected item
+      if (this.selectedItem) {
+         if (this.mouseInWidgetBounds(this.selectedItem, x, y)) {
+            return; //the selected item is in bounds
+         } else {
+            //selected item is out of bounds
+            this.dispatchEvent(this.selectedItem, [MenuItemEvents.UNHOVERED]);
+         }
+      }
+      //otherwise, find what object (if any) are hovered over
+      for (const child of this.children) {
+         //found child it's hovering over
+         if (this.mouseInWidgetBounds(child, x, y)) {
+            this.selectedItem = child;
+            this.dispatchEvent(child, [MenuItemEvents.HOVERING]);
+            //break early
+            return;
+         }
+      }
+   }
    handleMenuEvent(event: MenuItemEventData): void {
-		
+      console.log(event, this.selectedItem);
+		switch (event[0]) {
+         case MenuItemEvents.MOUSE_MOVE:
+         {
+            const [, eX, eY] = event;
+            const [x, y] = [eX - this.x, eY - this.y];
+            this.updateSelectedObject(x, y);
+            if (this.selectedItem)
+               this.dispatchEvent(this.selectedItem, [MenuItemEvents.MOUSE_MOVE, x, y]);
+         }
+         break;
+         case MenuItemEvents.CLICKED:
+         {
+            const [, eX, eY] = event;
+            const [x, y] = [eX - this.x, eY - this.y];
+            this.updateSelectedObject(x, y);
+            if (this.selectedItem)
+               this.dispatchEvent(this.selectedItem, [MenuItemEvents.CLICKED, x, y]);
+         }
+         break;
+         case MenuItemEvents.UNHOVERED:
+         {
+            if (this.selectedItem) {
+               this.dispatchEvent(this.selectedItem, [MenuItemEvents.UNHOVERED]);
+               this.selectedItem = undefined;
+            }
+            for (const handler of this.unhoverHandlers) {
+               handler();
+            }
+         }
+         break;
+
+      }
 	}
 
    getDimensions(): [number, number, number, number] {
@@ -350,15 +452,30 @@ class NewMenu implements Widget, WidgetEvents, WidgetManager {
 	}
 
    setDimensions(ctx: CanvasRenderingContext2D, x?: number, y?: number, width?: number, height?: number): void {
-      
+      this.x = x ?? this.x;
+      this.y = y ?? this.y;
+      if (width != undefined){
+         if (width == 0)
+            this.width = undefined;
+         else
+            this.width = width;
+      }
+      if (height != undefined){
+         if (height == 0)
+            this.height = undefined;
+         else
+            this.height = height;
+      }
 	}
 
-   addEvent(callback: () => void) {
-      
+
+   bindUnhoverEvent(callback: () => void) {
+      this.unhoverHandlers.push(callback);
    }
-
-   removeEvent(callback: () => void) {
-
+   unbindUnhoverEvent(callback: () => void) {
+      const index = this.unhoverHandlers.indexOf(callback);
+      if (index >= 0)
+         this.unhoverHandlers.splice(index);
    }
 
 }
@@ -371,12 +488,105 @@ class TmpManager implements WidgetManager {
    >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
       return new cons(ctx, this as WidgetManager, id, props);
    }
-   childUpdated(widget: Widget, ctx: CanvasRenderingContext2D) {
+   childUpdated(ctx: CanvasRenderingContext2D) {
 
    }
 }
 const tmpManager = new TmpManager();
 
+class RootWidgetManager implements WidgetManager {
+   private boundWidgets: Widget[] = [];
+   private popupWidgets: Set<Widget> = new Set();
+
+   private selectedWidget?: Widget;
+
+   constructor() {
+
+   }
+
+   addChild<
+      T extends Widget, 
+      U, 
+      O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U) => T
+   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
+      const widget: T = new cons(ctx, this, id, props);
+      
+      this.boundWidgets.push(widget);
+
+      return widget;
+   }
+   childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget) {
+      this.selectedWidget = undefined;
+   }
+
+   openPopup(ctx: CanvasRenderingContext2D, widget: Widget) {
+      this.popupWidgets.add(widget);
+      this.childUpdated(ctx, widget);
+   }
+   closePopup(ctx: CanvasRenderingContext2D, widget: Widget) {
+      this.popupWidgets.delete(widget);
+      this.childUpdated(ctx);
+   }
+
+   handleCanvasKeyEvent(ctx: CanvasRenderingContext2D, event: CanvasEventTypes, key: number): boolean {
+      return false;
+   }
+
+   private widgetInBounds(widget: Widget, x: number, y: number): boolean {
+      const [wX, wY, wW, wH] = widget.getDimensions();
+      return wX <= x && x <= wX + wW
+         && wY <= y && y <= wY + wH;
+   }
+   private dispatchEvent(widget: Widget, event: MenuItemEventData) {
+      if (event[0] in widget.handledEvents) {
+         widget.handleMenuEvent(event);
+      }
+   }
+   private updateSelected(x: number, y: number) {
+      if (this.selectedWidget) {
+         if (this.widgetInBounds(this.selectedWidget, x, y)) {
+            return;
+         } else {
+            this.dispatchEvent(this.selectedWidget, [MenuItemEvents.UNHOVERED]);
+            this.selectedWidget = undefined;
+         }
+      }
+
+      for (const widget of this.boundWidgets) {
+         if (this.widgetInBounds(widget, x, y)) {
+            this.selectedWidget = widget;
+            this.dispatchEvent(widget, [MenuItemEvents.HOVERING]);
+            return;
+         }
+      }
+   }
+
+   handleCanvasMouseEvent(ctx: CanvasRenderingContext2D, event: CanvasEventTypes, x: number, y: number): boolean {
+      this.updateSelected(x, y);
+      if (!this.selectedWidget) return false;
+
+      switch (event) {
+         case CanvasEventTypes.MOUSE_MOVE:
+            this.dispatchEvent(this.selectedWidget, [MenuItemEvents.MOUSE_MOVE, x, y]);
+         break;
+
+         case CanvasEventTypes.MOUSE_CLICK:
+            this.dispatchEvent(this.selectedWidget, [MenuItemEvents.CLICKED, x, y]);
+         break;
+      }
+
+      return true;
+   }
+   
+   handleCanvasWheelEvent(ctx: CanvasRenderingContext2D, event: CanvasEventTypes, deltaX: number, deltaY: number, deltaZ: number, deltaMode: number) {
+      return false;
+   }
+
+   handleCanvasAnimationFrameEvent(ctx: CanvasRenderingContext2D, event: CanvasEventTypes, delta: number) {
+      for (const widget of this.boundWidgets)
+         widget.render(ctx)
+   }
+}
 interface WidgetEvents {
    addEvent: (callback: () => void) => void;
    removeEvent: (callback: () => void) => void;
@@ -406,6 +616,8 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    nextMenuID: number = 0;
 
    openMenu: NewMenu|undefined = undefined;
+
+   readonly manager: RootWidgetManager = new RootWidgetManager();
 
    
 
@@ -447,6 +659,17 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          //TODO: Figure out what type to add/use here
          type: 0
       };
+
+      const buttonOpts: ButtonWidgetConstructor = {
+         x: 100,
+         y: 100,
+         text: "TEST!!!",
+         textFont: "64px Serif",
+         width: 300,
+         height: 300,
+         buttonColor: "#B0B0B0B0"
+      };
+      this.manager.addChild(this.ctx, -10, NewButton, buttonOpts);
    }
 
    getProp(propName: string) {
@@ -474,18 +697,29 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    }
 
    mouseWasOnTopBar: boolean = false;
+   mouseWasOnMenu: boolean = false;
    handleCanvasMouseEvent(event: CanvasEventTypes, x: number, y: number) {
       const n_x = x - BORDER_SIZE;
       const n_y = y - TOP_BAR_SIZE;
       let topBar = false;
       let [menX, menY, menWidth, menHeight] = this.openMenu?.getDimensions() ?? [0, 0, 0, 0];
+      let mouseOnMenu = false;
 
-      if (
+      if (this.manager.handleCanvasMouseEvent(this.ctx, event, x, y)) {
+
+      } else if (
          this.openMenu
          && x >= menX && x <= menX+menWidth
          && y >= menY && y <= menY+menHeight
       ) {
-         console.log("on the menu!!!");
+         // console.log(event);
+         if (event == CanvasEventTypes.MOUSE_MOVE) {
+            this.openMenu.handleMenuEvent([MenuItemEvents.MOUSE_MOVE, x, y]);
+         } else if (event == CanvasEventTypes.MOUSE_CLICK) {
+            this.openMenu.handleMenuEvent([MenuItemEvents.CLICKED, x, y]);
+         }
+         this.mouseWasOnMenu = true;
+         mouseOnMenu = true;
       } else if (
          n_x >= 0 && n_y >= 0
          && n_x <= this.appCanvasWidth
@@ -517,7 +751,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
                case CanvasEventTypes.MOUSE_CLICK:
                {
                   if (inBounds) {
-                     button.handleMenuEvent([MenuItemEvents.CLICKED])
+                     button.handleMenuEvent([MenuItemEvents.CLICKED, n_x, n_y])
                   }
                }
                break;
@@ -532,6 +766,10 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          for (const menu of this.menus.values()) {
             menu[0].handleMenuEvent([MenuItemEvents.UNHOVERED]);
          }
+      }
+      if (!mouseOnMenu && this.mouseWasOnMenu) {
+         this.mouseWasOnMenu = false;
+         this.openMenu?.handleMenuEvent([MenuItemEvents.UNHOVERED]);
       }
       return true;
    }
@@ -571,6 +809,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
 
       this.openMenu?.render(this.ctx);
 
+      this.manager.handleCanvasAnimationFrameEvent(this.ctx, event, delta);
    }
 
    twrGetAppCanvasJSID(mod:IWasmModule|IWasmModuleAsync) {
@@ -613,6 +852,19 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       };
       const menu: NewMenu = tmpManager.addChild(this.ctx, menuID, NewMenu, menuOptions);
       this.menus.set(id, [button, menu]);
+
+      const buttonOptions: ButtonWidgetConstructor = {
+         x: 0,
+         y: 0,
+         text: "Hello!!!",
+         textColor: "black",
+         buttonColor: "#B0B0B0",
+         selectedButtonColor: "#D0D0D0"
+      };
+      const secondButton: NewButton = menu.addChild(this.ctx, ++this.nextMenuItem, NewButton, buttonOptions);
+      secondButton.addEvent(() => {
+         console.log("pressed!!!");
+      });
 
       button.addEvent((() => {
          this.openMenu = menu;

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -316,10 +316,16 @@ class Button implements Widget, WidgetEvents {
    }
 }
 
-interface MenuWidgetConstructor extends WidgetConstructor {
+interface ContainedWidget {
+   widget: Widget,
+   x: number,
+   y: number
 }
-
-class Menu implements Widget, WidgetManager {
+interface Vec2 {
+   x: number,
+   y: number
+}
+abstract class WidgetContainer implements Widget, WidgetManager {
    readonly globalProps: GlobalWidgetProperties;
    readonly parent: WidgetManager;
    readonly id: number;
@@ -331,20 +337,29 @@ class Menu implements Widget, WidgetManager {
       MenuItemEvents.CLICKED_OFF
    ];
    
-   private width?: number;
-   private height?: number;
+   private _width?: number;
+   private _height?: number;
 
-   private children: [Widget, number][] = [];
+   protected children: ContainedWidget[] = [];
 
    private unhoverHandlers: (() => void)[] = [];
    private clickedOffHandlers: (() => void)[] = [];
 
-   private childHeight: number;
-   private childWidth: number;
+   private _calculatedDimensions: Vec2;
+   protected get calculatedDimensions() {return this._calculatedDimensions};
+   protected set calculatedDimensions(val: Vec2) {
+      this._calculatedDimensions = val;
+      if (this._width == undefined || this._height == undefined) {
+         this.parent.childUpdated(this.parent.getCtx());
+      }
+   }
+
+   protected get width() {return this._width};
+   protected get height() {return this._height};
 
    //the currently hovered over/selected item 
    //resets to undefined on menu update or UNHOVERED event
-   private selectedItem?: [Widget, number];
+   private selectedItem?: ContainedWidget;
 
    private _visible: boolean = true;
    
@@ -354,16 +369,18 @@ class Menu implements Widget, WidgetManager {
       this.parent = parent;
       this.id = id;
 
-      this.width = props.width;
-      this.height = props.height;
-      this.childHeight = globalProps.emptyMenuHeight;
-      this.childWidth = globalProps.emptyMenuWidth;
+      this._width = props.width;
+      this._height = props.height;
+      this._calculatedDimensions = {
+         x: globalProps.emptyMenuHeight,
+         y: globalProps.emptyMenuHeight,
+      };
    }
    getCtx() {
       return this.parent.getCtx();
    }
    fullUpdate(ctx: CanvasRenderingContext2D) {
-      for (const [widget,] of this.children) {
+      for (const {widget} of this.children) {
          widget.fullUpdate(ctx);
       }
       this.updateChildSize();
@@ -389,107 +406,41 @@ class Menu implements Widget, WidgetManager {
       if (this.pauseDeleteHandle)
          return;
 
-      // let i = this.children.indexOf(widget);
       for (let i = 0; i < this.children.length; i++) {
-         if (this.children[i][0] == widget) {
+         if (this.children[i].widget == widget) {
             if (i >= 0) {
                this.children.splice(i, 1);
                this.childUpdated(ctx);
+               return;
             }
          }
       }  
    }
+   
    delete(ctx: CanvasRenderingContext2D) {
       this.parent.handleDelete(ctx, this);
       
       this.pauseDeleteHandle = true;
-      let deleted: Widget[] = [];
-      for (const widget of this.children) {
-         deleted = deleted.concat(widget[0].delete(ctx));
+      let deleted: Widget[] = [this];
+      for (const {widget} of this.children) {
+         deleted = deleted.concat(widget.delete(ctx));
       }
-      //push self to list
-      deleted.push(this);
       this.children = [];
       this.updateChildSize();
       this.pauseDeleteHandle = false;
       return deleted;
 
    }
-   openPopup(ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) {
-      let [nX, nY] = [x, y];
-      let nextRelative = relativeChild;
-      if (relativeChild != undefined) {
-         for (const child of this.children) {
-            if (child[0] == relativeChild) {
-               nY += child[1];
-               if (nX > 0)
-                  nX += this.globalProps.menuBorderWidth * 2;
-               else
-                  nX -= this.globalProps.menuBorderWidth;
-               nextRelative = this;
-               break;
-            }
-         }
-      }
-      console.log(`open popup (Menu): (${x}, ${y}); (${nX}, ${nY})`);
-      this.parent.openPopup(ctx, widget, nX, nY, nextRelative);
-   }
+   abstract openPopup(ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget): void;
+
    closePopup(ctx: CanvasRenderingContext2D, widget: Widget) {
       this.parent.closePopup(ctx, widget);
    }
 
-   lastWidth: number = 0;
-   lastHeight: number = 0;
-   supressChildUpdates: boolean = false;
-   updateChildSize(forceRun: boolean = false) {
-      let childWidth = 0;
-      // let maxChildHeight = this.minChildHeight;
-      let childHeight = 0;
-      for (const [widget,] of this.children) {
-         if (!widget.visible)
-            continue;
-         const [width, ] = widget.getMinSize();
-         childWidth = Math.max(childWidth, width);
-         // maxChildHeight = Math.max(maxChildHeight, height+this.yPadding);
-         const [, height] = widget.getDimensions();
-         childHeight += height + this.globalProps.yPadding;
-      }
-      childWidth += this.globalProps.menuBorderWidth * 2;
-      childHeight += this.globalProps.menuBorderWidth * 2;
-
-      // console.log(childWidth, childHeight);
-
-      childWidth = Math.max(childWidth, this.globalProps.emptyMenuWidth);
-      // let childHeight = Math.max(maxChildHeight*this.children.length, this.absoluteMinHeight);
-      childHeight = Math.max(childHeight, this.globalProps.emptyMenuHeight);
-
-      const newWidth = this.width ?? childWidth;
-      const newHeight = this.height ?? childHeight;
-      this.childHeight = childHeight;
-      this.childWidth = childWidth;
-
-      // console.log(newWidth, newHeight, this.childWidth, this.childHeight);
-
-      console.log(`updating width: ${newWidth}; ${this.width}, ${childWidth}`);
-      if (this.lastWidth != newWidth || this.lastHeight != newHeight || forceRun) {
-         this.lastWidth = newWidth;
-         this.lastHeight = newHeight;
-         
-         let curHeight = this.globalProps.menuBorderWidth;
-         for (const widget of this.children) {
-            if (!widget[0].visible)
-               continue;
-            const [, height] = widget[0].getDimensions();
-            this.supressChildUpdates = true;
-            widget[0].setDimensions(newWidth - this.globalProps.menuBorderWidth * 2, undefined);
-            widget[1] = curHeight;
-            this.supressChildUpdates = false;
-            // curHeight += maxChildHeight;
-            curHeight += height + this.globalProps.yPadding;
-         }
-
-      }
-   }
+   // lastWidth: number = 0;
+   // lastHeight: number = 0;
+   protected supressChildUpdates: boolean = false;
+   abstract updateChildSize(forceRun?: boolean): void;
 
    childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot: boolean = false) {
       if (sendToRoot) {
@@ -504,10 +455,14 @@ class Menu implements Widget, WidgetManager {
       T extends Widget, 
       U, 
       O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U, globalProps: GlobalWidgetProperties) => T
-   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
+   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U, x: number, y: number): T {
       const widget: T = new cons(ctx, this, id, props, this.globalProps);
 
-      this.children.push([widget, 0]);
+      this.children.push({
+         widget: widget, 
+         x: x, 
+         y: y
+      });
       this.updateChildSize(true);
       this.parent.childUpdated(ctx, this);
 
@@ -516,8 +471,8 @@ class Menu implements Widget, WidgetManager {
 
    getMinSize(): [number, number] {
       return [
-         this.childWidth, 
-         this.childHeight
+         this._calculatedDimensions.x, 
+         this._calculatedDimensions.y
       ];
    }
 
@@ -527,8 +482,8 @@ class Menu implements Widget, WidgetManager {
 
 		ctx.save();
 
-      const width = this.width ?? this.childWidth;
-      const height = this.height ?? this.childHeight;
+      const width = this._width ?? this._calculatedDimensions.x;
+      const height = this._height ?? this._calculatedDimensions.y;
 
       ctx.fillStyle = this.globalProps.borderColor;
       ctx.fillRect(
@@ -553,8 +508,8 @@ class Menu implements Widget, WidgetManager {
          ctx.closePath();
       }
 
-      for (const widget of this.children) {
-         widget[0].render(ctx, offsetX + menuBorderWidth, offsetY + widget[1] + menuBorderWidth);
+      for (const {widget, x: wX, y: wY} of this.children) {
+         widget.render(ctx, offsetX + wX + menuBorderWidth, offsetY + wY + menuBorderWidth);
       }
 
       ctx.restore();
@@ -566,10 +521,10 @@ class Menu implements Widget, WidgetManager {
       }
    }
 
-   private mouseInWidgetBounds(widget: Widget, widgetY: number, x: number, y: number) {
+   private mouseInWidgetBounds(widgetContainer: ContainedWidget, x: number, y: number) {
+      const {widget, x: widgetX, y: widgetY} = widgetContainer;
       const [widgetWidth, widgetHeight] = widget.getDimensions();
-      const borderWidth = this.globalProps.menuBorderWidth;
-      return borderWidth <= x && x <= borderWidth + widgetWidth
+      return widgetX <= x && x <= widgetX + widgetWidth
             && widgetY <= y && y <= widgetY + widgetHeight;
    }
 
@@ -578,20 +533,20 @@ class Menu implements Widget, WidgetManager {
    private updateSelectedObject(ctx: CanvasRenderingContext2D,x: number, y: number) {
       //check if hovering over selected item
       if (this.selectedItem) {
-         if (this.mouseInWidgetBounds(this.selectedItem[0], this.selectedItem[1], x, y) && this.selectedItem[0].visible) {
+         if (this.mouseInWidgetBounds(this.selectedItem, x, y) && this.selectedItem.widget.visible) {
             return; //the selected item is in bounds
          } else {
             //selected item is out of bounds
-            this.dispatchEvent(ctx, this.selectedItem[0], [MenuItemEvents.UNHOVERED]);
+            this.dispatchEvent(ctx, this.selectedItem.widget, [MenuItemEvents.UNHOVERED]);
             this.selectedItem = undefined;
          }
       }
       //otherwise, find what object (if any) are hovered over
       for (const child of this.children) {
          //found child it's hovering over
-         if (this.mouseInWidgetBounds(child[0], child[1], x, y) && child[0].visible) {
+         if (this.mouseInWidgetBounds(child, x, y) && child.widget.visible) {
             this.selectedItem = child;
-            this.dispatchEvent(ctx, child[0], [MenuItemEvents.HOVERING]);
+            this.dispatchEvent(ctx, child.widget, [MenuItemEvents.HOVERING]);
             //break early
             return;
          }
@@ -606,8 +561,9 @@ class Menu implements Widget, WidgetManager {
             const [, eX, eY] = event;
             this.updateSelectedObject(ctx, eX, eY);
             if (this.selectedItem) {
-               const [x, y] = [eX - this.globalProps.menuBorderWidth, eY - this.selectedItem[1]];
-               this.dispatchEvent(ctx, this.selectedItem[0], [MenuItemEvents.MOUSE_MOVE, x, y]);
+               const {widget, x: wX, y: wY} = this.selectedItem;
+               const [x, y] = [eX - wX, eY - wY];
+               this.dispatchEvent(ctx, widget, [MenuItemEvents.MOUSE_MOVE, x, y]);
             }
          }
          break;
@@ -616,13 +572,13 @@ class Menu implements Widget, WidgetManager {
             const [, eX, eY, button] = event;
             this.updateSelectedObject(ctx, eX, eY);
             const selected = this.selectedItem;
-            for (const [widget,] of this.children) {
-               if (selected == undefined || widget != selected[0])
+            for (const {widget} of this.children) {
+               if (selected == undefined || widget != selected.widget)
                   this.dispatchEvent(ctx, widget, [MenuItemEvents.CLICKED_OFF]);
             }
             if (selected) {
-               const [x, y] = [eX - this.globalProps.menuBorderWidth, eY - selected[1]];
-               this.dispatchEvent(ctx, selected[0], [MenuItemEvents.CLICKED, x, y, button]);
+               const [x, y] = [eX - selected.x, eY - selected.y];
+               this.dispatchEvent(ctx, selected.widget, [MenuItemEvents.CLICKED, x, y, button]);
             }
             
          }
@@ -630,7 +586,7 @@ class Menu implements Widget, WidgetManager {
          case MenuItemEvents.UNHOVERED:
          {
             if (this.selectedItem) {
-               this.dispatchEvent(ctx, this.selectedItem[0], [MenuItemEvents.UNHOVERED]);
+               this.dispatchEvent(ctx, this.selectedItem.widget, [MenuItemEvents.UNHOVERED]);
                this.selectedItem = undefined;
             }
             for (const handler of this.unhoverHandlers) {
@@ -643,8 +599,8 @@ class Menu implements Widget, WidgetManager {
             for (const handler of this.clickedOffHandlers) {
                handler();
             }
-            for (const widget of this.children)
-               this.dispatchEvent(ctx, widget[0], [MenuItemEvents.CLICKED_OFF]);
+            for (const {widget} of this.children)
+               this.dispatchEvent(ctx, widget, [MenuItemEvents.CLICKED_OFF]);
          }
          break;
       }
@@ -652,23 +608,23 @@ class Menu implements Widget, WidgetManager {
 
    getDimensions(): [number, number] {
       return [
-         this.width ?? this.childWidth,
-         this.height ?? this.childHeight
+         this._width ?? this._calculatedDimensions.x,
+         this._height ?? this._calculatedDimensions.y
       ];
 	}
 
    setDimensions(width?: number, height?: number): void {
       if (width != undefined){
          if (width == 0)
-            this.width = undefined;
+            this._width = undefined;
          else
-            this.width = width;
+            this._width = width;
       }
       if (height != undefined){
          if (height == 0)
-            this.height = undefined;
+            this._height = undefined;
          else
-            this.height = height;
+            this._height = height;
       }
 	}
 
@@ -692,6 +648,99 @@ class Menu implements Widget, WidgetManager {
       }
    }
 
+}
+
+interface MenuWidgetConstructor extends WidgetConstructor {
+}
+
+class Menu extends WidgetContainer {
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
+      super(ctx, parent, id, props, globalProps);
+   }
+   getCtx() {
+      return this.parent.getCtx();
+   }
+   openPopup(ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) {
+      let [nX, nY] = [x, y];
+      let nextRelative = relativeChild;
+      if (relativeChild != undefined) {
+         for (const {widget, y: wY} of this.children) {
+            if (widget == relativeChild) {
+               nY += wY;
+               if (nX > 0)
+                  nX += this.globalProps.menuBorderWidth * 2;
+               else
+                  nX -= this.globalProps.menuBorderWidth;
+               nextRelative = this;
+               break;
+            }
+         }
+      }
+      console.log(`open popup (Menu): (${x}, ${y}); (${nX}, ${nY})`);
+      this.parent.openPopup(ctx, widget, nX, nY, nextRelative);
+   }
+
+   lastWidth: number = 0;
+   lastHeight: number = 0;
+   supressChildUpdates: boolean = false;
+   updateChildSize(forceRun: boolean = false) {
+      let childWidth = 0;
+      // let maxChildHeight = this.minChildHeight;
+      let childHeight = 0;
+      for (const {widget} of this.children) {
+         if (!widget.visible)
+            continue;
+         const [width, ] = widget.getMinSize();
+         childWidth = Math.max(childWidth, width);
+         // maxChildHeight = Math.max(maxChildHeight, height+this.yPadding);
+         const [, height] = widget.getDimensions();
+         childHeight += height + this.globalProps.yPadding;
+      }
+      childWidth += this.globalProps.menuBorderWidth * 2;
+      childHeight += this.globalProps.menuBorderWidth * 2;
+
+      // console.log(childWidth, childHeight);
+
+      childWidth = Math.max(childWidth, this.globalProps.emptyMenuWidth);
+      // let childHeight = Math.max(maxChildHeight*this.children.length, this.absoluteMinHeight);
+      childHeight = Math.max(childHeight, this.globalProps.emptyMenuHeight);
+
+      const newWidth = super.width ?? childWidth;
+      const newHeight = super.height ?? childHeight;
+      super.calculatedDimensions = {
+         x: newWidth,
+         y: newHeight
+      };
+
+      // console.log(newWidth, newHeight, this.childWidth, this.childHeight);
+
+      console.log(`updating width: ${newWidth}; ${super.width}, ${childWidth}`);
+      if (this.lastWidth != newWidth || this.lastHeight != newHeight || forceRun) {
+         this.lastWidth = newWidth;
+         this.lastHeight = newHeight;
+         
+         let curHeight = this.globalProps.menuBorderWidth;
+         for (const child of this.children) {
+            if (!child.widget.visible)
+               continue;
+            const [, height] = child.widget.getDimensions();
+            this.supressChildUpdates = true;
+            child.widget.setDimensions(newWidth - this.globalProps.menuBorderWidth * 2, undefined);
+            child.y = curHeight;
+            this.supressChildUpdates = false;
+            // curHeight += maxChildHeight;
+            curHeight += height + this.globalProps.yPadding;
+         }
+
+      }
+   }
+   addChild<
+      T extends Widget, 
+      U, 
+      O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U, globalProps: GlobalWidgetProperties) => T
+   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
+      return super.addChild(ctx, id, cons, props, this.globalProps.menuBorderWidth, 0);
+   }
 }
 
 interface RadioMenuWidgetConstructor extends MenuWidgetConstructor {
@@ -1829,38 +1878,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
 
       this.widgets.set(id, [WidgetType.SubMenu, button]);
 
-      // const subMenuOpts: MenuButtonWidgetConstructor = {
-      //    menuOptions: menuOptions,
-      //    height: TOP_BAR_SIZE - 0.5,
-      //    text: "hello there",
-      //    textColor: "black",
-      //    buttonColor: "#B0B0B0",
-      //    selectedButtonColor: "#D0D0D0",
-      //    openToRight: true,
-      //    suffixText: "▶",
-      // };
-      // const subMenu: MenuButton = button.addChild(this.ctx, 0, MenuButton, subMenuOpts);
-      // subMenu.addChild(this.ctx, 0, Button, {
-      //    height: TOP_BAR_SIZE - 0.5,
-      //    text: text,
-      //    textColor: "black",
-      //    buttonColor: "#B0B0B0",
-      //    selectedButtonColor: "#D0D0D0",
-      // });
-      // const subSubMenu: MenuButton = subMenu.addChild(this.ctx, 0, MenuButton, subMenuOpts);
-
-      // const checkBoxOpts: CheckBoxWidgetConstructor = {
-      //    text: "testBox!",
-      //    textColor: "black",
-      //    buttonColor: "#B0B0B0",
-      //    selectedButtonColor: "#D0D0D0",
-      //    checkedSymbol: "☑",
-      //    unCheckedSymbol: "☐",
-      // };
-      // const checkBox: CheckBox = subSubMenu.addChild(this.ctx, 0, CheckBox, checkBoxOpts);
-      // checkBox.addEvent((ctx: CanvasRenderingContext2D, selected: boolean) => {
-      //    console.log(`clicked: ${selected}!`);
-      // });
 
       return id;
    }

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -98,8 +98,8 @@ abstract class WidgetImpl implements Widget {
    readonly id: number;
    abstract readonly handledEvents: MenuItemEvents[];
 
-   protected abstract _width: number;
-   protected abstract _height: number;
+   protected abstract _width?: number;
+   protected abstract _height?: number;
    protected _visible: boolean = true;
 
    constructor(globalProps: GlobalWidgetProperties, parent: WidgetManager, cons: WidgetConstructor) {
@@ -126,21 +126,23 @@ abstract class WidgetImpl implements Widget {
    }
    get visible() {return this._visible};
 
-   set width(val: number) {
+   set width(val: number|undefined) {
       if (this._width != val) {
          this._width = val;
          this.propagateUpdate();
       }
    }
    get width() {return this._width};
+   abstract get usedWidth(): number;
 
-   set height(val: number) {
+   set height(val: number|undefined) {
       if (this._height != val) {
          this._height = val;
          this.propagateUpdate();
       }
    }
    get height() {return this._height};
+   abstract get usedHeight(): number;
 
 
 }
@@ -150,7 +152,7 @@ abstract class WidgetImpl implements Widget {
 // they are sort of auto implemented on any class that match their requirements
 // So this is "automatically" implemented on any class that implements the given constructor fields
 interface WidgetCreation<T extends Widget, U extends WidgetConstructor> {
-   new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, cons: U, globalProps: GlobalWidgetProperties): T
+   new (ctx: CanvasRenderingContext2D, parent: WidgetManager, cons: U, globalProps: GlobalWidgetProperties): T
 }
 
 interface WidgetConstructor {
@@ -179,8 +181,8 @@ class Button extends WidgetImpl implements WidgetEvents {
    // private width: number;
    // private height: number;
 
-   protected _width: number;
-   protected _height: number;
+   protected _width?: number;
+   protected _height?: number;
 
    // private updateProperty() {
    //    const ctx = this.parent.getCtx();
@@ -228,7 +230,7 @@ class Button extends WidgetImpl implements WidgetEvents {
       }
    };
 
-   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, cons: ButtonWidgetConstructor, globalProps: GlobalWidgetProperties) {
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, cons: ButtonWidgetConstructor, globalProps: GlobalWidgetProperties) {
       super(globalProps, parent, cons);
       // this.parent = parent;
       // this.id = id;
@@ -241,11 +243,11 @@ class Button extends WidgetImpl implements WidgetEvents {
 
       this.reservePrefixSpace = cons.reservePrefixSpace ?? true;
 
-      this.updateCalculatedFields(ctx);
-      const [minWidth, minHeight] = this.getMinSize();
-      console.log(`defaults (minWidth, minHeight): (${minWidth}, ${minHeight})`);
-      this._width = cons.width ?? minWidth;
-      this._height = cons.height ?? minHeight;
+      // this.updateCalculatedFields(ctx);
+      // const [minWidth, minHeight] = this.getMinSize();
+      // console.log(`defaults (minWidth, minHeight): (${minWidth}, ${minHeight})`);
+      this._width = cons.width/* ?? minWidth*/;
+      this._height = cons.height/* ?? minHeight*/;
       // this.calculatedWidth = minWidth;
       // this.calculatedHeight = minHeight;
       // this.width = cons.width ?? minWidth;
@@ -281,10 +283,10 @@ class Button extends WidgetImpl implements WidgetEvents {
       }
 
       textOffsets.mainTextX = this.centeredHorizontally 
-         ? (this.width - (minWidth - minPrefix - minSuffix))/2.0 
+         ? (this.usedWidth - (minWidth - minPrefix - minSuffix))/2.0 
          : minPrefix;
       
-      textOffsets.y = (this.height + getHeight(ctx, this.getFont()))/2.0;
+      textOffsets.y = (this.usedHeight + getHeight(ctx, this.getFont()))/2.0;
       textOffsets.suffixX = minSuffix;
       console.log(`test: ${textOffsets.mainTextX}, ${textOffsets.y}, ${textOffsets.suffixX}, ${minPrefix}, ${minWidth}, ${minSuffix}, ${this.width}, ${this.height}, ${getHeight(ctx, this.getFont())}, ${minSuffix}`);
    }
@@ -313,8 +315,8 @@ class Button extends WidgetImpl implements WidgetEvents {
 
    getDimensions(): [number, number] {
       return [
-         this.width, 
-         this.height
+         this.usedWidth, 
+         this.usedHeight
       ];
    }
    setDimensions(width?: number, height?: number) {
@@ -378,6 +380,12 @@ class Button extends WidgetImpl implements WidgetEvents {
          this.calculatedFields.height
       ]
    }
+   get usedWidth() {
+      return this._width ?? this.calculatedFields.width;
+   }
+   get usedHeight() {
+      return this._height ?? this.calculatedFields.height;
+   }
    // getTextOffsets(ctx: CanvasRenderingContext2D): [number, number, number] {
    //    const [minWidth, minHeight, minPrefix, minSuffix] = this.getFullMinSize(ctx);
 
@@ -413,7 +421,7 @@ class Button extends WidgetImpl implements WidgetEvents {
 
       const button_color = this.mousedOver ? this.globalProps.selectedColor : this.globalProps.borderColor;
       ctx.fillStyle = button_color;
-      ctx.fillRect(offsetX, offsetY, this._width, this._height);
+      ctx.fillRect(offsetX, offsetY, this.usedWidth, this.usedHeight);
 
       // ctx.font = this.globalProps.widgetTextFont;
       ctx.font = this.getFont();
@@ -433,7 +441,7 @@ class Button extends WidgetImpl implements WidgetEvents {
       if (this._suffixText != undefined) {
          ctx.fillText(
             " " + this._suffixText,
-            offsetX + (this._width - textOffsets.suffixX),
+            offsetX + (this.usedWidth - textOffsets.suffixX),
             textOffsets.y + offsetY
          );
       }
@@ -487,10 +495,10 @@ interface Vec2 {
    x: number,
    y: number
 }
-abstract class WidgetContainer implements Widget, WidgetManager {
-   readonly globalProps: GlobalWidgetProperties;
-   readonly parent: WidgetManager;
-   readonly id: number;
+abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
+   // readonly globalProps: GlobalWidgetProperties;
+   // readonly parent: WidgetManager;
+   // readonly id: number;
 
    readonly handledEvents: MenuItemEvents[] = [
       MenuItemEvents.CLICKED,
@@ -499,8 +507,8 @@ abstract class WidgetContainer implements Widget, WidgetManager {
       MenuItemEvents.CLICKED_OFF
    ];
    
-   private _width?: number;
-   private _height?: number;
+   protected _width?: number;
+   protected _height?: number;
 
    protected children: ContainedWidget[] = [];
 
@@ -516,21 +524,22 @@ abstract class WidgetContainer implements Widget, WidgetManager {
       }
    }
 
-   protected get width() {return this._width};
-   protected get height() {return this._height};
+   // protected get width() {return this._width};
+   // protected get height() {return this._height};
 
    //the currently hovered over/selected item 
    //resets to undefined on menu update or UNHOVERED event
    private selectedItem?: ContainedWidget;
 
-   private _visible: boolean = true;
+   // private _visible: boolean = true;
    private _drawOutline: boolean;
    get drawOutline() {return this._drawOutline};
    
-   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
-      this.globalProps = globalProps;
-      this.parent = parent;
-      this.id = id;
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, props: MenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
+      super(globalProps, parent, {});
+      // this.globalProps = globalProps;
+      // this.parent = parent;
+      // this.id = id;
 
       this._width = props.width;
       this._height = props.height;
@@ -552,18 +561,27 @@ abstract class WidgetContainer implements Widget, WidgetManager {
       this.selectedItem = undefined;
    }
 
-   set visible(visible: boolean) {
-      const ctx = this.parent.getCtx();
-      if (this._visible != visible) {
-         if (!visible)
-            this.handleMenuEvent(ctx, [MenuItemEvents.CLICKED_OFF]);
+   // set visible(visible: boolean) {
+   //    const ctx = this.parent.getCtx();
+   //    if (this._visible != visible) {
+   //       if (!visible)
+   //          this.handleMenuEvent(ctx, [MenuItemEvents.CLICKED_OFF]);
 
-         this._visible = visible;
-         this.parent.childUpdated(ctx, this, false);
+   //       this._visible = visible;
+   //       this.parent.childUpdated(ctx, this, false);
+   //    }
+   // }
+   // get visible() {
+   //    return this._visible;
+   // }
+
+   protected propagateUpdate(ctx?: CanvasRenderingContext2D): void {
+      const n_ctx = ctx ?? this.parent.getCtx();
+      this.handleMenuEvent(n_ctx, [MenuItemEvents.CLICKED_OFF]);
+
+      if (this._visible) {
+         this.updateChildSize();
       }
-   }
-   get visible() {
-      return this._visible;
    }
 
    pauseDeleteHandle: boolean = false;
@@ -619,8 +637,8 @@ abstract class WidgetContainer implements Widget, WidgetManager {
    protected addChild<
       T extends Widget,
       U extends WidgetConstructor,
-   >(ctx: CanvasRenderingContext2D, id: number, cons: WidgetCreation<T, U>, props: U, x: number, y: number): T {
-      const widget: T = new cons(ctx, this, id, props, this.globalProps);
+   >(ctx: CanvasRenderingContext2D, cons: WidgetCreation<T, U>, props: U, x: number, y: number): T {
+      const widget: T = new cons(ctx, this, props, this.globalProps);
 
       this.children.push({
          widget: widget, 
@@ -776,6 +794,12 @@ abstract class WidgetContainer implements Widget, WidgetManager {
          this._height ?? this._calculatedDimensions.y
       ];
 	}
+   get usedWidth() {
+      return this._width ?? this._calculatedDimensions.x;
+   }
+   get usedHeight() {
+      return this._height ?? this._calculatedDimensions.y;
+   }
 
    setDimensions(width?: number, height?: number): void {
       if (width != undefined){
@@ -819,8 +843,8 @@ interface MenuWidgetConstructor extends WidgetConstructor {
 }
 
 class Menu extends WidgetContainer {
-   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
-      super(ctx, parent, id, props, globalProps);
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, props: MenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
+      super(ctx, parent, props, globalProps);
    }
    getCtx() {
       return this.parent.getCtx();
@@ -902,14 +926,14 @@ class Menu extends WidgetContainer {
    addChild<
       T extends Widget,
       U extends WidgetConstructor,
-   >(ctx: CanvasRenderingContext2D, id: number, cons: WidgetCreation<T, U>, props: U): T {
-      return super.addChild(ctx, id, cons, props, this.globalProps.menuBorderWidth, 0);
+   >(ctx: CanvasRenderingContext2D, cons: WidgetCreation<T, U>, props: U): T {
+      return super.addChild(ctx, cons, props, this.globalProps.menuBorderWidth, 0);
    }
 }
 
 class MenuBar extends WidgetContainer {
-   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
-      super(ctx, parent, id, props, globalProps);
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, props: MenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
+      super(ctx, parent, props, globalProps);
    }
 
    protected updateChildSize(forceRun?: boolean) {
@@ -957,9 +981,9 @@ class MenuBar extends WidgetContainer {
    addChild<
       T extends Widget,
       U extends WidgetConstructor,
-   >(ctx: CanvasRenderingContext2D, id: number, cons: WidgetCreation<T, U>, props: U): T {
+   >(ctx: CanvasRenderingContext2D, cons: WidgetCreation<T, U>, props: U): T {
       return super.addChild(
-         ctx, id, cons, props,
+         ctx, cons, props,
          0, super.drawOutline ? this.globalProps.menuBorderWidth/2 : 0
       );
    }
@@ -1006,8 +1030,8 @@ class RootWidgetManager implements WidgetManager {
    addChild<
       T extends Widget,
       U extends WidgetConstructor,
-   >(ctx: CanvasRenderingContext2D, id: number, cons: WidgetCreation<T, U>, props: U, globalProps: GlobalWidgetProperties, x: number, y: number): T {
-      const widget: T = new cons(ctx, this, id, props, globalProps);
+   >(ctx: CanvasRenderingContext2D, cons: WidgetCreation<T, U>, props: U, globalProps: GlobalWidgetProperties, x: number, y: number): T {
+      const widget: T = new cons(ctx, this, props, globalProps);
       
       this.boundWidgets.push([widget, x, y]);
 
@@ -1159,12 +1183,12 @@ class MenuButton extends Button implements WidgetManager {
 
    private menuOpened: boolean = false;
 
-   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuButtonWidgetConstructor, globalProps: GlobalWidgetProperties) {
-      super(ctx, parent, id, props, globalProps);
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, props: MenuButtonWidgetConstructor, globalProps: GlobalWidgetProperties) {
+      super(ctx, parent, props, globalProps);
 
       this.openToRight = props.openToRight ?? false;
       this.offset = props.offset ?? 0;
-      this.menu = new Menu(ctx, this, 1, {
+      this.menu = new Menu(ctx, this, {
          width: props.menuWidth,
          height: props.menuHeight,
          drawOutline: true,
@@ -1228,8 +1252,8 @@ class MenuButton extends Button implements WidgetManager {
    addChild<
       T extends Widget,
       U extends WidgetConstructor,
-   >(ctx: CanvasRenderingContext2D, id: number, cons: WidgetCreation<T, U>, props: U): T {
-      return this.menu.addChild(ctx, id, cons, props);
+   >(ctx: CanvasRenderingContext2D, cons: WidgetCreation<T, U>, props: U): T {
+      return this.menu.addChild(ctx, cons, props);
    }
    openPopup(ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) {
       this.parent.openPopup(ctx, widget, x, y, relativeChild);
@@ -1242,16 +1266,19 @@ class MenuButton extends Button implements WidgetManager {
 interface SeperatorWidgetConstructor extends WidgetConstructor {
    seperatorText: string,
 }
-class Seperator implements Widget {
-   readonly globalProps: GlobalWidgetProperties;
-   readonly parent: WidgetManager;
-   readonly id: number;
+class Seperator extends WidgetImpl {
+   // readonly globalProps: GlobalWidgetProperties;
+   // readonly parent: WidgetManager;
+   // readonly id: number;
    readonly handledEvents: MenuItemEvents[] = [];
 
    private seperatorText: string;
 
-   private width: number;
-   private height: number;
+   // private width: number;
+   // private height: number;
+   protected _width?: number;
+   protected _height?: number;
+
    private minHeight: number = 0;
 
    private _text: string = "";
@@ -1261,33 +1288,37 @@ class Seperator implements Widget {
    set text(val: string) {this._text = val; this.fullUpdate(this.parent.getCtx())};
    get text(): string {return this._text};
 
-   private _visible: boolean = true;
+   // private _visible: boolean = true;
 
-   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: SeperatorWidgetConstructor, globalProps: GlobalWidgetProperties) {
-      this.globalProps = globalProps;
-      this.parent = parent;
-      this.id = id;
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, props: SeperatorWidgetConstructor, globalProps: GlobalWidgetProperties) {
+      super(globalProps, parent, {});
+      // this.globalProps = globalProps;
+      // this.parent = parent;
+      // // this.id = id;
+      // this.id = ++NEXT_WIDGET_ID;
       
       this.seperatorText = props.seperatorText;
 
-      this.width = props.width ?? 0;
-      this.height = props.height ?? 0;
-      
+      // this.width = props.width ?? 0;
+      // this.height = props.height ?? 0;
+      this._width = props.width;
+      this._height = props.height;
+
       this.updateText(ctx);
    }
    fullUpdate(ctx: CanvasRenderingContext2D) {
       this.updateText(ctx);
    }
 
-   set visible(visible: boolean) {
-      if (this._visible != visible) {
-         this._visible = visible;
-         this.parent.childUpdated(this.parent.getCtx(), this, false);
-      }
-   }
-   get visible() {
-      return this._visible;
-   }
+   // set visible(visible: boolean) {
+   //    if (this._visible != visible) {
+   //       this._visible = visible;
+   //       this.parent.childUpdated(this.parent.getCtx(), this, false);
+   //    }
+   // }
+   // get visible() {
+   //    return this._visible;
+   // }
 
    delete(ctx: CanvasRenderingContext2D) {
       this.parent.handleDelete(ctx, this);
@@ -1300,22 +1331,29 @@ class Seperator implements Widget {
       ctx.font = this.globalProps.widgetTextFont;
       const metrics = ctx.measureText(this.seperatorText);
 
-      const repeats = Math.floor(this.width/metrics.width);
+      const repeats = Math.floor(this.usedWidth/metrics.width);
       const width = repeats*metrics.width;
       const height = metrics.actualBoundingBoxAscent;
+      this.minHeight = height;
 
       this._text = this.seperatorText.repeat(repeats);
 
-      this.textXOffset = (this.width - width)/2.0;
+      this.textXOffset = (this.usedWidth - width)/2.0;
       // console.log(width, this.width, this.textXOffset);
-      this.textYOffset = (this.height + height)/2.0;
-      this.minHeight = height;
+      this.textYOffset = (this.usedHeight + height)/2.0;
+      
 
       ctx.restore();
    }
 
    getMinSize(): [number, number] {
       return [0, this.minHeight];
+   }
+   get usedWidth() {
+      return this._width ?? 0;
+   }
+   get usedHeight() {
+      return this._height ?? (this.usedWidth == 0 ? 0 : this.minHeight);
    }
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
       if (!this._visible)
@@ -1339,13 +1377,17 @@ class Seperator implements Widget {
       throw new Error(`Seperator widget doesn't accept events!!`);
    }
    getDimensions(): [number, number] {
-      return [this.width, this.height];
+      return [this.usedWidth, this.usedHeight];
+   }
+   protected propagateUpdate(ctx?: CanvasRenderingContext2D): void {
+      this.updateText(ctx ?? this.parent.getCtx());
    }
    setDimensions(width?: number, height?: number) {
       this.width = width ?? this.width;
       this.height = height ?? this.height;
       if (width != undefined || height != undefined) {
-         this.updateText(this.parent.getCtx());
+         // this.updateText(this.parent.getCtx());
+         this.propagateUpdate();
       }
    }
 }
@@ -1373,8 +1415,8 @@ class CheckBox extends Button {
       }
          
    }
-   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, cons: ButtonWidgetConstructor, globalProps: GlobalWidgetProperties) {
-      super(ctx, parent, id, cons, globalProps);
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, cons: ButtonWidgetConstructor, globalProps: GlobalWidgetProperties) {
+      super(ctx, parent, cons, globalProps);
 
       super.prefixText = globalProps.checkBoxUncheckedPrefix;
       
@@ -1431,8 +1473,8 @@ class RadioItem extends Button {
    private _selected = true;
    private radioGroup: RadioItemGroup;
 
-   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, cons: ButtonWidgetConstructor, globalProps: GlobalWidgetProperties) {
-      super(ctx, parent, id, cons, globalProps);
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, cons: ButtonWidgetConstructor, globalProps: GlobalWidgetProperties) {
+      super(ctx, parent, cons, globalProps);
 
       this.radioGroup = new RadioItemGroup(this, this.deselect.bind(this), this.setRadioGroup.bind(this));
 
@@ -1522,7 +1564,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       | [WidgetType.CheckBox, CheckBox]
    > = new Map();
    
-   nextWidgetID: number = 0;
+   // nextWidgetID: number = 0;
 
    readonly manager: RootWidgetManager;
    readonly menu: MenuBar;
@@ -1613,7 +1655,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          // xPadding: MENU_PADDING_X,
       };
       console.log(`Menu Bar target size: ${menuBarCons.height}, ${TOP_BAR_SIZE - 0.5}`);
-      this.menu = this.manager.addChild(this.ctx, 0, MenuBar, menuBarCons, this.widgetSettings, BORDER_SIZE + MENU_PADDING_X, 0);
+      this.menu = this.manager.addChild(this.ctx, MenuBar, menuBarCons, this.widgetSettings, BORDER_SIZE + MENU_PADDING_X, 0);
    }
 
    getProp(propName: string) {
@@ -1699,7 +1741,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    twrWindowAddMenu(mod: IWasmModuleAsync | IWasmModule, textPtr: number) {
       const text = mod.getString(textPtr);
 
-      const id = ++this.nextWidgetID;
+      // const id = ++this.nextWidgetID;
 
       const menuOptions: MenuWidgetConstructor = {
          // menuColor: "#B0B0B0",
@@ -1709,7 +1751,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          // borderColor: "black"
       };
 
-      const button: MenuButton = this.menu.addChild(this.ctx, id, MenuButton, {
+      const button: MenuButton = this.menu.addChild(this.ctx, MenuButton, {
          height: TOP_BAR_SIZE - 0.5,
          text: text,
          textColor: "black",
@@ -1720,10 +1762,10 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          reservePrefixSpace: false,
       });
 
-      this.widgets.set(id, [WidgetType.SubMenu, button]);
+      this.widgets.set(button.id, [WidgetType.SubMenu, button]);
 
 
-      return id;
+      return button.id;
    }
 
    twrWindowMenuAddWidget(mod: IWasmModuleAsync | IWasmModule, menuID: number, consPtr: number): number {
@@ -1769,7 +1811,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
 
       const extraPtr = consPtr + 12;
 
-      const id = ++this.nextWidgetID;
+      // const id = ++this.nextWidgetID;
       switch (type) {
          case WidgetType.Button:
          {
@@ -1788,8 +1830,9 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
                // buttonColor: this.widgetSettings.borderColor,
                // selectedButtonColor: this.widgetSettings.selectedColor,
             };
-            const widget: Button = menu.addChild(this.ctx, id, Button, button);
-            this.widgets.set(id, [WidgetType.Button, widget]);
+            const widget: Button = menu.addChild(this.ctx, Button, button);
+            this.widgets.set(widget.id, [WidgetType.Button, widget]);
+            return widget.id;
          }
          break;
 
@@ -1810,8 +1853,9 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
                // seperatorFont: getStringOrDef(extraPtr + 4, this.widgetSettings.widgetTextFont),
                // seperatorColor: this.widgetSettings.textColor
             };
-            const widget: Seperator = menu.addChild(this.ctx, id, Seperator, seperator);
-            this.widgets.set(id, [WidgetType.Seperator, widget]);
+            const widget: Seperator = menu.addChild(this.ctx, Seperator, seperator);
+            this.widgets.set(widget.id, [WidgetType.Seperator, widget]);
+            return widget.id;
          }
          break;
 
@@ -1829,8 +1873,9 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
                height: height,
                text: getStringOrDef(extraPtr + 0, "Lorem Ipsum"),
             };
-            const radioItem: RadioItem = menu.addChild(this.ctx, id, RadioItem, cons);
-            this.widgets.set(id, [WidgetType.RadioItem, radioItem]);
+            const radioItem: RadioItem = menu.addChild(this.ctx, RadioItem, cons);
+            this.widgets.set(radioItem.id, [WidgetType.RadioItem, radioItem]);
+            return radioItem.id;
          }
          break;
 
@@ -1878,8 +1923,9 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
                openToRight: true,
                suffixText: "▶",
             };
-            const subMenu: MenuButton = menu.addChild(this.ctx, id, MenuButton, cons);
-            this.widgets.set(id, [WidgetType.SubMenu, subMenu]);
+            const subMenu: MenuButton = menu.addChild(this.ctx, MenuButton, cons);
+            this.widgets.set(subMenu.id, [WidgetType.SubMenu, subMenu]);
+            return subMenu.id;
          }
          break;
 
@@ -1915,8 +1961,9 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
                // buttonColor: this.widgetSettings.borderColor,
                // selectedButtonColor: this.widgetSettings.selectedColor,
             };
-            const widget: CheckBox = menu.addChild(this.ctx, id, CheckBox, props);
-            this.widgets.set(id, [WidgetType.CheckBox, widget]);
+            const widget: CheckBox = menu.addChild(this.ctx, CheckBox, props);
+            this.widgets.set(widget.id, [WidgetType.CheckBox, widget]);
+            return widget.id;
          }
          break;
 
@@ -1927,7 +1974,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          break;
       }
 
-      return id;
+      // return id;
    }
 
    twrWindowMenuWidgetAddCallback(mod: IWasmModuleAsync | IWasmModule, widgetID: number, eventID: number, extraPtr: number) {

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -896,191 +896,15 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
 interface MenuBarWidgetConstructor extends WidgetConstructor {
 }
 
-class MenuBar implements Widget, WidgetManager {
-   readonly globalProps: GlobalWidgetProperties;
-   readonly parent: WidgetManager;
-   readonly id: number;
-   readonly handledEvents: MenuItemEvents[] = [
-      MenuItemEvents.CLICKED,
-      MenuItemEvents.CLICKED_OFF,
-      MenuItemEvents.UNHOVERED,
-      MenuItemEvents.MOUSE_MOVE
-   ];
-
-   private width?: number;
-   private height?: number;
-
-   private calcHeight;
-   private calcWidth;
-
-   private children: [Widget, number][] = [];
-
-   private supressChildUpdates = false;
-
-   private _visible: boolean = true;
-
+class MenuBar extends WidgetContainer {
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuBarWidgetConstructor, globalProps: GlobalWidgetProperties) {
-      this.globalProps = globalProps;
-      this.parent = parent;
-      this.id = id;
-
-      this.width = props.width;
-      this.height = props.height;
-
-      this.calcWidth = this.globalProps.emptyMenuWidth;
-      this.calcHeight = this.globalProps.emptyMenuWidth;
-   }
-   getCtx() {
-      return this.parent.getCtx();
+      super(ctx, parent, id, props, globalProps);
    }
 
-   fullUpdate(ctx: CanvasRenderingContext2D) {
-      for (const [widget,] of this.children) {
-         widget.fullUpdate(ctx);
-      }
-   }
-
-   set visible(visible: boolean) {
-      const ctx = this.parent.getCtx();
-      if (!this._visible != visible) {
-         if (!visible)
-            this.handleMenuEvent(ctx, [MenuItemEvents.CLICKED_OFF]);
-         this._visible = visible;
-         this.parent.childUpdated(ctx, this, false);
-      }
-   }
-   get visible() {
-      return this._visible;
-   }
-
-   getMinSize(): [number, number] {
-      return [this.calcWidth, this.calcHeight];
-   }
-   render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
-      if (!this._visible)
-         return;
-
-      for (let i = this.children.length-1; i >= 0; i--) {
-         const [widget, widgetX] = this.children[i];
-         widget.render(
-            ctx,
-            widgetX + offsetX,
-            offsetY
-         );
-      }
-   };
-
-   private selected?: [Widget, number];
-   private dispatchEvent(ctx: CanvasRenderingContext2D, widget: Widget, event: MenuItemEventData) {
-      if (widget.handledEvents.includes(event[0])) {
-         widget.handleMenuEvent(ctx, event);
-      }
-   }
-   private mouseInWidgetBounds(widget: Widget, widgetX: number, x: number, y: number) {
-      const [widgetWidth, widgetHeight] = widget.getDimensions();
-      return widgetX <= x && x <= widgetX + widgetWidth
-            && 0 <= y && y <= widgetHeight;
-   }
-   private updateSelected(ctx: CanvasRenderingContext2D, x: number, y: number) {
-      if (this.selected) {
-         if (this.mouseInWidgetBounds(this.selected[0], this.selected[1], x, y) && this.selected[0].visible) {
-            return;
-         } else {
-            this.dispatchEvent(ctx, this.selected[0], [MenuItemEvents.UNHOVERED]);
-            this.selected = undefined;
-         }
-      }
-
-      for (const widget of this.children) {
-         if (this.mouseInWidgetBounds(widget[0], widget[1], x, y) && widget[0].visible) {
-            this.selected = widget;
-            this.dispatchEvent(ctx, widget[0], [MenuItemEvents.HOVERING]);
-            return;
-         }
-      }
-   }
-   handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
-      if (!this._visible)
-         return;
-
-      switch (event[0]) {
-         case MenuItemEvents.MOUSE_MOVE:
-         {
-            const [,eX, eY] = event;
-            this.updateSelected(ctx, eX, eY);
-            if (this.selected) {
-               const [x, y] = [eX - this.selected[1], eY];
-               this.dispatchEvent(ctx, this.selected[0], [MenuItemEvents.MOUSE_MOVE, x, y]);
-            }
-         }
-         break;
-         case MenuItemEvents.CLICKED:
-         {
-            const [,eX, eY, button] = event;
-            this.updateSelected(ctx, eX, eY);
-            if (this.selected) {
-               const [x, y] = [eX - this.selected[1], eY];
-               this.dispatchEvent(ctx, this.selected[0], [MenuItemEvents.CLICKED, x, y, button]);
-            }
-         }
-         break;
-         case MenuItemEvents.UNHOVERED:
-         {
-            if (this.selected)
-               this.dispatchEvent(ctx, this.selected[0], [MenuItemEvents.UNHOVERED]);
-            this.selected = undefined;
-         }
-         break;
-
-         case MenuItemEvents.CLICKED_OFF:
-         {
-            if (this.selected) {
-               this.dispatchEvent(ctx, this.selected[0], [MenuItemEvents.UNHOVERED]);
-            }
-            this.selected = undefined;
-
-            for (const widget of this.children) {
-               this.dispatchEvent(ctx, widget[0], [MenuItemEvents.CLICKED_OFF]);
-            }
-
-         }
-         break;
-
-         default:
-         {
-            throw new Error(`MenuBar HandleMenuEvent: Error! Was given an unhandled event (${MenuItemEvents[event[0]]})!`);
-         }
-         break;
-      }
-   }
-   getDimensions(): [number, number] {
-      return [
-         this.width ?? this.calcWidth,
-         this.height ?? this.calcHeight
-      ];
-   }
-   setDimensions(width?: number, height?: number) {
-      this.width = width ?? this.width;
-      this.height = height ?? this.height;
-      const ctx = this.parent.getCtx();
-      this.parent.childUpdated(ctx, this);
-   }
-   delete(ctx: CanvasRenderingContext2D): Widget[] {
-      this.supressChildUpdates = true;
-      let deleted: Widget[] = [this];
-      for (const widget of this.children) {
-         deleted.push(...widget[0].delete(ctx));
-      }
-      this.children = [];
-      this.supressChildUpdates = false;
-      return deleted;
-   }
-   private updateChildren() {
-      this.selected = undefined;
-
+   updateChildSize(forceRun?: boolean) {
       let minHeight = this.globalProps.emptyMenuWidth;
       let width = 0;
-      for (const [widget,] of this.children) {
+      for (const {widget} of this.children) {
          if (!widget.visible)
             continue;
 
@@ -1092,49 +916,41 @@ class MenuBar implements Widget, WidgetManager {
          // console.log(`${widgetWidth}, ${widgetMinWidth}, ${Math.max(this.minChildWidth, widgetWidth, widgetMinWidth)}`);
       }
 
-      this.calcHeight = minHeight;
-      this.calcWidth = width;
+      super.calculatedDimensions = {
+         x: width,
+         y: minHeight
+      };
 
-      const tmpHeight = this.height ?? this.calcHeight;
-      const tmpWidth = this.width ?? this.calcWidth;
+      const tmpHeight = super.height ?? minHeight;
+      const tmpWidth = super.width ?? width;
       
       let pos = 0;
       this.supressChildUpdates = true;
-      for (const widget of this.children) {
-         if (!widget[0].visible)
+      for (const child of this.children) {
+         if (!child.widget.visible)
             continue;
 
-         const [widgetWidth, widgetHeight] = widget[0].getDimensions();
-         const [minWidgetWidth,] = widget[0].getMinSize();
+         const [widgetWidth, widgetHeight] = child.widget.getDimensions();
+         const [minWidgetWidth,] = child.widget.getMinSize();
          const nWidth = Math.max(this.globalProps.emptyMenuWidth, widgetWidth, minWidgetWidth);
-         widget[0].setDimensions(
+         child.widget.setDimensions(
             nWidth,
             tmpHeight
          );
-         widget[1] = pos;
+         child.x = pos;
          pos += nWidth + this.globalProps.xPadding;
       }
       this.supressChildUpdates = false;
-   }
-
-   childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) {
-      if (sendToRoot) {
-         this.parent.childUpdated(ctx, widget, true);
-      } else if(!this.supressChildUpdates) {
-         this.updateChildren();
-      }
    }
    addChild<
       T extends Widget, 
       U, 
       O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U, globalProps: GlobalWidgetProperties) => T
-   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U, globalProps: GlobalWidgetProperties): T {
-      const widget: T = new cons(ctx, this, id, props, globalProps);
-      
-      this.children.push([widget, 0]);
-      this.childUpdated(ctx, widget);
-
-      return widget;
+   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
+      return super.addChild(
+         ctx, id, cons, props,
+         0, this.globalProps.menuBorderWidth
+      );
    }
 
    openPopup(ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) {
@@ -1142,8 +958,8 @@ class MenuBar implements Widget, WidgetManager {
       let nextRelative = relativeChild;
       if (relativeChild != undefined) {
          for (const child of this.children) {
-            if (child[0] == relativeChild) {
-               nX += child[1];
+            if (child.widget == relativeChild) {
+               nX += child.x;
                nextRelative = this;
                break;
             }
@@ -1151,21 +967,6 @@ class MenuBar implements Widget, WidgetManager {
       }
       console.log(`open popup (MenuBar): (${x}, ${y}); (${nX}, ${nY})`);
       this.parent.openPopup(ctx, widget, nX, nY, nextRelative);
-   }
-   closePopup(ctx: CanvasRenderingContext2D, widget: Widget) {
-      this.parent.closePopup(ctx, widget);
-   }
-   handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
-      if (!this.supressChildUpdates) {
-         for (let i = 0; i < this.children.length; i++) {
-            if (this.children[i][0] == widget) {
-               this.children.splice(i, 1);
-               this.updateChildren();
-               break;
-            }
-         }
-         throw new Error(`MenuBar handleDelete was given an unregistered widget to delete!`);   
-      }
    }
 }
 
@@ -1874,7 +1675,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          selectedButtonColor: "#D0D0D0",
          menuOptions: menuOptions,
          offset: 0.5,
-      }, this.widgetSettings);
+      });
 
       this.widgets.set(id, [WidgetType.SubMenu, button]);
 

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -140,6 +140,7 @@ abstract class WidgetImpl implements Widget {
          this.propagateUpdate();
       }
    }
+   get height() {return this._height};
 
 
 }
@@ -240,7 +241,9 @@ class Button extends WidgetImpl implements WidgetEvents {
 
       this.reservePrefixSpace = cons.reservePrefixSpace ?? true;
 
+      this.updateCalculatedFields(ctx);
       const [minWidth, minHeight] = this.getMinSize();
+      console.log(`defaults (minWidth, minHeight): (${minWidth}, ${minHeight})`);
       this._width = cons.width ?? minWidth;
       this._height = cons.height ?? minHeight;
       // this.calculatedWidth = minWidth;
@@ -282,7 +285,8 @@ class Button extends WidgetImpl implements WidgetEvents {
          : minPrefix;
       
       textOffsets.y = (this.height + getHeight(ctx, this.getFont()))/2.0;
-      textOffsets.suffixX = minSuffix
+      textOffsets.suffixX = minSuffix;
+      console.log(`test: ${textOffsets.mainTextX}, ${textOffsets.y}, ${textOffsets.suffixX}, ${minPrefix}, ${minWidth}, ${minSuffix}, ${this.width}, ${this.height}, ${getHeight(ctx, this.getFont())}, ${minSuffix}`);
    }
 
    fullUpdate(ctx: CanvasRenderingContext2D) {
@@ -399,7 +403,8 @@ class Button extends WidgetImpl implements WidgetEvents {
       ctx.save();
 
       if (this._text == "Box Options") {
-         console.log(`box option dims: (${this._width}, ${this._height})`);
+         // console.log(`box option dims: (${this._width}, ${this._height}); (${offsetX}, ${offsetY}); ${this.calculatedFields.textOffsets}`);
+         // console.log(this.calculatedFields.textOffsets);
       }
 
       // const width = this._width ?? this.calculatedFields.width;
@@ -1356,7 +1361,7 @@ class CheckBox extends Button {
 
    setSelected(val: boolean, supressEventPassdown: boolean = false, ctx?: CanvasRenderingContext2D) {
       if (val == this._selected) return;
-
+      this._selected = val;
       //prefixText uses builtin getter/setter to auto update properties
       super.prefixText = this.globalProps[this._selected ? "checkBoxCheckedPrefix" : "checkBoxUncheckedPrefix"];
       
@@ -1423,7 +1428,7 @@ class RadioItemGroup {
 class RadioItem extends Button {
    private callbacks: Set<(ctx: CanvasRenderingContext2D, selected: boolean) => void> = new Set();
 
-   private _selected = false;
+   private _selected = true;
    private radioGroup: RadioItemGroup;
 
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, cons: ButtonWidgetConstructor, globalProps: GlobalWidgetProperties) {
@@ -1431,7 +1436,7 @@ class RadioItem extends Button {
 
       this.radioGroup = new RadioItemGroup(this, this.deselect.bind(this), this.setRadioGroup.bind(this));
 
-      super.prefixText = globalProps.radioMenuUncheckedPrefix;
+      super.prefixText = globalProps.radioMenuCheckedPrefix;
       
       super.addEvent((ctx) => {
          if (!this._selected) {
@@ -1475,178 +1480,6 @@ class RadioItem extends Button {
    }
 }
 
-
-interface RadioMenuWidgetConstructor extends MenuWidgetConstructor {
-   optionHeight?: number;
-}
-
-// class RadioItem2 extends Button {
-//    private callbacks: Set<(ctx: CanvasRenderingContext2D, selected: boolean) => void> = new Set();
-
-//    private _selected = false;
-
-//    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, cons: ButtonWidgetConstructor, globalProps: GlobalWidgetProperties, registerDeselecterFunc: (deselectFunc: () => void) => void) {
-//       super(ctx, parent, id, cons, globalProps);
-
-//       super.prefixText = globalProps.radioMenuUncheckedPrefix;
-      
-//       super.addEvent((ctx) => {
-//          this._selected = !this._selected;
-
-//          for (const callback of this.callbacks) {
-//             callback(ctx, this._selected);
-//          }
-//       });
-//    }
-
-//    private deselect() {
-      
-//    }
-// }
-// class RadioMenu implements Widget, WidgetManager, WidgetEvents {
-//    readonly globalProps: GlobalWidgetProperties;
-//    readonly parent: WidgetManager;
-//    readonly id: number;
-//    readonly handledEvents: MenuItemEvents[];
-
-//    private menu: Menu;
-//    private _optionHeight: number;
-//    set optionHeight(val: number) {
-//       for (const [_, widget] of this.options) {
-//          widget.setDimensions(undefined, val);
-//       }
-//    }
-//    get optionHeight(): number {return this._optionHeight};
-   
-//    private options: Map<string, Button> = new Map();
-//    private selected?: string;
-
-//    private events: Set<(ctx: CanvasRenderingContext2D, opt: string) => void> = new Set();
-
-//    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: RadioMenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
-//       this.globalProps = globalProps;
-//       // console.log(`Creating new radiomenu: ${props.height}, ${props.width}`);
-//       this.menu = new Menu(ctx, this, 0, props, globalProps);
-//       this.parent = parent;
-//       this.id = id;
-
-//       this._optionHeight = props.optionHeight ?? 20;
-      
-//       this.handledEvents = this.menu.handledEvents;
-//    }
-//    getCtx() {
-//       return this.parent.getCtx();
-//    }
-//    fullUpdate(ctx: CanvasRenderingContext2D) {
-//       if (this.selected != undefined)
-//          // this.options.get(this.selected)!.setButtonPrefixText(ctx, this.globalProps.radioMenuPrefix);
-//          this.options.get(this.selected)!.prefixText = this.globalProps.radioMenuCheckedPrefix;
-//       this.menu.fullUpdate(ctx);
-//    }
-//    set visible(visible: boolean) {
-//       this.menu.visible = visible;
-//    }
-//    get visible() {
-//       return this.menu.visible;
-//    }
-
-//    addOption(ctx: CanvasRenderingContext2D, opt: string) {
-//       if (this.options.has(opt))
-//          throw new Error(`RadioMenu: addOption already has the ${opt} option!`);
-
-//       let prefix = undefined;
-//       if (this.selected == undefined) {
-//          this.selected = opt;
-//          prefix = this.globalProps.radioMenuCheckedPrefix;
-//       }
-
-//       // console.log(`Radio menu adding button: Menu width is: ${this.menu.getDimensions()[0]}`);
-//       const buttonOpts: ButtonWidgetConstructor = {
-//          width: 20,
-//          height: this._optionHeight,
-//          text: opt,
-//          prefixText: prefix,
-//       };
-//       const button: Button = this.menu.addChild(ctx, 0, Button, buttonOpts);
-
-//       this.options.set(opt, button);
-
-//       button.addEvent(((ctx: CanvasRenderingContext2D) => {
-//          this.changeSelected(ctx, opt);
-//       }).bind(this));
-
-//       this.childUpdated(ctx, this);
-//    }
-
-//    changeSelected(ctx: CanvasRenderingContext2D, opt: string) {
-//       if (this.selected != opt) {
-//          if (this.selected != undefined) {
-//             let button = this.options.get(this.selected)!;
-
-//             // button.setButtonPrefixText(ctx, undefined);
-//             button.prefixText = undefined;
-//          }
-//          this.selected = opt;
-//          // this.options.get(this.selected)!.setButtonPrefixText(ctx, this.globalProps.radioMenuPrefix);
-//          this.options.get(this.selected)!.prefixText = this.globalProps.radioMenuCheckedPrefix;
-
-//          for (const event of this.events) {
-//             event(ctx, this.selected);
-//          }
-//          this.menu.childUpdated(ctx);
-//       }
-//    }
-
-//    getMinSize(): [number, number] {
-//       return this.menu.getMinSize();
-//    }
-//    render(ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) {
-//       this.menu.render(ctx, offsetX, offsetY);
-//    }
-//    handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
-//       this.menu.handleMenuEvent(ctx, event);
-//    }
-//    getDimensions(): [number, number] {
-//       // console.log(`Getting radio menu dimensions: ${this.menu.getDimensions()}`);
-//       return this.menu.getDimensions();
-//    }
-//    setDimensions(width?: number, height?: number) {
-//       return this.menu.setDimensions(width, height);
-//    }
-
-//    childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) {
-//       // console.log("radio menu updated!!!");
-//       this.parent.childUpdated(ctx, widget == this.menu ? this : widget, sendToRoot);
-//    }
-
-//    openPopup(ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) {
-//       this.parent.openPopup(ctx, widget, x, y, relativeChild);
-//    }
-//    closePopup(ctx: CanvasRenderingContext2D, widget: Widget) {
-//       this.parent.closePopup(ctx, widget);
-//    }
-
-//    private supressDeleteHandle: boolean = false;
-//    delete(ctx: CanvasRenderingContext2D) {
-//       this.supressDeleteHandle = true;
-//       this.parent.handleDelete(ctx, this);
-//       this.menu.delete(ctx);
-//       this.supressDeleteHandle = false;
-//       return [this];
-//    }
-//    handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
-//       if (this.supressDeleteHandle) return;
-//       throw new Error("RadialMenu shouldn't be handling an delete events!!!");
-//    }
-
-//    addEvent(callback: (ctx: CanvasRenderingContext2D, opt: string) => void) {
-//       this.events.add(callback);
-//    }
-//    removeEvent(callback: (ctx: CanvasRenderingContext2D, opt: string) => void) {
-//       this.events.delete(callback);
-//    }
-
-// }
 
 interface WidgetEvents {
    addEvent: (callback: () => void) => void;
@@ -1982,42 +1815,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          }
          break;
 
-         // case WidgetType.RadioMenu:
-         // {
-         //    // struct twr_widget_radio_menu_constructor {
-         //    //    /// @brief Base widget constructor
-         //    //    struct twr_widget_constructor base;
-         //    //    ///@brief defaults to 0
-         //    //    long minimum_width;
-         //    //    /// @brief defaults to 0
-         //    //    long minimum_height;
-         //    //    /**
-         //    //     * Symbol used to denote that the option is selected
-         //    //     * defaults to *
-         //    //     */
-         //    //    const char* selected_symbol;
-         //    //    /// @brief default to 20
-         //    //    long option_height;
-         //    // };
-         //    const cons: RadioMenuWidgetConstructor = {
-         //       width: width,
-         //       height: height,
-         //       // minimumWidth: getLongOrDef(extraPtr + 0, 0),            
-         //       // minimumHeight: getLongOrDef(extraPtr + 4, 0),
-         //       // yPadding: this.widgetSettings.yPadding,
-         //       // menuColor: this.widgetSettings.borderColor,
-         //       // hoveredBackgroundColor: this.widgetSettings.selectedColor,
-         //       // selectedSymbol: getStringOrDef(extraPtr + 8, "*"),
-         //       // reservedPrefixLength: this.widgetSettings.reservedPrefixLen,
-         //       optionHeight: getLongOrDef(extraPtr + 12, 20),
-         //       // optionTextFont: this.widgetSettings.widgetTextFont,
-         //       // optionTextColor: this.widgetSettings.textColor,
-         //    };
-         //    const radio: RadioMenu = menu.addChild(this.ctx, id, RadioMenu, cons);
-         //    this.widgets.set(id, [WidgetType.RadioMenu, radio]);
-         // }
-         // break;
-
          case WidgetType.RadioItem:
          {
             // struct twr_widget_button_constructor {
@@ -2148,19 +1945,11 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          }
          break;
 
-         // case WidgetType.RadioMenu:
-         // {
-         //    const radio: RadioMenu = widget[1];
-         //    radio.addEvent(async (ctx: CanvasRenderingContext2D, opt: string) => {
-         //       mod.postEvent(eventID, extraPtr, await mod.putString(opt));
-         //    });
-         // }
-         // break;
          case WidgetType.RadioItem:
          {
             const radioItem: RadioItem = widget[1];
-            radioItem.addEvent((ctx: CanvasRenderingContext2D) => {
-               mod.postEvent(eventID, extraPtr);
+            radioItem.addEvent((ctx: CanvasRenderingContext2D, selected: boolean) => {
+               mod.postEvent(eventID, extraPtr, selected ? 1 : 0);
             });
          }
          break;

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -201,7 +201,7 @@ class Button extends WidgetImpl implements WidgetEvents {
 
 
 
-   private selected: boolean = false;
+   private mousedOver: boolean = false;
    private events: Set<((ctx: CanvasRenderingContext2D) => void)> = new Set();
 
    // private _visible: boolean = true;
@@ -406,7 +406,7 @@ class Button extends WidgetImpl implements WidgetEvents {
       // const height = this._height ?? this.calculatedFields.height;
       const textOffsets = this.calculatedFields.textOffsets;
 
-      const button_color = this.selected ? this.globalProps.selectedColor : this.globalProps.borderColor;
+      const button_color = this.mousedOver ? this.globalProps.selectedColor : this.globalProps.borderColor;
       ctx.fillStyle = button_color;
       ctx.fillRect(offsetX, offsetY, this._width, this._height);
 
@@ -450,13 +450,13 @@ class Button extends WidgetImpl implements WidgetEvents {
 
          case MenuItemEvents.HOVERING:
          {
-            this.selected = true;
+            this.mousedOver = true;
          }
          break;
 
          case MenuItemEvents.UNHOVERED:
          {
-            this.selected = false;
+            this.mousedOver = false;
          }
          break;
 
@@ -1354,20 +1354,30 @@ class CheckBox extends Button {
 
    private _selected = false;
 
+   setSelected(val: boolean, supressEventPassdown: boolean = false, ctx?: CanvasRenderingContext2D) {
+      if (val == this._selected) return;
+
+      //prefixText uses builtin getter/setter to auto update properties
+      super.prefixText = this.globalProps[this._selected ? "checkBoxCheckedPrefix" : "checkBoxUncheckedPrefix"];
+      
+      if (!supressEventPassdown) {
+         const n_ctx = ctx ?? this.parent.getCtx();
+         for (const callback of this.callbacks) {
+            callback(n_ctx, this._selected);
+         }
+      }
+         
+   }
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, cons: ButtonWidgetConstructor, globalProps: GlobalWidgetProperties) {
       super(ctx, parent, id, cons, globalProps);
 
       super.prefixText = globalProps.checkBoxUncheckedPrefix;
       
       super.addEvent((ctx) => {
-         this._selected = !this._selected;
-
-         super.prefixText = globalProps[this._selected ? "checkBoxCheckedPrefix" : "checkBoxUncheckedPrefix"];
-         for (const callback of this.callbacks) {
-            callback(ctx, this._selected);
-         }
+         this.setSelected(!this._selected, false, ctx);
       });
    }
+
 
    addEvent(callback: (ctx: CanvasRenderingContext2D, selected: boolean) => void) {
       this.callbacks.add(callback);
@@ -1470,153 +1480,173 @@ interface RadioMenuWidgetConstructor extends MenuWidgetConstructor {
    optionHeight?: number;
 }
 
-class RadioItem2 {
+// class RadioItem2 extends Button {
+//    private callbacks: Set<(ctx: CanvasRenderingContext2D, selected: boolean) => void> = new Set();
 
-}
-class RadioMenu implements Widget, WidgetManager, WidgetEvents {
-   readonly globalProps: GlobalWidgetProperties;
-   readonly parent: WidgetManager;
-   readonly id: number;
-   readonly handledEvents: MenuItemEvents[];
+//    private _selected = false;
 
-   private menu: Menu;
-   private _optionHeight: number;
-   set optionHeight(val: number) {
-      for (const [_, widget] of this.options) {
-         widget.setDimensions(undefined, val);
-      }
-   }
-   get optionHeight(): number {return this._optionHeight};
-   
-   private options: Map<string, Button> = new Map();
-   private selected?: string;
+//    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, cons: ButtonWidgetConstructor, globalProps: GlobalWidgetProperties, registerDeselecterFunc: (deselectFunc: () => void) => void) {
+//       super(ctx, parent, id, cons, globalProps);
 
-   private events: Set<(ctx: CanvasRenderingContext2D, opt: string) => void> = new Set();
-
-   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: RadioMenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
-      this.globalProps = globalProps;
-      // console.log(`Creating new radiomenu: ${props.height}, ${props.width}`);
-      this.menu = new Menu(ctx, this, 0, props, globalProps);
-      this.parent = parent;
-      this.id = id;
-
-      this._optionHeight = props.optionHeight ?? 20;
+//       super.prefixText = globalProps.radioMenuUncheckedPrefix;
       
-      this.handledEvents = this.menu.handledEvents;
-   }
-   getCtx() {
-      return this.parent.getCtx();
-   }
-   fullUpdate(ctx: CanvasRenderingContext2D) {
-      if (this.selected != undefined)
-         // this.options.get(this.selected)!.setButtonPrefixText(ctx, this.globalProps.radioMenuPrefix);
-         this.options.get(this.selected)!.prefixText = this.globalProps.radioMenuCheckedPrefix;
-      this.menu.fullUpdate(ctx);
-   }
-   set visible(visible: boolean) {
-      this.menu.visible = visible;
-   }
-   get visible() {
-      return this.menu.visible;
-   }
+//       super.addEvent((ctx) => {
+//          this._selected = !this._selected;
 
-   addOption(ctx: CanvasRenderingContext2D, opt: string) {
-      if (this.options.has(opt))
-         throw new Error(`RadioMenu: addOption already has the ${opt} option!`);
+//          for (const callback of this.callbacks) {
+//             callback(ctx, this._selected);
+//          }
+//       });
+//    }
 
-      let prefix = undefined;
-      if (this.selected == undefined) {
-         this.selected = opt;
-         prefix = this.globalProps.radioMenuCheckedPrefix;
-      }
+//    private deselect() {
+      
+//    }
+// }
+// class RadioMenu implements Widget, WidgetManager, WidgetEvents {
+//    readonly globalProps: GlobalWidgetProperties;
+//    readonly parent: WidgetManager;
+//    readonly id: number;
+//    readonly handledEvents: MenuItemEvents[];
 
-      // console.log(`Radio menu adding button: Menu width is: ${this.menu.getDimensions()[0]}`);
-      const buttonOpts: ButtonWidgetConstructor = {
-         width: 20,
-         height: this._optionHeight,
-         text: opt,
-         prefixText: prefix,
-      };
-      const button: Button = this.menu.addChild(ctx, 0, Button, buttonOpts);
+//    private menu: Menu;
+//    private _optionHeight: number;
+//    set optionHeight(val: number) {
+//       for (const [_, widget] of this.options) {
+//          widget.setDimensions(undefined, val);
+//       }
+//    }
+//    get optionHeight(): number {return this._optionHeight};
+   
+//    private options: Map<string, Button> = new Map();
+//    private selected?: string;
 
-      this.options.set(opt, button);
+//    private events: Set<(ctx: CanvasRenderingContext2D, opt: string) => void> = new Set();
 
-      button.addEvent(((ctx: CanvasRenderingContext2D) => {
-         this.changeSelected(ctx, opt);
-      }).bind(this));
+//    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: RadioMenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
+//       this.globalProps = globalProps;
+//       // console.log(`Creating new radiomenu: ${props.height}, ${props.width}`);
+//       this.menu = new Menu(ctx, this, 0, props, globalProps);
+//       this.parent = parent;
+//       this.id = id;
 
-      this.childUpdated(ctx, this);
-   }
+//       this._optionHeight = props.optionHeight ?? 20;
+      
+//       this.handledEvents = this.menu.handledEvents;
+//    }
+//    getCtx() {
+//       return this.parent.getCtx();
+//    }
+//    fullUpdate(ctx: CanvasRenderingContext2D) {
+//       if (this.selected != undefined)
+//          // this.options.get(this.selected)!.setButtonPrefixText(ctx, this.globalProps.radioMenuPrefix);
+//          this.options.get(this.selected)!.prefixText = this.globalProps.radioMenuCheckedPrefix;
+//       this.menu.fullUpdate(ctx);
+//    }
+//    set visible(visible: boolean) {
+//       this.menu.visible = visible;
+//    }
+//    get visible() {
+//       return this.menu.visible;
+//    }
 
-   changeSelected(ctx: CanvasRenderingContext2D, opt: string) {
-      if (this.selected != opt) {
-         if (this.selected != undefined) {
-            let button = this.options.get(this.selected)!;
+//    addOption(ctx: CanvasRenderingContext2D, opt: string) {
+//       if (this.options.has(opt))
+//          throw new Error(`RadioMenu: addOption already has the ${opt} option!`);
 
-            // button.setButtonPrefixText(ctx, undefined);
-            button.prefixText = undefined;
-         }
-         this.selected = opt;
-         // this.options.get(this.selected)!.setButtonPrefixText(ctx, this.globalProps.radioMenuPrefix);
-         this.options.get(this.selected)!.prefixText = this.globalProps.radioMenuCheckedPrefix;
+//       let prefix = undefined;
+//       if (this.selected == undefined) {
+//          this.selected = opt;
+//          prefix = this.globalProps.radioMenuCheckedPrefix;
+//       }
 
-         for (const event of this.events) {
-            event(ctx, this.selected);
-         }
-         this.menu.childUpdated(ctx);
-      }
-   }
+//       // console.log(`Radio menu adding button: Menu width is: ${this.menu.getDimensions()[0]}`);
+//       const buttonOpts: ButtonWidgetConstructor = {
+//          width: 20,
+//          height: this._optionHeight,
+//          text: opt,
+//          prefixText: prefix,
+//       };
+//       const button: Button = this.menu.addChild(ctx, 0, Button, buttonOpts);
 
-   getMinSize(): [number, number] {
-      return this.menu.getMinSize();
-   }
-   render(ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) {
-      this.menu.render(ctx, offsetX, offsetY);
-   }
-   handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
-      this.menu.handleMenuEvent(ctx, event);
-   }
-   getDimensions(): [number, number] {
-      // console.log(`Getting radio menu dimensions: ${this.menu.getDimensions()}`);
-      return this.menu.getDimensions();
-   }
-   setDimensions(width?: number, height?: number) {
-      return this.menu.setDimensions(width, height);
-   }
+//       this.options.set(opt, button);
 
-   childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) {
-      // console.log("radio menu updated!!!");
-      this.parent.childUpdated(ctx, widget == this.menu ? this : widget, sendToRoot);
-   }
+//       button.addEvent(((ctx: CanvasRenderingContext2D) => {
+//          this.changeSelected(ctx, opt);
+//       }).bind(this));
 
-   openPopup(ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) {
-      this.parent.openPopup(ctx, widget, x, y, relativeChild);
-   }
-   closePopup(ctx: CanvasRenderingContext2D, widget: Widget) {
-      this.parent.closePopup(ctx, widget);
-   }
+//       this.childUpdated(ctx, this);
+//    }
 
-   private supressDeleteHandle: boolean = false;
-   delete(ctx: CanvasRenderingContext2D) {
-      this.supressDeleteHandle = true;
-      this.parent.handleDelete(ctx, this);
-      this.menu.delete(ctx);
-      this.supressDeleteHandle = false;
-      return [this];
-   }
-   handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
-      if (this.supressDeleteHandle) return;
-      throw new Error("RadialMenu shouldn't be handling an delete events!!!");
-   }
+//    changeSelected(ctx: CanvasRenderingContext2D, opt: string) {
+//       if (this.selected != opt) {
+//          if (this.selected != undefined) {
+//             let button = this.options.get(this.selected)!;
 
-   addEvent(callback: (ctx: CanvasRenderingContext2D, opt: string) => void) {
-      this.events.add(callback);
-   }
-   removeEvent(callback: (ctx: CanvasRenderingContext2D, opt: string) => void) {
-      this.events.delete(callback);
-   }
+//             // button.setButtonPrefixText(ctx, undefined);
+//             button.prefixText = undefined;
+//          }
+//          this.selected = opt;
+//          // this.options.get(this.selected)!.setButtonPrefixText(ctx, this.globalProps.radioMenuPrefix);
+//          this.options.get(this.selected)!.prefixText = this.globalProps.radioMenuCheckedPrefix;
 
-}
+//          for (const event of this.events) {
+//             event(ctx, this.selected);
+//          }
+//          this.menu.childUpdated(ctx);
+//       }
+//    }
+
+//    getMinSize(): [number, number] {
+//       return this.menu.getMinSize();
+//    }
+//    render(ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) {
+//       this.menu.render(ctx, offsetX, offsetY);
+//    }
+//    handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
+//       this.menu.handleMenuEvent(ctx, event);
+//    }
+//    getDimensions(): [number, number] {
+//       // console.log(`Getting radio menu dimensions: ${this.menu.getDimensions()}`);
+//       return this.menu.getDimensions();
+//    }
+//    setDimensions(width?: number, height?: number) {
+//       return this.menu.setDimensions(width, height);
+//    }
+
+//    childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) {
+//       // console.log("radio menu updated!!!");
+//       this.parent.childUpdated(ctx, widget == this.menu ? this : widget, sendToRoot);
+//    }
+
+//    openPopup(ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) {
+//       this.parent.openPopup(ctx, widget, x, y, relativeChild);
+//    }
+//    closePopup(ctx: CanvasRenderingContext2D, widget: Widget) {
+//       this.parent.closePopup(ctx, widget);
+//    }
+
+//    private supressDeleteHandle: boolean = false;
+//    delete(ctx: CanvasRenderingContext2D) {
+//       this.supressDeleteHandle = true;
+//       this.parent.handleDelete(ctx, this);
+//       this.menu.delete(ctx);
+//       this.supressDeleteHandle = false;
+//       return [this];
+//    }
+//    handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
+//       if (this.supressDeleteHandle) return;
+//       throw new Error("RadialMenu shouldn't be handling an delete events!!!");
+//    }
+
+//    addEvent(callback: (ctx: CanvasRenderingContext2D, opt: string) => void) {
+//       this.events.add(callback);
+//    }
+//    removeEvent(callback: (ctx: CanvasRenderingContext2D, opt: string) => void) {
+//       this.events.delete(callback);
+//    }
+
+// }
 
 interface WidgetEvents {
    addEvent: (callback: () => void) => void;
@@ -1632,7 +1662,8 @@ const MENU_START_X = BORDER_SIZE;
 enum WidgetType {
    Button,
    Seperator,
-   RadioMenu,
+   // RadioMenu,
+   RadioItem,
    SubMenu,
    CheckBox,
 }
@@ -1652,7 +1683,8 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       number, 
       [WidgetType.Button, Button]
       | [WidgetType.Seperator, Seperator]
-      | [WidgetType.RadioMenu, RadioMenu]
+      // | [WidgetType.RadioMenu, RadioMenu]
+      | [WidgetType.RadioItem, RadioItem]
       | [WidgetType.SubMenu, MenuButton]
       | [WidgetType.CheckBox, CheckBox]
    > = new Map();
@@ -1691,8 +1723,9 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       twrWindowMenuAddWidget: {},
       twrWindowMenuWidgetAddCallback: {},
       twrWindowMenuDeleteWidget: {},
-      twrWindowMenuRadioMenuAddOption: {},
+      // twrWindowMenuRadioMenuAddOption: {},
       twrWindowMenuWidgetSetVisibility: {},
+      twrWindowMenuRadioItemMerge: {},
    };
 
    // every library should have this line
@@ -1949,39 +1982,58 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          }
          break;
 
-         case WidgetType.RadioMenu:
+         // case WidgetType.RadioMenu:
+         // {
+         //    // struct twr_widget_radio_menu_constructor {
+         //    //    /// @brief Base widget constructor
+         //    //    struct twr_widget_constructor base;
+         //    //    ///@brief defaults to 0
+         //    //    long minimum_width;
+         //    //    /// @brief defaults to 0
+         //    //    long minimum_height;
+         //    //    /**
+         //    //     * Symbol used to denote that the option is selected
+         //    //     * defaults to *
+         //    //     */
+         //    //    const char* selected_symbol;
+         //    //    /// @brief default to 20
+         //    //    long option_height;
+         //    // };
+         //    const cons: RadioMenuWidgetConstructor = {
+         //       width: width,
+         //       height: height,
+         //       // minimumWidth: getLongOrDef(extraPtr + 0, 0),            
+         //       // minimumHeight: getLongOrDef(extraPtr + 4, 0),
+         //       // yPadding: this.widgetSettings.yPadding,
+         //       // menuColor: this.widgetSettings.borderColor,
+         //       // hoveredBackgroundColor: this.widgetSettings.selectedColor,
+         //       // selectedSymbol: getStringOrDef(extraPtr + 8, "*"),
+         //       // reservedPrefixLength: this.widgetSettings.reservedPrefixLen,
+         //       optionHeight: getLongOrDef(extraPtr + 12, 20),
+         //       // optionTextFont: this.widgetSettings.widgetTextFont,
+         //       // optionTextColor: this.widgetSettings.textColor,
+         //    };
+         //    const radio: RadioMenu = menu.addChild(this.ctx, id, RadioMenu, cons);
+         //    this.widgets.set(id, [WidgetType.RadioMenu, radio]);
+         // }
+         // break;
+
+         case WidgetType.RadioItem:
          {
-            // struct twr_widget_radio_menu_constructor {
+            // struct twr_widget_button_constructor {
             //    /// @brief Base widget constructor
             //    struct twr_widget_constructor base;
-            //    ///@brief defaults to 0
-            //    long minimum_width;
-            //    /// @brief defaults to 0
-            //    long minimum_height;
-            //    /**
-            //     * Symbol used to denote that the option is selected
-            //     * defaults to *
-            //     */
-            //    const char* selected_symbol;
-            //    /// @brief default to 20
-            //    long option_height;
+            //    /// @brief defaults to "Lorem Ipsum"
+            //    const char* text;
             // };
-            const cons: RadioMenuWidgetConstructor = {
+
+            const cons: ButtonWidgetConstructor = {
                width: width,
                height: height,
-               // minimumWidth: getLongOrDef(extraPtr + 0, 0),            
-               // minimumHeight: getLongOrDef(extraPtr + 4, 0),
-               // yPadding: this.widgetSettings.yPadding,
-               // menuColor: this.widgetSettings.borderColor,
-               // hoveredBackgroundColor: this.widgetSettings.selectedColor,
-               // selectedSymbol: getStringOrDef(extraPtr + 8, "*"),
-               // reservedPrefixLength: this.widgetSettings.reservedPrefixLen,
-               optionHeight: getLongOrDef(extraPtr + 12, 20),
-               // optionTextFont: this.widgetSettings.widgetTextFont,
-               // optionTextColor: this.widgetSettings.textColor,
+               text: getStringOrDef(extraPtr + 0, "Lorem Ipsum"),
             };
-            const radio: RadioMenu = menu.addChild(this.ctx, id, RadioMenu, cons);
-            this.widgets.set(id, [WidgetType.RadioMenu, radio]);
+            const radioItem: RadioItem = menu.addChild(this.ctx, id, RadioItem, cons);
+            this.widgets.set(id, [WidgetType.RadioItem, radioItem]);
          }
          break;
 
@@ -2096,11 +2148,19 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          }
          break;
 
-         case WidgetType.RadioMenu:
+         // case WidgetType.RadioMenu:
+         // {
+         //    const radio: RadioMenu = widget[1];
+         //    radio.addEvent(async (ctx: CanvasRenderingContext2D, opt: string) => {
+         //       mod.postEvent(eventID, extraPtr, await mod.putString(opt));
+         //    });
+         // }
+         // break;
+         case WidgetType.RadioItem:
          {
-            const radio: RadioMenu = widget[1];
-            radio.addEvent(async (ctx: CanvasRenderingContext2D, opt: string) => {
-               mod.postEvent(eventID, extraPtr, await mod.putString(opt));
+            const radioItem: RadioItem = widget[1];
+            radioItem.addEvent((ctx: CanvasRenderingContext2D) => {
+               mod.postEvent(eventID, extraPtr);
             });
          }
          break;
@@ -2132,15 +2192,26 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       }
    }
 
-   twrWindowMenuRadioMenuAddOption(mod: IWasmModuleAsync | IWasmModule, widgetID: number, optionPtr: number) {
-      if (!this.widgets.has(widgetID)) throw new Error(`twrWindowMenuRadioMenuAddOption: Error! was given an invalid widgetID (${widgetID})`);
-      const widget = this.widgets.get(widgetID)!;
+   // twrWindowMenuRadioMenuAddOption(mod: IWasmModuleAsync | IWasmModule, widgetID: number, optionPtr: number) {
+   //    if (!this.widgets.has(widgetID)) throw new Error(`twrWindowMenuRadioMenuAddOption: Error! was given an invalid widgetID (${widgetID})`);
+   //    const widget = this.widgets.get(widgetID)!;
 
-      if (widget[0] != WidgetType.RadioMenu) throw new Error(`twrWindowMenuRadioMenuAddOption: Error! was given an invalid widget type! Expected RadioMenu, got ${WidgetType[widget[0]]}`);
+   //    if (widget[0] != WidgetType.RadioMenu) throw new Error(`twrWindowMenuRadioMenuAddOption: Error! was given an invalid widget type! Expected RadioMenu, got ${WidgetType[widget[0]]}`);
       
-      const radio: RadioMenu = widget[1];
+   //    const radio: RadioMenu = widget[1];
 
-      radio.addOption(this.ctx, mod.getString(optionPtr));
+   //    radio.addOption(this.ctx, mod.getString(optionPtr));
+   // }
+   twrWindowMenuRadioItemMerge(mod: IWasmModuleAsync | IWasmModule, widgetID1: number, widgetID2: number) {
+      const widget1 = this.widgets.get(widgetID1);
+      const widget2 = this.widgets.get(widgetID2);
+      if (widget1 == undefined) throw new Error(`twrWindowMenuRadioItemMerge: Error! was given an invalid widgetID1 (${widgetID1})`);
+      if (widget2 == undefined) throw new Error(`twrWindowMenuRadioItemMerge: Error! was given an invalid widgetID2 (${widgetID2})`);
+
+      if (widget1[0] != WidgetType.RadioItem) throw new Error(`twrWindowMenuRadioItemMerge: Error! was given an invalid widget1 type! Got ${WidgetType[widget1[0]]}, expected RadioItem!`);
+      if (widget2[0] != WidgetType.RadioItem) throw new Error(`twrWindowMenuRadioItemMerge: Error! was given an invalid widget2 type! Got ${WidgetType[widget2[0]]}, expected RadioItem!`);
+
+      widget1[1].mergeGroups(widget2[1]);
    }
 
 

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -74,16 +74,21 @@ interface Widget {
    readonly handledEvents: MenuItemEvents[];
    set visible(val: boolean);
    get visible(): boolean;
-   // set width(val: number);
-   // get width(): number;
-   // set height(val: number);
-   // get height(): number;
-   
-   getMinSize: () => [number, number];
+
+   set width(val: number|undefined);
+   get width(): number|undefined;
+   set height(val: number|undefined);
+   get height(): number|undefined;
+   get usedWidth(): number;
+   get usedHeight(): number;
+   get minWidth(): number;
+   get minHeight(): number;
+
+   // getMinSize: () => [number, number];
    render: (ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) => void;
    handleMenuEvent: (ctx: CanvasRenderingContext2D, event: MenuItemEventData) => void;
-   getDimensions: () => [number, number];
-   setDimensions: (width?: number, height?: number) => void;
+   // getDimensions: () => [number, number];
+   // setDimensions: (width?: number, height?: number) => void;
    delete: (ctx: CanvasRenderingContext2D) => Widget[];
    // setVisibility: (visibility: boolean) => void;
    // isVisible: () => boolean;
@@ -108,15 +113,15 @@ abstract class WidgetImpl implements Widget {
       this.globalProps = globalProps;
 
    }
-   abstract getMinSize(): [number, number];
+   // abstract getMinSize(): [number, number];
    abstract render(ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number): void;
    abstract handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData): void;
    abstract delete(ctx: CanvasRenderingContext2D): Widget[];
    abstract fullUpdate(ctx: CanvasRenderingContext2D): void;
    protected abstract propagateUpdate(ctx?: CanvasRenderingContext2D): void;
 
-   abstract getDimensions(): [number, number];
-   abstract setDimensions(width?: number, height?: number): void;
+   // abstract getDimensions(): [number, number];
+   // abstract setDimensions(width?: number, height?: number): void;
 
    set visible(val: boolean) {
       if (this._visible != val) {
@@ -134,6 +139,7 @@ abstract class WidgetImpl implements Widget {
    }
    get width() {return this._width};
    abstract get usedWidth(): number;
+   abstract get minWidth(): number;
 
    set height(val: number|undefined) {
       if (this._height != val) {
@@ -143,6 +149,7 @@ abstract class WidgetImpl implements Widget {
    }
    get height() {return this._height};
    abstract get usedHeight(): number;
+   abstract get minHeight(): number;
 
 
 }
@@ -313,24 +320,24 @@ class Button extends WidgetImpl implements WidgetEvents {
    //    return this._visible;
    // }
 
-   getDimensions(): [number, number] {
-      return [
-         this.usedWidth, 
-         this.usedHeight
-      ];
-   }
-   setDimensions(width?: number, height?: number) {
-      if (
-         (width != undefined && width != this._width)
-         || (height != undefined && height != this._height)
-      ) {
-         this._height = height ?? this._height;
-         this._width = width ?? this._width;
+   // getDimensions(): [number, number] {
+   //    return [
+   //       this.usedWidth, 
+   //       this.usedHeight
+   //    ];
+   // }
+   // setDimensions(width?: number, height?: number) {
+   //    if (
+   //       (width != undefined && width != this._width)
+   //       || (height != undefined && height != this._height)
+   //    ) {
+   //       this._height = height ?? this._height;
+   //       this._width = width ?? this._width;
 
-         console.log(`new dimensions (${this._text}): (${this._width}, ${this._height})`);
-         this.propagateUpdate();
-      }
-   }
+   //       console.log(`new dimensions (${this._text}): (${this._width}, ${this._height})`);
+   //       this.propagateUpdate();
+   //    }
+   // }
 
    private getFullMinSize(ctx: CanvasRenderingContext2D): [number, number, number, number] {
       ctx.save();
@@ -370,18 +377,24 @@ class Button extends WidgetImpl implements WidgetEvents {
 
       return [minWidth, minHeight, minPrefix, minSuffix];
    }
-   getMinSize(): [number, number] {
-      // const [width, height,,] = this.getFullMinSize(this.parent.getCtx());
-      // console.log(`button min size (${this._text}), (${width}, ${height})`)
-      // return [width, height];
-      console.log(`button min size (${this._text}): (${this.calculatedFields.width}, ${this.calculatedFields.height})`);
-      return [
-         this.calculatedFields.width,
-         this.calculatedFields.height
-      ]
+   // getMinSize(): [number, number] {
+   //    // const [width, height,,] = this.getFullMinSize(this.parent.getCtx());
+   //    // console.log(`button min size (${this._text}), (${width}, ${height})`)
+   //    // return [width, height];
+   //    console.log(`button min size (${this._text}): (${this.calculatedFields.width}, ${this.calculatedFields.height})`);
+   //    return [
+   //       this.calculatedFields.width,
+   //       this.calculatedFields.height
+   //    ]
+   // }
+   get minWidth() {
+      return this.calculatedFields.width;
    }
    get usedWidth() {
       return this._width ?? this.calculatedFields.width;
+   }
+   get minHeight() {
+      return this.calculatedFields.height;
    }
    get usedHeight() {
       return this._height ?? this.calculatedFields.height;
@@ -651,13 +664,18 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
       return widget;
    }
 
-   getMinSize(): [number, number] {
-      return [
-         this._calculatedDimensions.x, 
-         this._calculatedDimensions.y
-      ];
+   // getMinSize(): [number, number] {
+   //    return [
+   //       this._calculatedDimensions.x, 
+   //       this._calculatedDimensions.y
+   //    ];
+   // }
+   get minWidth() {
+      return this._calculatedDimensions.x;
    }
-
+   get minHeight() {
+      return this._calculatedDimensions.y;
+   }
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0): void {
       if (!this._visible)
          return;
@@ -705,9 +723,9 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
 
    private mouseInWidgetBounds(widgetContainer: ContainedWidget, x: number, y: number) {
       const {widget, x: widgetX, y: widgetY} = widgetContainer;
-      const [widgetWidth, widgetHeight] = widget.getDimensions();
-      return widgetX <= x && x <= widgetX + widgetWidth
-            && widgetY <= y && y <= widgetY + widgetHeight;
+      // const [widgetWidth, widgetHeight] = widget.getDimensions();
+      return widgetX <= x && x <= widgetX + widget.usedWidth
+            && widgetY <= y && y <= widgetY + widget.usedHeight;
    }
 
    //updates the currently selected object using the given coords
@@ -788,12 +806,12 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
       }
 	}
 
-   getDimensions(): [number, number] {
-      return [
-         this._width ?? this._calculatedDimensions.x,
-         this._height ?? this._calculatedDimensions.y
-      ];
-	}
+   // getDimensions(): [number, number] {
+   //    return [
+   //       this._width ?? this._calculatedDimensions.x,
+   //       this._height ?? this._calculatedDimensions.y
+   //    ];
+	// }
    get usedWidth() {
       return this._width ?? this._calculatedDimensions.x;
    }
@@ -801,20 +819,20 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
       return this._height ?? this._calculatedDimensions.y;
    }
 
-   setDimensions(width?: number, height?: number): void {
-      if (width != undefined){
-         if (width == 0)
-            this._width = undefined;
-         else
-            this._width = width;
-      }
-      if (height != undefined){
-         if (height == 0)
-            this._height = undefined;
-         else
-            this._height = height;
-      }
-	}
+   // setDimensions(width?: number, height?: number): void {
+   //    if (width != undefined){
+   //       if (width == 0)
+   //          this._width = undefined;
+   //       else
+   //          this._width = width;
+   //    }
+   //    if (height != undefined){
+   //       if (height == 0)
+   //          this._height = undefined;
+   //       else
+   //          this._height = height;
+   //    }
+	// }
 
 
    bindUnhoverEvent(callback: () => void) {
@@ -879,11 +897,12 @@ class Menu extends WidgetContainer {
       for (const {widget} of this.children) {
          if (!widget.visible)
             continue;
-         const [width, ] = widget.getMinSize();
+         // const [width, ] = widget.getMinSize();
+         const width = widget.minWidth;
          childWidth = Math.max(childWidth, width);
          // maxChildHeight = Math.max(maxChildHeight, height+this.yPadding);
-         const [, height] = widget.getDimensions();
-         childHeight += height + this.globalProps.yPadding;
+         // const [, height] = widget.getDimensions();
+         childHeight += widget.usedHeight + this.globalProps.yPadding;
       }
       childWidth += this.globalProps.menuBorderWidth * 4;
       childHeight += this.globalProps.menuBorderWidth * 2;
@@ -912,13 +931,14 @@ class Menu extends WidgetContainer {
          for (const child of this.children) {
             if (!child.widget.visible)
                continue;
-            const [, height] = child.widget.getDimensions();
+            // const [, height] = child.widget.getDimensions();
             this.supressChildUpdates = true;
-            child.widget.setDimensions(newWidth - this.globalProps.menuBorderWidth * 4, undefined);
+            child.widget.width = newWidth - this.globalProps.menuBorderWidth * 4;
+            // child.widget.setDimensions(newWidth - this.globalProps.menuBorderWidth * 4, undefined);
             child.y = curHeight;
             this.supressChildUpdates = false;
             // curHeight += maxChildHeight;
-            curHeight += height + this.globalProps.yPadding;
+            curHeight += child.widget.usedHeight + this.globalProps.yPadding;
          }
 
       }
@@ -943,8 +963,10 @@ class MenuBar extends WidgetContainer {
          if (!widget.visible)
             continue;
 
-         const [widgetWidth, widgetHeight] = widget.getDimensions();
-         const [widgetMinWidth, widgetMinHeight] = widget.getMinSize();
+         // const [widgetWidth, widgetHeight] = widget.getDimensions();
+         const [widgetWidth, widgetHeight] = [widget.usedWidth, widget.usedHeight];
+         // const [widgetMinWidth, widgetMinHeight] = widget.getMinSize();
+         const [widgetMinWidth, widgetMinHeight] = [widget.minWidth, widget.minHeight];
          
          minHeight = Math.max(minHeight, widgetHeight, widgetMinHeight);
          width += Math.max(this.globalProps.emptyMenuWidth, widgetWidth, widgetMinWidth) + this.globalProps.xPadding;
@@ -965,13 +987,18 @@ class MenuBar extends WidgetContainer {
          if (!child.widget.visible)
             continue;
 
-         const [widgetWidth, widgetHeight] = child.widget.getDimensions();
-         const [minWidgetWidth,] = child.widget.getMinSize();
+         // const [widgetWidth, widgetHeight] = child.widget.getDimensions();
+         const widgetWidth = child.widget.usedWidth;
+         // const [minWidgetWidth,] = child.widget.getMinSize();
+         const minWidgetWidth = child.widget.minWidth;
          const nWidth = Math.max(this.globalProps.emptyMenuWidth, widgetWidth, minWidgetWidth);
-         child.widget.setDimensions(
-            nWidth,
-            tmpHeight
-         );
+         // child.widget.setDimensions(
+         //    nWidth,
+         //    tmpHeight
+         // );
+         child.widget.width = nWidth;
+         child.widget.height = tmpHeight;
+
          console.log(`${tmpHeight}, ${super.height}, ${child.y}`);
          child.x = pos;
          pos += nWidth + this.globalProps.xPadding;
@@ -1069,7 +1096,8 @@ class RootWidgetManager implements WidgetManager {
    }
 
    private widgetInBounds(widget: Widget, widgetX: number, widgetY: number, x: number, y: number): boolean {
-      const [wW, wH] = widget.getDimensions();
+      // const [wW, wH] = widget.getDimensions();
+      const [wW, wH] = [widget.usedWidth, widget.usedHeight];
       return widgetX <= x && x <= widgetX + wW
          && widgetY <= y && y <= widgetY + wH;
    }
@@ -1195,7 +1223,8 @@ class MenuButton extends Button implements WidgetManager {
       }, globalProps);
 
       super.addEvent((() => {
-         const [width,height] = super.getDimensions();
+         // const [width,height] = super.getDimensions();
+         const [width, height] = [super.usedWidth, super.usedHeight];
          let x = this.openToRight ? width + this.offset : 0;
          let y = this.openToRight ? 0 : height + this.offset;
          // console.log(`spawning menu at: (${x}, ${y})`)
@@ -1279,7 +1308,7 @@ class Seperator extends WidgetImpl {
    protected _width?: number;
    protected _height?: number;
 
-   private minHeight: number = 0;
+   private _minHeight: number = 0;
 
    private _text: string = "";
    private textXOffset: number = 0;
@@ -1334,7 +1363,7 @@ class Seperator extends WidgetImpl {
       const repeats = Math.floor(this.usedWidth/metrics.width);
       const width = repeats*metrics.width;
       const height = metrics.actualBoundingBoxAscent;
-      this.minHeight = height;
+      this._minHeight = height;
 
       this._text = this.seperatorText.repeat(repeats);
 
@@ -1346,14 +1375,24 @@ class Seperator extends WidgetImpl {
       ctx.restore();
    }
 
-   getMinSize(): [number, number] {
-      return [0, this.minHeight];
+   // getMinSize(): [number, number] {
+   //    return [0, this.minHeight];
+   // }
+   get minWidth() {
+      return 0;
    }
    get usedWidth() {
       return this._width ?? 0;
    }
+   get minHeight() {
+      if (this._width == 0) {
+         return 0;
+      } else {
+         return this._minHeight;
+      }
+   }
    get usedHeight() {
-      return this._height ?? (this.usedWidth == 0 ? 0 : this.minHeight);
+      return this._height ?? this.minHeight;
    }
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
       if (!this._visible)
@@ -1376,20 +1415,20 @@ class Seperator extends WidgetImpl {
    handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
       throw new Error(`Seperator widget doesn't accept events!!`);
    }
-   getDimensions(): [number, number] {
-      return [this.usedWidth, this.usedHeight];
-   }
+   // getDimensions(): [number, number] {
+   //    return [this.usedWidth, this.usedHeight];
+   // }
    protected propagateUpdate(ctx?: CanvasRenderingContext2D): void {
       this.updateText(ctx ?? this.parent.getCtx());
    }
-   setDimensions(width?: number, height?: number) {
-      this.width = width ?? this.width;
-      this.height = height ?? this.height;
-      if (width != undefined || height != undefined) {
-         // this.updateText(this.parent.getCtx());
-         this.propagateUpdate();
-      }
-   }
+   // setDimensions(width?: number, height?: number) {
+   //    this.width = width ?? this.width;
+   //    this.height = height ?? this.height;
+   //    if (width != undefined || height != undefined) {
+   //       // this.updateText(this.parent.getCtx());
+   //       this.propagateUpdate();
+   //    }
+   // }
 }
 
 

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -20,7 +20,37 @@ enum twrWindowEvents {
    CLOSE,
    
 }
-
+// interface AsyncLikeSyncInterface<T extends any[]> {
+//    isAsync: boolean,
+//    then: <U>(func: (...val: T) => U) => U | Promise<U>;
+// }
+class FakePromise<T> implements PromiseLike<T> {
+   private val: T | Promise<T>;
+   constructor(val: T) {
+      this.val = val;
+   }
+   then<TResult1, TResult2>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined): PromiseLike<TResult1 | TResult2> {
+      if ((onfulfilled == null || onfulfilled == undefined) && (onrejected == null || onrejected == undefined)) {
+         throw new Error(`FakePromise.then must have at least one parameter defined!!`);
+      }
+      if (this.val instanceof Promise) {
+         return new FakePromise(this.val.then(onfulfilled, onrejected));
+      }
+      throw new Error();
+   }
+   extractVal(): T | Promise<T> {
+      return this.val;
+   }
+   private setupNextFakePromise<U>(val: U | FakePromise<U> | Promise<U>): FakePromise<U> | FakePromise<Promise<U>> {
+      if (val instanceof FakePromise) {
+         return val;
+      } else if (val instanceof Promise) {
+         return new FakePromise(val);
+      } else {
+         return new FakePromise(val);
+      }
+   }
+}
 enum MenuItemEvents {
    HOVERING,
    UNHOVERED,
@@ -2213,17 +2243,69 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       return propField[0] as number;
    }
 
-   twrWindowMenuWidgetListProps(mod: IWasmModule, widgetID: number, lengthPtr: number) {
+   // private wrapPossibleSync<T extends (...args: any[]) => any>(func: T, ...args: Parameters<T>): AsyncLikeSyncInterface<[ReturnType<T>]> {
+   //    const val = func(...args);
+   //    if (val instanceof Promise) {
+   //       return {
+   //          isAsync: true,
+   //          then: <U>(n_func: (val: ReturnType<T>) => U): U | Promise<U> => {
+   //             return val.then(n_func);
+   //          }
+   //       };
+   //    } else {
+   //       return {
+   //          isAsync: false,
+   //          then: <U>(n_func: (val: ReturnType<T>) => U): U | Promise<U> => {
+   //             return n_func(val);
+   //          }
+   //       }
+   //    }
+   // }
+   private wrapPossibleSync<T extends (...args: any[]) => any>(func: T, ...args: Parameters<T>): FakePromise<ReturnType<T>> | Promise<ReturnType<T>> {
+      const val = func(...args);
+      if (val instanceof Promise) {
+         // return {
+         //    isAsync: true,
+         //    then: <U>(n_func: (val: ReturnType<T>) => U): U | Promise<U> => {
+         //       return val.then(n_func);
+         //    }
+         // };
+         return val;
+      } else {
+         // return {
+         //    isAsync: false,
+         //    then: <U>(n_func: (val: ReturnType<T>) => U): U | Promise<U> => {
+         //       return n_func(val);
+         //    }
+         // }
+         
+         return new FakePromise(val);
+      }
+   }
+   // private waitForAll<
+   //    // U,
+   //    // Fns extends ((...args: any[]) => any)[],
+   //    // FinalFn extends (...args: Parameters<Fns[number]>) => U
+   //    T extends any[]
+   // >(...args: AsyncLikeSyncInterface<T[number]>[]): AsyncLikeSyncInterface<T> {
+   //    let isAsync = false;
+   //    for (let i = 0; i < args.length; i++) {
+   //       if (args instanceof Promise)
+   //    }
+   //    return {
+   //       then: <U>(n_func: (...args: T) => U): U | Promise<U> => {
+
+   //       }
+   //    }
+   // }
+   twrWindowMenuWidgetListProps(mod: IWasmModuleAsync, widgetID: number, lengthPtr: number) {
       const widget = this.widgets.get(widgetID);
       if (widget == undefined) throw new Error(`twrWindowMenuWidgetListProps: Error! was given an invalid widgetID (${widgetID})`);
 
-      const props = [];
+      const props: Uint8Array<ArrayBufferLike>[] = [];
       let totalSize = 0;
       for (const name in widget[1].publicProperties) {
          const ru8=mod.wasmMem.stringToU8(name);
-         // const strIndex:number=this.malloc(ru8.length+1);
-         // this.mem8u.set(ru8, strIndex);
-         // this.mem8u[strIndex+ru8.length]=0;
    
          totalSize += ru8.length + 1;
          props.push(ru8);
@@ -2231,20 +2313,20 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       totalSize += props.length * 4;
       mod.wasmMem.setLong(lengthPtr, props.length);
 
-      const alloc = mod.malloc(totalSize);
-      let offset = props.length*4;
-      for (let i = 0; i < props.length; i++) {
-         mod.wasmMem.setDouble(i * 4, offset);
-         mod.wasmMem.mem8u.set(props[i], offset);
-         mod.wasmMem.mem8u[offset+props[i].length] = 0; //null ptr at end
-         offset += props[i].length + 1;
-      }
+      return this.wrapPossibleSync(mod.malloc, totalSize).then((alloc) => {
+         let offset = props.length*4;
+         for (let i = 0; i < props.length; i++) {
+            mod.wasmMem.setLong(i * 4, offset);
+            mod.wasmMem.mem8u.set(props[i], offset);
+            mod.wasmMem.mem8u[offset+props[i].length] = 0; //null ptr at end
+            offset += props[i].length + 1;
+         }
+         return alloc;
+      });
+      
 
-      return alloc
-
+      // return alloc
    }
-
-
 
 }
 

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -34,6 +34,26 @@ type MenuItemEventData = [ MenuItemEvents.HOVERING ]
    | [ MenuItemEvents.MOUSE_MOVE, number, number]
    | [ MenuItemEvents.CLICKED_OFF];
 
+
+interface GlobalWidgetProperties {
+   borderColor: string,
+   selectedColor: string,
+   menuOptionFont: string,
+   widgetTextFont: string,
+   menuOpenOffset: number,
+   subMenuOpenOffset: number,
+   textColor: string,
+   reservedPrefixLen: number,
+   xPadding: number,
+   yPadding: number,
+   menuBorderWidth: number,
+   menuBorderColor: string,
+   emptyMenuHeight: number,
+   emptyMenuWidth: number,
+   radioMenuPrefix: string;
+   checkBoxCheckedPrefix: string;
+   checkBoxUncheckedPrefix: string;
+};
 interface WidgetManager {
    childUpdated: (ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) => void;
    //really, really long type. Basically accepts any class constructor that created a Widget
@@ -46,6 +66,7 @@ interface WidgetManager {
    handleDelete: (ctx: CanvasRenderingContext2D, widget: Widget) => void;
 }
 interface Widget {
+   readonly globalProps: GlobalWidgetProperties;
    readonly parent: WidgetManager; 
    readonly id: number;
    readonly handledEvents: MenuItemEvents[];
@@ -57,6 +78,8 @@ interface Widget {
    delete: (ctx: CanvasRenderingContext2D) => Widget[];
    setVisibility: (ctx: CanvasRenderingContext2D, visibility: boolean) => void;
    isVisible: () => boolean;
+
+   fullUpdate: (ctx: CanvasRenderingContext2D) => void;
 }
 
 interface WidgetConstructor {
@@ -69,32 +92,10 @@ interface ButtonWidgetConstructor extends WidgetConstructor {
    suffixText?: string;
    centeredHorizontally?: boolean;
    reservedPrefixSpace?: number;
-   textFont?: string;
-   textColor?: string;
-   buttonColor?: string;
-   selectedButtonColor?: string;
-}
-
-//implementation of Map that will automatically
-// set a default value for a get on an unknown item
-class DefaultMap<K, V> extends Map<K, V> {
-   private readonly def: V;
-   constructor(def: V) {
-      super();
-      this.def = def;
-   }
-   
-   get(key: K): V {
-      const val = super.get(key);
-      if (val != undefined)
-         return val;
-      const newVal = structuredClone(this.def);
-      super.set(key, newVal);
-      return newVal;
-   }
 }
 
 class Button implements Widget, WidgetEvents {
+   readonly globalProps: GlobalWidgetProperties;
    readonly parent: WidgetManager; 
    readonly id: number;
    readonly handledEvents: MenuItemEvents[] = [
@@ -113,17 +114,13 @@ class Button implements Widget, WidgetEvents {
    private suffixText?: string;
    private centeredHorizontally: boolean;
    private reservedPrefixSpace: number;
-   private textFont: string;
-   private textColor: string;
-   private buttonColor: string;
-   private selectedButtonColor: string;
 
    private selected: boolean = false;
    private events: Set<((ctx: CanvasRenderingContext2D) => void)> = new Set();
 
    private visibility: boolean = true;
 
-   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, cons: ButtonWidgetConstructor) {
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, cons: ButtonWidgetConstructor, globalProps: GlobalWidgetProperties) {
       this.parent = parent;
       this.id = id;
 
@@ -132,16 +129,16 @@ class Button implements Widget, WidgetEvents {
       this.suffixText = cons.suffixText;
       this.centeredHorizontally = cons.centeredHorizontally ?? false;
       this.reservedPrefixSpace = cons.reservedPrefixSpace ?? 0;
-      this.textFont = cons.textFont ?? "16px Serif";
-      this.textColor = cons.textColor ?? "white";
-      this.buttonColor = cons.buttonColor ?? "grey";
-      this.selectedButtonColor = cons.selectedButtonColor ?? "darkgrey";
+      this.globalProps = globalProps;
 
       const [minWidth, minHeight] = this.getMinSize(ctx);
 
       this.width = cons.width ?? minWidth;
       this.height = cons.height ?? minHeight;
       
+      this.textOffsets = this.getTextOffsets(ctx);
+   }
+   fullUpdate(ctx: CanvasRenderingContext2D) {
       this.textOffsets = this.getTextOffsets(ctx);
    }
    delete(ctx: CanvasRenderingContext2D) {
@@ -187,7 +184,7 @@ class Button implements Widget, WidgetEvents {
 
    private getFullMinSize(ctx: CanvasRenderingContext2D): [number, number, number, number] {
       ctx.save();
-      ctx.font = this.textFont;
+      ctx.font = this.globalProps.widgetTextFont;
 
       const spaceMeasure = ctx.measureText(" ");
       const spaceWidth = spaceMeasure.width;
@@ -229,12 +226,12 @@ class Button implements Widget, WidgetEvents {
 
       ctx.save();
 
-      const button_color = this.selected ? this.selectedButtonColor : this.buttonColor ;
+      const button_color = this.selected ? this.globalProps.selectedColor : this.globalProps.borderColor;
       ctx.fillStyle = button_color;
       ctx.fillRect(offsetX, offsetY, this.width, this.height);
 
-      ctx.font = this.textFont;
-      ctx.fillStyle = this.textColor;
+      ctx.font = this.globalProps.widgetTextFont;
+      ctx.fillStyle = this.globalProps.textColor;
       if (this.prefixText != undefined) {
          ctx.fillText(
             this.prefixText,
@@ -296,16 +293,10 @@ class Button implements Widget, WidgetEvents {
 }
 
 interface MenuWidgetConstructor extends WidgetConstructor {
-   minimumWidth?: number;
-   minimumHeight?: number;
-   menuColor?: string;
-   yPadding?: number;
-   minChildHeight?: number;
-   borderColor?: string;
-   borderWidth?: number;
 }
 
 class Menu implements Widget, WidgetManager {
+   readonly globalProps: GlobalWidgetProperties;
    readonly parent: WidgetManager;
    readonly id: number;
 
@@ -315,53 +306,40 @@ class Menu implements Widget, WidgetManager {
       MenuItemEvents.MOUSE_MOVE,
       MenuItemEvents.CLICKED_OFF
    ];
-
-   private absoluteMinWidth: number;
-   private absoluteMinHeight: number;
-   private minChildHeight: number;
    
    private width?: number;
    private height?: number;
-   private yPadding: number;
-
-   private childWidth: number;
-   private childHeight: number;
-
-   private menuColor: string;
 
    private children: [Widget, number][] = [];
 
    private unhoverHandlers: (() => void)[] = [];
    private clickedOffHandlers: (() => void)[] = [];
 
+   private childHeight: number;
+   private childWidth: number;
 
    //the currently hovered over/selected item 
    //resets to undefined on menu update or UNHOVERED event
    private selectedItem?: [Widget, number];
 
-   private borderColor: string;
-   private borderWidth: number;
-
    private visibility: boolean = true;
    
-   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuWidgetConstructor) {
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
+      this.globalProps = globalProps;
       this.parent = parent;
       this.id = id;
 
-      this.absoluteMinWidth = props.minimumWidth ?? 5;
-      this.absoluteMinHeight = props.minimumHeight ?? 5;
-      this.childWidth = this.absoluteMinWidth;
-      this.childHeight = this.absoluteMinHeight;
-      this.minChildHeight = props.minChildHeight ?? 5;
-
       this.width = props.width;
       this.height = props.height;
-      this.yPadding = props.yPadding ?? 10;
-
-      this.borderColor = props.borderColor ?? "black";
-      this.borderWidth = props.borderWidth ?? 0.0;
-
-      this.menuColor = props.menuColor ?? "gray";
+      this.childHeight = globalProps.emptyMenuHeight;
+      this.childWidth = globalProps.emptyMenuWidth;
+   }
+   fullUpdate(ctx: CanvasRenderingContext2D) {
+      for (const [widget,] of this.children) {
+         widget.fullUpdate(ctx);
+      }
+      this.updateChildSize(ctx);
+      this.selectedItem = undefined;
    }
 
    setVisibility(ctx: CanvasRenderingContext2D, visibility: boolean) {
@@ -416,9 +394,9 @@ class Menu implements Widget, WidgetManager {
             if (child[0] == relativeChild) {
                nY += child[1];
                if (nX > 0)
-                  nX += this.borderWidth * 2;
+                  nX += this.globalProps.menuBorderWidth * 2;
                else
-                  nX -= this.borderWidth;
+                  nX -= this.globalProps.menuBorderWidth;
                nextRelative = this;
                break;
             }
@@ -445,16 +423,16 @@ class Menu implements Widget, WidgetManager {
          childWidth = Math.max(childWidth, width);
          // maxChildHeight = Math.max(maxChildHeight, height+this.yPadding);
          const [, height] = widget.getDimensions();
-         childHeight += height + this.yPadding;
+         childHeight += height + this.globalProps.yPadding;
       }
-      childWidth += this.borderWidth * 2;
-      childHeight += this.borderWidth * 2;
+      childWidth += this.globalProps.menuBorderWidth * 2;
+      childHeight += this.globalProps.menuBorderWidth * 2;
 
       // console.log(childWidth, childHeight);
 
-      childWidth = Math.max(childWidth, this.absoluteMinWidth);
+      childWidth = Math.max(childWidth, this.globalProps.emptyMenuWidth);
       // let childHeight = Math.max(maxChildHeight*this.children.length, this.absoluteMinHeight);
-      childHeight = Math.max(childHeight, this.absoluteMinHeight);
+      childHeight = Math.max(childHeight, this.globalProps.emptyMenuHeight);
 
       const newWidth = this.width ?? childWidth;
       const newHeight = this.height ?? childHeight;
@@ -468,17 +446,17 @@ class Menu implements Widget, WidgetManager {
          this.lastWidth = newWidth;
          this.lastHeight = newHeight;
          
-         let curHeight = this.borderWidth;
+         let curHeight = this.globalProps.menuBorderWidth;
          for (const widget of this.children) {
             if (!widget[0].isVisible())
                continue;
             const [, height] = widget[0].getDimensions();
             this.supressChildUpdates = true;
-            widget[0].setDimensions(ctx, newWidth - this.borderWidth * 2, undefined);
+            widget[0].setDimensions(ctx, newWidth - this.globalProps.menuBorderWidth * 2, undefined);
             widget[1] = curHeight;
             this.supressChildUpdates = false;
             // curHeight += maxChildHeight;
-            curHeight += height + this.yPadding;
+            curHeight += height + this.globalProps.yPadding;
          }
 
       }
@@ -496,9 +474,9 @@ class Menu implements Widget, WidgetManager {
    addChild<
       T extends Widget, 
       U, 
-      O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U) => T
+      O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U, globalProps: GlobalWidgetProperties) => T
    >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
-      const widget: T = new cons(ctx, this, id, props);
+      const widget: T = new cons(ctx, this, id, props, this.globalProps);
 
       this.children.push([widget, 0]);
       this.updateChildSize(ctx, true);
@@ -523,7 +501,7 @@ class Menu implements Widget, WidgetManager {
       const width = this.width ?? this.childWidth;
       const height = this.height ?? this.childHeight;
 
-      ctx.fillStyle = this.menuColor;
+      ctx.fillStyle = this.globalProps.borderColor;
       ctx.fillRect(
          offsetX,
          offsetY,
@@ -531,22 +509,23 @@ class Menu implements Widget, WidgetManager {
          height,
       );
 
-      if (this.borderWidth > 0) {
-         ctx.strokeStyle = this.borderColor;
-         ctx.lineWidth = this.borderWidth;
+      const menuBorderWidth = this.globalProps.menuBorderWidth;
+      if (menuBorderWidth > 0) {
+         ctx.strokeStyle = this.globalProps.menuBorderColor;
+         ctx.lineWidth = menuBorderWidth;
          ctx.beginPath();
          ctx.rect(
-            offsetX + this.borderWidth/2.0, 
-            offsetY + this.borderWidth/2.0, 
-            width - this.borderWidth,
-            height - this.borderWidth
+            offsetX + menuBorderWidth/2.0, 
+            offsetY + menuBorderWidth/2.0, 
+            width - menuBorderWidth,
+            height - menuBorderWidth
          );
          ctx.stroke();
          ctx.closePath();
       }
 
       for (const widget of this.children) {
-         widget[0].render(ctx, offsetX + this.borderWidth, offsetY + widget[1] + this.borderWidth);
+         widget[0].render(ctx, offsetX + menuBorderWidth, offsetY + widget[1] + menuBorderWidth);
       }
 
       ctx.restore();
@@ -560,7 +539,8 @@ class Menu implements Widget, WidgetManager {
 
    private mouseInWidgetBounds(widget: Widget, widgetY: number, x: number, y: number) {
       const [widgetWidth, widgetHeight] = widget.getDimensions();
-      return this.borderWidth <= x && x <= this.borderWidth + widgetWidth
+      const borderWidth = this.globalProps.menuBorderWidth;
+      return borderWidth <= x && x <= borderWidth + widgetWidth
             && widgetY <= y && y <= widgetY + widgetHeight;
    }
 
@@ -597,7 +577,7 @@ class Menu implements Widget, WidgetManager {
             const [, eX, eY] = event;
             this.updateSelectedObject(ctx, eX, eY);
             if (this.selectedItem) {
-               const [x, y] = [eX - this.borderWidth, eY - this.selectedItem[1]];
+               const [x, y] = [eX - this.globalProps.menuBorderWidth, eY - this.selectedItem[1]];
                this.dispatchEvent(ctx, this.selectedItem[0], [MenuItemEvents.MOUSE_MOVE, x, y]);
             }
          }
@@ -608,7 +588,7 @@ class Menu implements Widget, WidgetManager {
             this.updateSelectedObject(ctx, eX, eY);
             const selected = this.selectedItem;
             if (selected) {
-               const [x, y] = [eX - this.borderWidth, eY - selected[1]];
+               const [x, y] = [eX - this.globalProps.menuBorderWidth, eY - selected[1]];
                this.dispatchEvent(ctx, selected[0], [MenuItemEvents.CLICKED, x, y, button]);
             }
             for (const [widget,] of this.children) {
@@ -686,55 +666,37 @@ class Menu implements Widget, WidgetManager {
 
 interface RadioMenuWidgetConstructor extends MenuWidgetConstructor {
    optionHeight?: number;
-   selectedSymbol?: string;
-   reservedPrefixLength?: number;
-   optionTextFont?: string;
-   optionTextColor?: string;
-   hoveredBackgroundColor?: string;
 }
 
 class RadioMenu implements Widget, WidgetManager, WidgetEvents {
+   readonly globalProps: GlobalWidgetProperties;
    readonly parent: WidgetManager;
    readonly id: number;
    readonly handledEvents: MenuItemEvents[];
 
    private menu: Menu;
    private optionHeight: number;
-   private selectedSymbol: string;
-   private reservedPrefixLength: number;
-   private optionTextFont: string;
-   private optionTextColor: string;
-   private backgroundColor: string;
-   private hoveredBackgroundColor: string;
    
    private options: Map<string, Button> = new Map();
    private selected?: string;
 
    private events: Set<(ctx: CanvasRenderingContext2D, opt: string) => void> = new Set();
 
-   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: RadioMenuWidgetConstructor) {
-      this.backgroundColor = props.menuColor ?? "gray";
-      props.menuColor = this.backgroundColor;
-
-      this.menu = new Menu(ctx, this, 0, props);
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: RadioMenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
+      this.globalProps = globalProps;
+      this.menu = new Menu(ctx, this, 0, props, globalProps);
       this.parent = parent;
       this.id = id;
 
       this.optionHeight = props.optionHeight ?? 20;
-
-      this.selectedSymbol = props.selectedSymbol ?? "*";
-      const selectSymbolMeasure = ctx.measureText(this.selectedSymbol);
-      const selectSymbolWidth = selectSymbolMeasure.width;
-      const spaceMeasure = ctx.measureText(" ");
-      const spaceWidth = spaceMeasure.width;
-      this.reservedPrefixLength = props.reservedPrefixLength ?? (selectSymbolWidth + spaceWidth*2);
       
-      this.optionTextFont = props.optionTextFont ?? "16px Seriph";
-      this.optionTextColor = props.optionTextColor ?? "black";
-      this.hoveredBackgroundColor = props.hoveredBackgroundColor ?? "lightgray";
       this.handledEvents = this.menu.handledEvents;
    }
-
+   fullUpdate(ctx: CanvasRenderingContext2D) {
+      if (this.selected != undefined)
+         this.options.get(this.selected)!.setButtonPrefixText(ctx, this.globalProps.radioMenuPrefix);
+      this.menu.fullUpdate(ctx);
+   }
    setVisibility(ctx: CanvasRenderingContext2D, visible: boolean) {
       this.menu.setVisibility(ctx, visible);
    }
@@ -749,21 +711,15 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
       let prefix = undefined;
       if (this.selected == undefined) {
          this.selected = opt;
-         prefix = this.selectedSymbol;
+         prefix = this.globalProps.radioMenuPrefix;
       }
-
-      console.log("reservedPrefixLength: ", this.reservedPrefixLength);
 
       const buttonOpts: ButtonWidgetConstructor = {
          width: -1,
          height: this.optionHeight,
          text: opt,
          prefixText: prefix,
-         reservedPrefixSpace: this.reservedPrefixLength,
-         textColor: this.optionTextColor,
-         textFont: this.optionTextFont,
-         buttonColor: this.backgroundColor,
-         selectedButtonColor: this.hoveredBackgroundColor,
+         reservedPrefixSpace: this.globalProps.reservedPrefixLen,
       };
       const button: Button = this.menu.addChild(ctx, 0, Button, buttonOpts);
 
@@ -782,7 +738,7 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
             button.setButtonPrefixText(ctx, undefined);
          }
          this.selected = opt;
-         this.options.get(this.selected)!.setButtonPrefixText(ctx, this.selectedSymbol);
+         this.options.get(this.selected)!.setButtonPrefixText(ctx, this.globalProps.radioMenuPrefix);
          
          for (const event of this.events) {
             event(ctx, this.selected);
@@ -841,14 +797,10 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
 }
 
 interface MenuBarWidgetConstructor extends WidgetConstructor {
-   minimumWidth?: number;
-   minimumHeight?: number;
-   menuColor?: string;
-   xPadding?: number;
-   minChildWidth?: number;
 }
 
 class MenuBar implements Widget, WidgetManager {
+   readonly globalProps: GlobalWidgetProperties;
    readonly parent: WidgetManager;
    readonly id: number;
    readonly handledEvents: MenuItemEvents[] = [
@@ -860,11 +812,6 @@ class MenuBar implements Widget, WidgetManager {
 
    private width?: number;
    private height?: number;
-   private minimumWidth: number;
-   private minimumHeight: number;
-   private menuColor: string;
-   private xPadding: number;
-   private minChildWidth: number;
 
    private calcHeight;
    private calcWidth;
@@ -875,20 +822,21 @@ class MenuBar implements Widget, WidgetManager {
 
    private visible: boolean = true;
 
-   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuBarWidgetConstructor) {
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuBarWidgetConstructor, globalProps: GlobalWidgetProperties) {
+      this.globalProps = globalProps;
       this.parent = parent;
       this.id = id;
 
       this.width = props.width;
       this.height = props.height;
 
-      this.minimumWidth = props.minimumWidth ?? 10;
-      this.minimumHeight = props.minimumHeight ?? 10;
-      this.calcWidth = this.minimumWidth;
-      this.calcHeight = this.minimumHeight;
-      this.menuColor = props.menuColor ?? "#B0B0B0";
-      this.xPadding = props.xPadding ?? 5;
-      this.minChildWidth = props.minChildWidth ?? 10;
+      this.calcWidth = this.globalProps.emptyMenuWidth;
+      this.calcHeight = this.globalProps.emptyMenuWidth;
+   }
+   fullUpdate(ctx: CanvasRenderingContext2D) {
+      for (const [widget,] of this.children) {
+         widget.fullUpdate(ctx);
+      }
    }
 
    setVisibility(ctx: CanvasRenderingContext2D, visible: boolean) {
@@ -1027,7 +975,7 @@ class MenuBar implements Widget, WidgetManager {
    private updateChildren(ctx: CanvasRenderingContext2D) {
       this.selected = undefined;
 
-      let minHeight = this.minimumHeight;
+      let minHeight = this.globalProps.emptyMenuWidth;
       let width = 0;
       for (const [widget,] of this.children) {
          if (!widget.isVisible())
@@ -1037,7 +985,7 @@ class MenuBar implements Widget, WidgetManager {
          const [widgetMinWidth, widgetMinHeight] = widget.getMinSize(ctx);
          
          minHeight = Math.max(minHeight, widgetHeight, widgetMinHeight);
-         width += Math.max(this.minChildWidth, widgetWidth, widgetMinWidth) + this.xPadding;
+         width += Math.max(this.globalProps.emptyMenuWidth, widgetWidth, widgetMinWidth) + this.globalProps.xPadding;
          // console.log(`${widgetWidth}, ${widgetMinWidth}, ${Math.max(this.minChildWidth, widgetWidth, widgetMinWidth)}`);
       }
 
@@ -1055,14 +1003,14 @@ class MenuBar implements Widget, WidgetManager {
 
          const [widgetWidth, widgetHeight] = widget[0].getDimensions();
          const [minWidgetWidth,] = widget[0].getMinSize(ctx);
-         const nWidth = Math.max(this.minChildWidth, widgetWidth, minWidgetWidth);
+         const nWidth = Math.max(this.globalProps.emptyMenuWidth, widgetWidth, minWidgetWidth);
          widget[0].setDimensions(
             ctx,
             nWidth,
             tmpHeight
          );
          widget[1] = pos;
-         pos += nWidth + this.xPadding;
+         pos += nWidth + this.globalProps.xPadding;
       }
       this.supressChildUpdates = false;
    }
@@ -1275,11 +1223,13 @@ class RootWidgetManager implements WidgetManager {
 }
 
 interface MenuButtonWidgetConstructor extends ButtonWidgetConstructor {
-   menuOptions: MenuWidgetConstructor,
+   menuWidth?: number;
+   menuHeight?: number;
    openToRight?: boolean,
    offset?: number,
 }
 class MenuButton implements Widget, WidgetManager {
+   readonly globalProps: GlobalWidgetProperties;
    readonly parent: WidgetManager;
    readonly id: number;
    readonly handledEvents: MenuItemEvents[] = [
@@ -1299,20 +1249,23 @@ class MenuButton implements Widget, WidgetManager {
 
    private visible: boolean = true;
 
-   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuButtonWidgetConstructor) {
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuButtonWidgetConstructor, globalProps: GlobalWidgetProperties) {
+      this.globalProps = globalProps;
       this.parent = parent;
       this.id = id;
 
       this.openToRight = props.openToRight ?? false;
       this.offset = props.offset ?? 0;
 
-      this.button = new Button(ctx, this, 0, props);
+      this.button = new Button(ctx, this, 0, props, this.globalProps);
 
-      const menuOptions = structuredClone(props.menuOptions);
       const [width, ] = this.button.getDimensions();
 
-      menuOptions.minimumWidth = menuOptions.minimumWidth ?? width; 
-      this.menu = new Menu(ctx, this, 1, menuOptions);
+      // menuOptions.minimumWidth = menuOptions.minimumWidth ?? width; 
+      this.menu = new Menu(ctx, this, 1, {
+         width: props.menuWidth,
+         height: props.menuHeight
+      }, globalProps);
 
       this.button.addEvent((() => {
          const [width,height] = this.button.getDimensions();
@@ -1327,6 +1280,10 @@ class MenuButton implements Widget, WidgetManager {
          this.menuOpened = false;
       }).bind(this));
 
+   }
+   fullUpdate(ctx: CanvasRenderingContext2D) {
+      this.button.fullUpdate(ctx);
+      this.menu.fullUpdate(ctx);
    }
 
    setVisibility(ctx: CanvasRenderingContext2D, visible: boolean) {
@@ -1394,7 +1351,7 @@ class MenuButton implements Widget, WidgetManager {
    addChild<
       T extends Widget, 
       U, 
-      O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U) => T
+      O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U, globalProps: GlobalWidgetProperties) => T
    >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
       return this.menu.addChild(ctx, id, cons, props);
    }
@@ -1408,17 +1365,14 @@ class MenuButton implements Widget, WidgetManager {
 
 interface SeperatorWidgetConstructor extends WidgetConstructor {
    seperatorText: string,
-   seperatorFont?: string,
-   seperatorColor?: string
 }
 class Seperator implements Widget {
+   readonly globalProps: GlobalWidgetProperties;
    readonly parent: WidgetManager;
    readonly id: number;
    readonly handledEvents: MenuItemEvents[] = [];
 
    private seperatorText: string;
-   private seperatorFont: string;
-   private seperatorColor: string;
 
    private width: number;
    private height: number;
@@ -1430,17 +1384,19 @@ class Seperator implements Widget {
 
    private visible: boolean = true;
 
-   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: SeperatorWidgetConstructor) {
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: SeperatorWidgetConstructor, globalProps: GlobalWidgetProperties) {
+      this.globalProps = globalProps;
       this.parent = parent;
       this.id = id;
       
       this.seperatorText = props.seperatorText;
-      this.seperatorColor = props.seperatorColor ?? "black";
-      this.seperatorFont = props.seperatorFont ?? "16px Seriph";
 
       this.width = props.width ?? 0;
       this.height = props.height ?? 0;
       
+      this.updateText(ctx);
+   }
+   fullUpdate(ctx: CanvasRenderingContext2D) {
       this.updateText(ctx);
    }
 
@@ -1462,7 +1418,7 @@ class Seperator implements Widget {
       ctx.save();
       // console.log(this.width);
 
-      ctx.font = this.seperatorFont;
+      ctx.font = this.globalProps.widgetTextFont;
       const metrics = ctx.measureText(this.seperatorText);
 
       const repeats = Math.floor(this.width/metrics.width);
@@ -1488,8 +1444,8 @@ class Seperator implements Widget {
 
       ctx.save();
 
-      ctx.font = this.seperatorFont;
-      ctx.fillStyle = this.seperatorColor;
+      ctx.font = this.globalProps.widgetTextFont;
+      ctx.fillStyle = this.globalProps.textColor;
 
       // console.log(this.x, offsetX, this.textXOffset, this.x + offsetX + this.textXOffset);
       ctx.fillText(
@@ -1516,15 +1472,9 @@ class Seperator implements Widget {
 }
 interface CheckBoxWidgetConstructor extends WidgetConstructor {
    text: string;
-   checkedSymbol?: string;
-   unCheckedSymbol?: string;
-   reservedPrefixSpace?: number;
-   textFont?: string;
-   textColor?: string;
-   buttonColor?: string;
-   selectedButtonColor?: string;
 }
 class CheckBox implements Widget, WidgetManager, WidgetEvents {
+   readonly globalProps: GlobalWidgetProperties;
    readonly parent: WidgetManager;
    readonly id: number;
    readonly handledEvents: MenuItemEvents[];
@@ -1532,45 +1482,41 @@ class CheckBox implements Widget, WidgetManager, WidgetEvents {
    private button: Button;
    private changeEventHandlers: Set<(ctx: CanvasRenderingContext2D, selected: boolean) => void> = new Set();
    private selected = false;
-   private checkedSymbol: string;
-   private uncheckedSymbol?: string;
 
-   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: CheckBoxWidgetConstructor) {
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: CheckBoxWidgetConstructor, globalProps: GlobalWidgetProperties) {
+      this.globalProps = globalProps;
       this.parent = parent;
       this.id = id;
 
-      this.checkedSymbol = props.checkedSymbol ?? "*";
-      const checkedSymbolWidth = ctx.measureText(this.checkedSymbol).width;
-      this.uncheckedSymbol = props.unCheckedSymbol;
-      const uncheckedSymbolWidth = ctx.measureText(props.unCheckedSymbol ?? "").width;
-      const spaceWidth = ctx.measureText(" ").width;
-      const reservedPrefixSpace = props.reservedPrefixSpace ?? (Math.max(checkedSymbolWidth, uncheckedSymbolWidth) + spaceWidth * 2.0);
 
       const buttonCons: ButtonWidgetConstructor = {
          text: props.text,
-         reservedPrefixSpace: reservedPrefixSpace,
-         prefixText: this.uncheckedSymbol,
-         textFont: props.textFont,
-         textColor: props.textColor,
-         buttonColor: props.buttonColor,
-         selectedButtonColor: props.selectedButtonColor,
          width: props.width,
          height: props.height
       };
-      this.button = new Button(ctx, this, 0, buttonCons);
+      this.button = new Button(ctx, this, 0, buttonCons, this.globalProps);
       this.handledEvents = this.button.handledEvents;
 
       this.button.addEvent((ctx) => {
          this.selected = !this.selected;
          if (this.selected) {
-            this.button.setButtonPrefixText(ctx, this.checkedSymbol);
+            this.button.setButtonPrefixText(ctx, this.globalProps.checkBoxCheckedPrefix);
          } else {
-            this.button.setButtonPrefixText(ctx, this.uncheckedSymbol);
+            this.button.setButtonPrefixText(ctx, this.globalProps.checkBoxUncheckedPrefix);
          }
          for (const callback of this.changeEventHandlers) {
             callback(ctx, this.selected);
          }
       })
+   }
+   fullUpdate(ctx: CanvasRenderingContext2D) {
+      this.button.fullUpdate(ctx);
+      this.button.setButtonPrefixText(
+         ctx,
+         this.selected
+            ? this.globalProps.checkBoxCheckedPrefix
+            : this.globalProps.checkBoxUncheckedPrefix
+      );
    }
    setVisibility(ctx: CanvasRenderingContext2D, visibility: boolean) {
       this.button.setVisibility(ctx, visibility);

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -1962,28 +1962,51 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          case WidgetType.CheckBox:
          {
             // struct twr_widget_check_box_constructor {
+            //    /// @brief Base widget constructor
             //    struct twr_widget_constructor base;
+            //    /**
+            //     * Text for the check box
+            //     * defaults to Lorem Ipsum
+            //     */
             //    const char* text;
+            //    /**
+            //     * Text prefix used to indicate that the check box is clicked
+            //     * defaults to *
+            //     */
             //    const char* checked_symbol;
+            //    /**
+            //     * text prefix used to indicate that the check box is not clicked
+            //     * defaults to ""
+            //     */
             //    const char* unchecked_symbol;
+            //    /**
+            //     * amount of space to reserve for the checked and unchecked symbol prefixes
+            //     * defaults to max(width(checked_symbol),width(unchecked_symbol)) + width(" ") * 2
+            //     */
             //    long reserved_prefix_space;
+            //    /// @brief defaults to "16px Seriph"
             //    const char* text_font;
+            //    /// @brief defaults to "Black"
             //    const char* text_color;
+            //    /// @brief defaults to #B0B0B0
             //    const char* button_color;
+            //    /// @brief defaults to #D0D0D0
             //    const char* selected_button_color;
             // };
 
             const props: CheckBoxWidgetConstructor = {
-               
-               const char* text;
-               const char* checked_symbol;
-               const char* unchecked_symbol;
-               long reserved_prefix_space;
-               const char* text_font;
-               const char* text_color;
-               const char* button_color;
-               const char* selected_button_color;
+               text: getStringOrDef(extraPtr + 0, "Lorem Ipsum"),
+               checkedSymbol: getStringOrDef(extraPtr + 4, "*"),
+               unCheckedSymbol: getStringOrDef(extraPtr + 8, ""),
+               reservedPrefixSpace: getLongOrDef(extraPtr + 12, undefined),
+               textFont: getStringOrDef(extraPtr + 16, "16px Seriph"),
+               textColor: getStringOrDef(extraPtr + 20, "Black"),
+               buttonColor: getStringOrDef(extraPtr + 24, "#B0B0B0"),
+               selectedButtonColor: getStringOrDef(extraPtr + 28, "#D0D0D0"),
             };
+            console.log("checkbox: ", props);
+            const widget: CheckBox = menu.addChild(this.ctx, id, CheckBox, props);
+            this.widgets.set(id, [WidgetType.CheckBox, widget]);
          }
          break;
 

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -63,6 +63,10 @@ interface WidgetConstructor {
 }
 interface ButtonWidgetConstructor extends WidgetConstructor {
    text: string;
+   prefixText?: string;
+   suffixText?: string;
+   centeredHorizontally?: boolean;
+   reservedPrefixSpace?: number;
    textFont?: string;
    textColor?: string;
    buttonColor?: string;
@@ -100,9 +104,13 @@ class Button implements Widget, WidgetEvents {
    private width: number;
    private height: number;
 
-   private textOffsets: [number, number];
+   private textOffsets: [number, number, number];
 
    private text: string;
+   private prefixText?: string;
+   private suffixText?: string;
+   private centeredHorizontally: boolean;
+   private reservedPrefixSpace: number;
    private textFont: string;
    private textColor: string;
    private buttonColor: string;
@@ -116,6 +124,10 @@ class Button implements Widget, WidgetEvents {
       this.id = id;
 
       this.text = cons.text;
+      this.prefixText = cons.prefixText;
+      this.suffixText = cons.suffixText;
+      this.centeredHorizontally = cons.centeredHorizontally ?? false;
+      this.reservedPrefixSpace = cons.reservedPrefixSpace ?? 0;
       this.textFont = cons.textFont ?? "16px Serif";
       this.textColor = cons.textColor ?? "white";
       this.buttonColor = cons.buttonColor ?? "grey";
@@ -151,25 +163,48 @@ class Button implements Widget, WidgetEvents {
       this.textOffsets = this.getTextOffsets(ctx);
       this.parent.childUpdated(ctx, this);
    }
+   setButtonPrefixText(ctx: CanvasRenderingContext2D, newText?: string) {
+      this.prefixText = newText;
+      this.textOffsets = this.getTextOffsets(ctx);
+      this.parent.childUpdated(ctx, this);
+   }
 
-   getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
+   private getFullMinSize(ctx: CanvasRenderingContext2D): [number, number, number, number] {
       ctx.save();
       ctx.font = this.textFont;
 
+      const spaceMeasure = ctx.measureText(" ");
+      const spaceWidth = spaceMeasure.width;
+      let minPrefix = this.reservedPrefixSpace;
+      if (this.prefixText != undefined) {
+         const prefixMeasure = ctx.measureText(this.prefixText);
+         minPrefix = Math.min(minPrefix, prefixMeasure.width + spaceWidth);
+      }
+      let minSuffix = 0;
+      if (this.suffixText != undefined) {
+         const suffixMeasure = ctx.measureText(this.suffixText);
+         minSuffix = suffixMeasure.width + spaceWidth;
+      }
+
       const measure = ctx.measureText(this.text);
-      const minWidth = measure.width;
+      const minWidth = measure.width + minPrefix + minSuffix;
       const minHeight = measure.actualBoundingBoxAscent;
 
       ctx.restore();
 
-      return [minWidth, minHeight];
+      return [minWidth, minHeight, minPrefix, minSuffix];
    }
-   getTextOffsets(ctx: CanvasRenderingContext2D): [number, number] {
-      const [minWidth, minHeight] = this.getMinSize(ctx);
+   getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
+      const [width, height,,] = this.getFullMinSize(ctx);
+      return [width, height];
+   }
+   getTextOffsets(ctx: CanvasRenderingContext2D): [number, number, number] {
+      const [minWidth, minHeight, minPrefix, minSuffix] = this.getFullMinSize(ctx);
 
       return [
-         (this.width - minWidth)/2.0,
-         (this.height + minHeight)/2.0
+         this.centeredHorizontally ? (this.width - (minWidth - minPrefix - minSuffix))/2.0 : minPrefix,
+         (this.height + minHeight)/2.0,
+         minSuffix
       ];
    }
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
@@ -181,11 +216,25 @@ class Button implements Widget, WidgetEvents {
 
       ctx.font = this.textFont;
       ctx.fillStyle = this.textColor;
+      if (this.prefixText != undefined) {
+         ctx.fillText(
+            this.prefixText,
+            offsetX,
+            this.textOffsets[1] + offsetY
+         );
+      } 
       ctx.fillText(
          this.text,
          this.textOffsets[0] + offsetX,
          this.textOffsets[1] + offsetY
       );
+      if (this.suffixText != undefined) {
+         ctx.fillText(
+            " " + this.suffixText,
+            offsetX + (this.width - this.textOffsets[2]),
+            this.textOffsets[1] + offsetY
+         );
+      }
 
       ctx.restore();
    }
@@ -591,6 +640,7 @@ class Menu implements Widget, WidgetManager {
 interface RadioMenuWidgetConstructor extends MenuWidgetConstructor {
    optionHeight?: number;
    selectedSymbol?: string;
+   reservedPrefixLength?: number;
    optionTextFont?: string;
    optionTextColor?: string;
    hoveredBackgroundColor?: string;
@@ -604,6 +654,7 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
    private menu: Menu;
    private optionHeight: number;
    private selectedSymbol: string;
+   private reservedPrefixLength: number;
    private optionTextFont: string;
    private optionTextColor: string;
    private backgroundColor: string;
@@ -623,7 +674,14 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
       this.id = id;
 
       this.optionHeight = props.optionHeight ?? 20;
+
       this.selectedSymbol = props.selectedSymbol ?? "*";
+      const selectSymbolMeasure = ctx.measureText(this.selectedSymbol);
+      const selectSymbolWidth = selectSymbolMeasure.width;
+      const spaceMeasure = ctx.measureText(" ");
+      const spaceWidth = spaceMeasure.width;
+      this.reservedPrefixLength = props.reservedPrefixLength ?? (selectSymbolWidth + spaceWidth*2);
+      
       this.optionTextFont = props.optionTextFont ?? "16px Seriph";
       this.optionTextColor = props.optionTextColor ?? "black";
       this.hoveredBackgroundColor = props.hoveredBackgroundColor ?? "lightgray";
@@ -634,16 +692,18 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
       if (this.options.has(opt))
          throw new Error(`RadioMenu: addOption already has the ${opt} option!`);
 
-      let prefix = " ".repeat(this.selectedSymbol.length + 1);
+      let prefix = undefined;
       if (this.selected == undefined) {
          this.selected = opt;
-         prefix = this.selectedSymbol + " ";
+         prefix = this.selectedSymbol;
       }
 
       const buttonOpts: ButtonWidgetConstructor = {
          width: -1,
          height: this.optionHeight,
-         text: prefix + opt,
+         text: opt,
+         prefixText: prefix,
+         reservedPrefixSpace: this.reservedPrefixLength,
          textColor: this.optionTextColor,
          textFont: this.optionTextFont,
          buttonColor: this.backgroundColor,
@@ -661,14 +721,12 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
    changeSelected(ctx: CanvasRenderingContext2D, opt: string) {
       if (this.selected != opt) {
          if (this.selected != undefined) {
-            let selectedLength = this.selectedSymbol.length+1;
-            let selectedPrefix = " ".repeat(selectedLength);
             let button = this.options.get(this.selected)!;
 
-            button.setButtonText(ctx, selectedPrefix + this.selected);
+            button.setButtonPrefixText(ctx, undefined);
          }
          this.selected = opt;
-         this.options.get(this.selected)!.setButtonText(ctx, this.selectedSymbol + " " + this.selected);
+         this.options.get(this.selected)!.setButtonPrefixText(ctx, this.selectedSymbol);
          
          for (const event of this.events) {
             event(ctx, this.selected);
@@ -1336,7 +1394,103 @@ class Seperator implements Widget {
          this.updateText(ctx);
       }
    }
+}
+interface CheckBoxWidgetConstructor extends WidgetConstructor {
+   text: string;
+   checkedSymbol?: string;
+   unCheckedSymbol?: string;
+   reservedPrefixSpace?: number;
+   textFont?: string;
+   textColor?: string;
+   buttonColor?: string;
+   selectedButtonColor?: string;
+}
+class CheckBox implements Widget, WidgetManager, WidgetEvents {
+   readonly parent: WidgetManager;
+   readonly id: number;
+   readonly handledEvents: MenuItemEvents[];
 
+   private button: Button;
+   private changeEventHandlers: Set<(ctx: CanvasRenderingContext2D, selected: boolean) => void> = new Set();
+   private selected = false;
+   private checkedSymbol: string;
+   private uncheckedSymbol?: string;
+
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: CheckBoxWidgetConstructor) {
+      this.parent = parent;
+      this.id = id;
+
+      this.checkedSymbol = props.checkedSymbol ?? "*";
+      const checkedSymbolWidth = ctx.measureText(this.checkedSymbol).width;
+      this.uncheckedSymbol = props.unCheckedSymbol;
+      const uncheckedSymbolWidth = ctx.measureText(props.unCheckedSymbol ?? "").width;
+      const spaceWidth = ctx.measureText(" ").width;
+      const reservedPrefixSpace = props.reservedPrefixSpace ?? (Math.max(checkedSymbolWidth, uncheckedSymbolWidth) + spaceWidth * 2.0);
+
+      const buttonCons: ButtonWidgetConstructor = {
+         text: props.text,
+         reservedPrefixSpace: reservedPrefixSpace,
+         prefixText: this.uncheckedSymbol,
+         textFont: props.textFont,
+         textColor: props.textColor,
+         buttonColor: props.buttonColor,
+         selectedButtonColor: props.selectedButtonColor,
+         width: props.width,
+         height: props.height
+      };
+      this.button = new Button(ctx, this, 0, buttonCons);
+      this.handledEvents = this.button.handledEvents;
+
+      this.button.addEvent((ctx) => {
+         this.selected = !this.selected;
+         if (this.selected) {
+            this.button.setButtonPrefixText(ctx, this.checkedSymbol);
+         } else {
+            this.button.setButtonPrefixText(ctx, this.uncheckedSymbol);
+         }
+         for (const callback of this.changeEventHandlers) {
+            callback(ctx, this.selected);
+         }
+      })
+   }
+   addEvent(callback: (ctx: CanvasRenderingContext2D, selected: boolean) => void) {
+      this.changeEventHandlers.add(callback);
+   }
+   removeEvent(callback: (ctx: CanvasRenderingContext2D, selected: boolean) => void) {
+      this.changeEventHandlers.delete(callback);
+   }
+
+   getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
+      return this.button.getMinSize(ctx);
+   }
+   render(ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) {
+      this.button.render(ctx, offsetX, offsetY);
+   }
+   handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
+      this.button.handleMenuEvent(ctx, event);
+   }
+   getDimensions(): [number, number] {
+      return this.button.getDimensions();
+   }
+   setDimensions(ctx: CanvasRenderingContext2D, width?: number, height?: number) {
+      this.button.setDimensions(ctx, width, height);
+   }
+   delete(ctx: CanvasRenderingContext2D): Widget[] {
+      this.button.delete(ctx);
+      return [this];
+   }
+   childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) {
+      this.parent.childUpdated(ctx, this, sendToRoot);
+   }
+   openPopup(ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) {
+      throw new Error(`CheckBox should never have openPopup be called on it!`);
+   }
+   closePopup(ctx: CanvasRenderingContext2D, widget: Widget) {
+      throw new Error(`CheckBox should never have closePopup be called on it!`);
+   }
+   handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
+      //do nothing
+   }
 }
 interface WidgetEvents {
    addEvent: (callback: () => void) => void;
@@ -1352,7 +1506,9 @@ const MENU_START_X = BORDER_SIZE;
 enum WidgetType {
    Button,
    Seperator,
-   RadioMenu
+   RadioMenu,
+   SubMenu,
+   CheckBox,
 }
 
 export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, IConsoleWindow {
@@ -1366,17 +1522,17 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    appCanvasHeight: number;
    readonly appCanvas: twrConsoleCanvas;
 
-   menuItems: Map<
+   widgets: Map<
       number, 
       [WidgetType.Button, Button]
       | [WidgetType.Seperator, Seperator]
       | [WidgetType.RadioMenu, RadioMenu]
+      | [WidgetType.SubMenu, MenuButton]
+      | [WidgetType.CheckBox, CheckBox]
    > = new Map();
    
-   nextMenuItem: number = 0;
+   nextWidgetID: number = 0;
 
-   menus: Map<number, MenuButton> = new Map();
-   nextMenuID: number = 0;
    readonly manager: RootWidgetManager = new RootWidgetManager();
    readonly menu: MenuBar;
    
@@ -1526,7 +1682,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    twrWindowAddMenu(mod: IWasmModuleAsync | IWasmModule, textPtr: number) {
       const text = mod.getString(textPtr);
 
-      const id = ++this.nextMenuID;
+      const id = ++this.nextWidgetID;
 
       const menuOptions: MenuWidgetConstructor = {
          menuColor: "#B0B0B0",
@@ -1546,33 +1702,51 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          offset: 0.5,
       });
 
-      this.menus.set(id, button);
+      this.widgets.set(id, [WidgetType.SubMenu, button]);
 
-      const subMenuOpts: MenuButtonWidgetConstructor = {
-         menuOptions: menuOptions,
-         height: TOP_BAR_SIZE - 0.5,
-         text: "hello there",
-         textColor: "black",
-         buttonColor: "#B0B0B0",
-         selectedButtonColor: "#D0D0D0",
-         openToRight: true,
-      };
-      const subMenu: MenuButton = button.addChild(this.ctx, 0, MenuButton, subMenuOpts);
-      subMenu.addChild(this.ctx, 0, Button, {
-         height: TOP_BAR_SIZE - 0.5,
-         text: text,
-         textColor: "black",
-         buttonColor: "#B0B0B0",
-         selectedButtonColor: "#D0D0D0",
-      });
-      subMenu.addChild(this.ctx, 0, MenuButton, subMenuOpts);
+      // const subMenuOpts: MenuButtonWidgetConstructor = {
+      //    menuOptions: menuOptions,
+      //    height: TOP_BAR_SIZE - 0.5,
+      //    text: "hello there",
+      //    textColor: "black",
+      //    buttonColor: "#B0B0B0",
+      //    selectedButtonColor: "#D0D0D0",
+      //    openToRight: true,
+      //    suffixText: "▶",
+      // };
+      // const subMenu: MenuButton = button.addChild(this.ctx, 0, MenuButton, subMenuOpts);
+      // subMenu.addChild(this.ctx, 0, Button, {
+      //    height: TOP_BAR_SIZE - 0.5,
+      //    text: text,
+      //    textColor: "black",
+      //    buttonColor: "#B0B0B0",
+      //    selectedButtonColor: "#D0D0D0",
+      // });
+      // const subSubMenu: MenuButton = subMenu.addChild(this.ctx, 0, MenuButton, subMenuOpts);
+
+      // const checkBoxOpts: CheckBoxWidgetConstructor = {
+      //    text: "testBox!",
+      //    textColor: "black",
+      //    buttonColor: "#B0B0B0",
+      //    selectedButtonColor: "#D0D0D0",
+      //    checkedSymbol: "☑",
+      //    unCheckedSymbol: "☐",
+      // };
+      // const checkBox: CheckBox = subSubMenu.addChild(this.ctx, 0, CheckBox, checkBoxOpts);
+      // checkBox.addEvent((ctx: CanvasRenderingContext2D, selected: boolean) => {
+      //    console.log(`clicked: ${selected}!`);
+      // });
 
       return id;
    }
 
    twrWindowMenuAddWidget(mod: IWasmModuleAsync | IWasmModule, menuID: number, consPtr: number): number {
-      if (!this.menus.has(menuID)) throw new Error(`twrWindowMenuAddWidget was given an invalid menu ID (${menuID})!`);
-      const menu = this.menus.get(menuID)!;
+      if (!this.widgets.has(menuID)) throw new Error(`twrWindowMenuAddWidget was given an invalid menu ID (${menuID})!`);
+      const widgetBase = this.widgets.get(menuID)!;
+      if (widgetBase[0] != WidgetType.SubMenu)
+         throw new Error(`twrWindowMenuAddWidget was given a non-menu (${WidgetType[widgetBase[0]]}) widget as a menu!`);
+
+      const menu = widgetBase[1];
 
       // struct twr_widget_constructor {
       //    enum WindowWidget type;
@@ -1604,14 +1778,12 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
 
       const type = mod.getLong(consPtr + 0) as WidgetType;
 
-      const x = getLongOrDef(consPtr + 4, 0);
-      const y = getLongOrDef(consPtr + 8, 0);
-      const width = getLongOrDef(consPtr + 12, undefined);
-      const height = getLongOrDef(consPtr + 16, undefined);
+      const width = getLongOrDef(consPtr + 4, undefined);
+      const height = getLongOrDef(consPtr + 8, undefined);
 
-      const extraPtr = consPtr + 20;
+      const extraPtr = consPtr + 12;
 
-      const id = ++this.nextMenuItem;
+      const id = ++this.nextWidgetID;
       switch (type) {
          case WidgetType.Button:
          {
@@ -1639,7 +1811,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
                selectedButtonColor: getStringOrDef(extraPtr + 16, "#D0D0D0")
             };
             const widget: Button = menu.addChild(this.ctx, id, Button, button);
-            this.menuItems.set(id, [WidgetType.Button, widget]);
+            this.widgets.set(id, [WidgetType.Button, widget]);
          }
          break;
 
@@ -1663,7 +1835,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
                seperatorColor: getStringOrDef(extraPtr + 8, "black")
             };
             const widget: Seperator = menu.addChild(this.ctx, id, Seperator, seperator);
-            this.menuItems.set(id, [WidgetType.Seperator, widget]);
+            this.widgets.set(id, [WidgetType.Seperator, widget]);
          }
          break;
 
@@ -1673,29 +1845,34 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             //    /// @brief Base widget constructor
             //    struct twr_widget_constructor base;
             //    ///@brief defaults to 0
-            //    long minimumWidth;
+            //    long minimum_width;
             //    /// @brief defaults to 0
-            //    long minimumHeight;
+            //    long minimum_height;
             //    /// @brief defaults to 0
-            //    long yPadding;
+            //    long y_padding;
             //    /// @brief defaults to gray
-            //    const char* menuColor;
+            //    const char* menu_color;
             //    /**
             //     * Color options change to when hovered over
             //     * defaults to light gray
             //     */
-            //    const char* hoveredBackgroundColor;
+            //    const char* hovered_background_color;
             //    /**
             //     * Symbol used to denote that the option is selected
             //     * defaults to *
             //     */
-            //    const char* selectedSymbol;
+            //    const char* selected_symbol;
+            //    /**
+            //     * Amount of space before option text reserved for the select symbol
+            //     * defaults to width of (selected_symbol + "  ")
+            //     */
+            //    long reserved_prefix_length;
             //    /// @brief default to 20
-            //    long optionHeight;
+            //    long option_height;
             //    /// @brief defaults to 16px Seriph
-            //    const char* optionTextFont;
+            //    const char* option_text_font;
             //    /// @brief defaults to black
-            //    const char* optionTextColor;
+            //    const char* option_text_color;
             // };
             const cons: RadioMenuWidgetConstructor = {
                width: width,
@@ -1706,13 +1883,107 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
                menuColor: getStringOrDef(extraPtr + 12, "gray"),
                hoveredBackgroundColor: getStringOrDef(extraPtr + 16, "lightgray"),
                selectedSymbol: getStringOrDef(extraPtr + 20, "*"),
-               optionHeight: getLongOrDef(extraPtr + 24, 20),
-               optionTextFont: getStringOrDef(extraPtr + 28, "16px Seriph"),
-               optionTextColor: getStringOrDef(extraPtr + 32, "black"),
+               reservedPrefixLength: getLongOrDef(extraPtr + 24, undefined),
+               optionHeight: getLongOrDef(extraPtr + 28, 20),
+               optionTextFont: getStringOrDef(extraPtr + 32, "16px Seriph"),
+               optionTextColor: getStringOrDef(extraPtr + 36, "black"),
             };
             console.log(cons);
             const radio: RadioMenu = menu.addChild(this.ctx, id, RadioMenu, cons);
-            this.menuItems.set(id, [WidgetType.RadioMenu, radio]);
+            this.widgets.set(id, [WidgetType.RadioMenu, radio]);
+         }
+         break;
+
+         case WidgetType.SubMenu:
+         {
+            // struct twr_widget_sub_menu_constructor {
+            //    /// @brief Base widget constructor
+            //    struct twr_widget_constructor base;
+            //    /**
+            //     * Text for the button that opens this menu
+            //     * defaults to Lorem Ipsum
+            //     */
+            //    const char* button_text;
+            //    /// @brief defaults to 16px Seriph
+            //    const char* button_text_font;
+            //    /// @brief defaults to "black"
+            //    const char* button_text_color;
+            //    /// @brief defaults to #B0B0B0
+            //    const char* button_color;
+            //    /// @brief defaults to #D0D0D0
+            //    const char* selected_button_color;
+            
+            //    /// @brief defaults to 10
+            //    long minimum_menu_width;
+            //    /// @brief defaults to 10
+            //    long minimum_menu_height;
+            //    /// @brief defaults to #B0B0B0
+            //    const char* menu_color;
+            //    /// @brief defaults to 5
+            //    long menu_y_padding;
+            //    /// @brief defaults to 10
+            //    long min_child_height;
+            //    /// @brief defaults to black
+            //    const char* menu_border_color;
+            //    /// @brief defaults to 0
+            //    long menu_border_width;
+            //    ///@brief defaults to 0
+            //    long menu_open_offset;
+            // };
+
+            const cons: MenuButtonWidgetConstructor = {
+               width: width,
+               height: height,
+               text: getStringOrDef(extraPtr + 0, "Lorem Ipsum"),
+               textFont: getStringOrDef(extraPtr + 4, "16px Seriph"),
+               textColor: getStringOrDef(extraPtr + 8, "black"),
+               buttonColor: getStringOrDef(extraPtr + 12, "#B0B0B0"),
+               selectedButtonColor: getStringOrDef(extraPtr + 16, "#D0D0D0"),
+
+               menuOptions: {
+                  minimumWidth: getLongOrDef(extraPtr + 20, 10),
+                  minimumHeight: getLongOrDef(extraPtr + 24, 10),
+                  menuColor: getStringOrDef(extraPtr + 28, "#B0B0B0"),
+                  yPadding: getLongOrDef(extraPtr + 32, 5),
+                  minChildHeight: getLongOrDef(extraPtr + 36, 10),
+                  borderColor: getStringOrDef(extraPtr + 40, "black"),
+                  borderWidth: getLongOrDef(extraPtr + 44, 1.0),
+               },
+
+               offset: getLongOrDef(extraPtr + 48, 0),
+               openToRight: true,
+               suffixText: "▶",
+            };
+            const subMenu: MenuButton = menu.addChild(this.ctx, id, MenuButton, cons);
+            this.widgets.set(id, [WidgetType.SubMenu, subMenu]);
+         }
+         break;
+
+         case WidgetType.CheckBox:
+         {
+            // struct twr_widget_check_box_constructor {
+            //    struct twr_widget_constructor base;
+            //    const char* text;
+            //    const char* checked_symbol;
+            //    const char* unchecked_symbol;
+            //    long reserved_prefix_space;
+            //    const char* text_font;
+            //    const char* text_color;
+            //    const char* button_color;
+            //    const char* selected_button_color;
+            // };
+
+            const props: CheckBoxWidgetConstructor = {
+               
+               const char* text;
+               const char* checked_symbol;
+               const char* unchecked_symbol;
+               long reserved_prefix_space;
+               const char* text_font;
+               const char* text_color;
+               const char* button_color;
+               const char* selected_button_color;
+            };
          }
          break;
 
@@ -1727,8 +1998,8 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    }
 
    twrWindowMenuWidgetAddCallback(mod: IWasmModuleAsync | IWasmModule, widgetID: number, eventID: number, extraPtr: number) {
-      if (!this.menuItems.has(widgetID)) throw new Error(`twrWindowMenuButtonAddCallback: Error! was given an invalid widgetID (${widgetID})`);
-      const widget = this.menuItems.get(widgetID)!;
+      if (!this.widgets.has(widgetID)) throw new Error(`twrWindowMenuButtonAddCallback: Error! was given an invalid widgetID (${widgetID})`);
+      const widget = this.widgets.get(widgetID)!;
 
       switch (widget[0]) {
          case WidgetType.Button:
@@ -1750,27 +2021,36 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          }
          break;
 
+         case WidgetType.CheckBox:
+         {
+            const checkBox: CheckBox = widget[1];
+            checkBox.addEvent((ctx: CanvasRenderingContext2D, selected: boolean) => {
+               mod.postEvent(eventID, extraPtr, selected ? 1 : 0);
+            });
+         }
+         break;
+
          default:
          {
-            throw new Error(`twrWindowMenuWidgetAddCallback: Error! was given an invalid widget type! Expected button or radioMenu, got ${WidgetType[widget[0]]}`);
+            throw new Error(`twrWindowMenuWidgetAddCallback: Error! was given an invalid widget type! Expected button, checkBox, or radioMenu, got ${WidgetType[widget[0]]}`);
          }
          break;
       }      
    }
 
    twrWindowMenuDeleteWidget(mod: IWasmModuleAsync | IWasmModule, widgetID: number) {
-      if (!this.menuItems.has(widgetID)) throw new Error(`twrWindowMenuDeleteWidget: Error! was given an invalid widgetID (${widgetID})`);
-      const widget = this.menuItems.get(widgetID)!;
+      if (!this.widgets.has(widgetID)) throw new Error(`twrWindowMenuDeleteWidget: Error! was given an invalid widgetID (${widgetID})`);
+      const widget = this.widgets.get(widgetID)!;
 
       const deleted = widget[1].delete(this.ctx);
       for (const del of deleted) {
-         this.menuItems.delete(del.id);
+         this.widgets.delete(del.id);
       }
    }
 
    twrWindowMenuRadioMenuAddOption(mod: IWasmModuleAsync | IWasmModule, widgetID: number, optionPtr: number) {
-      if (!this.menuItems.has(widgetID)) throw new Error(`twrWindowMenuRadioMenuAddOption: Error! was given an invalid widgetID (${widgetID})`);
-      const widget = this.menuItems.get(widgetID)!;
+      if (!this.widgets.has(widgetID)) throw new Error(`twrWindowMenuRadioMenuAddOption: Error! was given an invalid widgetID (${widgetID})`);
+      const widget = this.widgets.get(widgetID)!;
 
       if (widget[0] != WidgetType.RadioMenu) throw new Error(`twrWindowMenuRadioMenuAddOption: Error! was given an invalid widget type! Expected RadioMenu, got ${WidgetType[widget[0]]}`);
       

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -95,7 +95,7 @@ interface ButtonWidgetConstructor extends WidgetConstructor {
    suffixText?: string;
    centeredHorizontally?: boolean;
 
-   reservedPrefixSpace?: number;
+   reservePrefixSpace?: boolean;
 }
  
 class Button implements Widget, WidgetEvents {
@@ -122,9 +122,9 @@ class Button implements Widget, WidgetEvents {
    private _prefixText?: string;
    private _suffixText?: string;
    private centeredHorizontally: boolean;
-   private reservedPrefixSpace: number;
+   private reservePrefixSpace: boolean;
 
-   set text(val: string) {this._text = this.text; this.updateProperty()};
+   set text(val: string) {this._text = val; this.updateProperty()};
    get text(): string {return this._text};
    set prefixText(val: string|undefined) {this._prefixText = val; this.updateProperty()};
    get prefixText(): string|undefined {return this._prefixText};
@@ -146,8 +146,9 @@ class Button implements Widget, WidgetEvents {
       this._prefixText = cons.prefixText;
       this._suffixText = cons.suffixText;
       this.centeredHorizontally = cons.centeredHorizontally ?? false;
-      this.reservedPrefixSpace = cons.reservedPrefixSpace ?? 0;
       this.globalProps = globalProps;
+
+      this.reservePrefixSpace = cons.reservePrefixSpace ?? true;
 
       const [minWidth, minHeight] = this.getMinSize();
 
@@ -198,31 +199,43 @@ class Button implements Widget, WidgetEvents {
       ctx.save();
       // ctx.font = this.globalProps.widgetTextFont;
       ctx.font = this.getFont();
-
       const spaceMeasure = ctx.measureText(" ");
       const spaceWidth = spaceMeasure.width;
-      let minPrefix = this.reservedPrefixSpace;
-      if (this._prefixText != undefined) {
-         const prefixMeasure = ctx.measureText(this._prefixText);
-         minPrefix = Math.max(minPrefix, prefixMeasure.width + spaceWidth);
-      }
-      let minSuffix = 0;
-      if (this._suffixText != undefined) {
-         const suffixMeasure = ctx.measureText(this._suffixText);
-         minSuffix = suffixMeasure.width + spaceWidth;
-      }
 
-      const measure = ctx.measureText(this._text);
-      const minWidth = measure.width + minPrefix + minSuffix;
-      const minHeight = measure.actualBoundingBoxAscent;
-
+      ctx.textBaseline = "bottom";
+      let minWidth = 0;
+      let minHeight = 0;
+      const parts = [this._prefixText, this._suffixText, this._text];
+      let partWidths = [];
+      for (let i = 0; i < parts.length; i++) {
+         const part = parts[i];
+         const minPartWidth = i == 0 && this.reservePrefixSpace
+            ? this.globalProps.reservedPrefixLen
+            : 0;
+         
+         if (part != undefined) {
+            const measure = ctx.measureText(part);
+            const width = Math.max(minPartWidth, measure.width) 
+            minWidth += width + spaceWidth;
+            minHeight = Math.max(minHeight, measure.actualBoundingBoxAscent + measure.actualBoundingBoxDescent);
+            partWidths[i] = width; 
+         } else {
+            minWidth += minPartWidth;
+            partWidths[i] = minPartWidth;
+         }
+      }
       ctx.restore();
+      minWidth -= spaceWidth;
+
+      const [minPrefix, minSuffix, ] = partWidths;
+
+      console.log(`getFullMinSize: ${minWidth}, ${minHeight}, ${minPrefix}, ${minSuffix}`);
 
       return [minWidth, minHeight, minPrefix, minSuffix];
    }
    getMinSize(): [number, number] {
       const [width, height,,] = this.getFullMinSize(this.parent.getCtx());
-      console.log(`button min size (${this._text}), (${width}, ${height})`)
+      // console.log(`button min size (${this._text}), (${width}, ${height})`)
       return [width, height];
    }
    getTextOffsets(ctx: CanvasRenderingContext2D): [number, number, number] {
@@ -234,7 +247,7 @@ class Button implements Widget, WidgetEvents {
          const measure = ctx.measureText("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.!?*&^%$#@)(0123456789-=_+`~[]{}\\|;:'\"");
          ctx.restore();
 
-         return measure.actualBoundingBoxAscent;
+         return measure.actualBoundingBoxAscent + measure.actualBoundingBoxDescent;
       }
 
       return [
@@ -362,7 +375,8 @@ abstract class WidgetContainer implements Widget, WidgetManager {
    private selectedItem?: ContainedWidget;
 
    private _visible: boolean = true;
-   
+   private _drawOutline: boolean;
+   get drawOutline() {return this._drawOutline};
    
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
       this.globalProps = globalProps;
@@ -375,6 +389,8 @@ abstract class WidgetContainer implements Widget, WidgetManager {
          x: globalProps.emptyMenuHeight,
          y: globalProps.emptyMenuHeight,
       };
+
+      this._drawOutline = props.drawOutline ?? false;
    }
    getCtx() {
       return this.parent.getCtx();
@@ -440,7 +456,7 @@ abstract class WidgetContainer implements Widget, WidgetManager {
    // lastWidth: number = 0;
    // lastHeight: number = 0;
    protected supressChildUpdates: boolean = false;
-   abstract updateChildSize(forceRun?: boolean): void;
+   protected abstract updateChildSize(forceRun?: boolean): void;
 
    childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot: boolean = false) {
       if (sendToRoot) {
@@ -451,7 +467,7 @@ abstract class WidgetContainer implements Widget, WidgetManager {
          this.parent.childUpdated(ctx, this, false);
       }
    }
-   addChild<
+   protected addChild<
       T extends Widget, 
       U, 
       O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U, globalProps: GlobalWidgetProperties) => T
@@ -494,7 +510,7 @@ abstract class WidgetContainer implements Widget, WidgetManager {
       );
 
       const menuBorderWidth = this.globalProps.menuBorderWidth;
-      if (menuBorderWidth > 0) {
+      if (menuBorderWidth > 0 && this._drawOutline) {
          ctx.strokeStyle = this.globalProps.menuBorderColor;
          ctx.lineWidth = menuBorderWidth;
          ctx.beginPath();
@@ -651,6 +667,7 @@ abstract class WidgetContainer implements Widget, WidgetManager {
 }
 
 interface MenuWidgetConstructor extends WidgetConstructor {
+   drawOutline?: boolean,
 }
 
 class Menu extends WidgetContainer {
@@ -676,14 +693,14 @@ class Menu extends WidgetContainer {
             }
          }
       }
-      console.log(`open popup (Menu): (${x}, ${y}); (${nX}, ${nY})`);
+      // console.log(`open popup (Menu): (${x}, ${y}); (${nX}, ${nY})`);
       this.parent.openPopup(ctx, widget, nX, nY, nextRelative);
    }
 
    lastWidth: number = 0;
    lastHeight: number = 0;
    supressChildUpdates: boolean = false;
-   updateChildSize(forceRun: boolean = false) {
+   protected updateChildSize(forceRun: boolean = false) {
       let childWidth = 0;
       // let maxChildHeight = this.minChildHeight;
       let childHeight = 0;
@@ -696,7 +713,7 @@ class Menu extends WidgetContainer {
          const [, height] = widget.getDimensions();
          childHeight += height + this.globalProps.yPadding;
       }
-      childWidth += this.globalProps.menuBorderWidth * 2;
+      childWidth += this.globalProps.menuBorderWidth * 4;
       childHeight += this.globalProps.menuBorderWidth * 2;
 
       // console.log(childWidth, childHeight);
@@ -714,7 +731,7 @@ class Menu extends WidgetContainer {
 
       // console.log(newWidth, newHeight, this.childWidth, this.childHeight);
 
-      console.log(`updating width: ${newWidth}; ${super.width}, ${childWidth}`);
+      // console.log(`updating width: ${newWidth}; ${super.width}, ${childWidth}`);
       if (this.lastWidth != newWidth || this.lastHeight != newHeight || forceRun) {
          this.lastWidth = newWidth;
          this.lastHeight = newHeight;
@@ -725,7 +742,7 @@ class Menu extends WidgetContainer {
                continue;
             const [, height] = child.widget.getDimensions();
             this.supressChildUpdates = true;
-            child.widget.setDimensions(newWidth - this.globalProps.menuBorderWidth * 2, undefined);
+            child.widget.setDimensions(newWidth - this.globalProps.menuBorderWidth * 4, undefined);
             child.y = curHeight;
             this.supressChildUpdates = false;
             // curHeight += maxChildHeight;
@@ -769,7 +786,7 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
 
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: RadioMenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
       this.globalProps = globalProps;
-      console.log(`Creating new radiomenu: ${props.height}, ${props.width}`);
+      // console.log(`Creating new radiomenu: ${props.height}, ${props.width}`);
       this.menu = new Menu(ctx, this, 0, props, globalProps);
       this.parent = parent;
       this.id = id;
@@ -804,13 +821,12 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
          prefix = this.globalProps.radioMenuPrefix;
       }
 
-      console.log(`Radio menu adding button: Menu width is: ${this.menu.getDimensions()[0]}`);
+      // console.log(`Radio menu adding button: Menu width is: ${this.menu.getDimensions()[0]}`);
       const buttonOpts: ButtonWidgetConstructor = {
          width: 20,
          height: this._optionHeight,
          text: opt,
          prefixText: prefix,
-         reservedPrefixSpace: this.globalProps.reservedPrefixLen,
       };
       const button: Button = this.menu.addChild(ctx, 0, Button, buttonOpts);
 
@@ -852,7 +868,7 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
       this.menu.handleMenuEvent(ctx, event);
    }
    getDimensions(): [number, number] {
-      console.log(`Getting radio menu dimensions: ${this.menu.getDimensions()}`);
+      // console.log(`Getting radio menu dimensions: ${this.menu.getDimensions()}`);
       return this.menu.getDimensions();
    }
    setDimensions(width?: number, height?: number) {
@@ -860,7 +876,7 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
    }
 
    childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) {
-      console.log("radio menu updated!!!");
+      // console.log("radio menu updated!!!");
       this.parent.childUpdated(ctx, widget == this.menu ? this : widget, sendToRoot);
    }
 
@@ -893,15 +909,13 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
 
 }
 
-interface MenuBarWidgetConstructor extends WidgetConstructor {
-}
 
 class MenuBar extends WidgetContainer {
-   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuBarWidgetConstructor, globalProps: GlobalWidgetProperties) {
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
       super(ctx, parent, id, props, globalProps);
    }
 
-   updateChildSize(forceRun?: boolean) {
+   protected updateChildSize(forceRun?: boolean) {
       let minHeight = this.globalProps.emptyMenuWidth;
       let width = 0;
       for (const {widget} of this.children) {
@@ -937,6 +951,7 @@ class MenuBar extends WidgetContainer {
             nWidth,
             tmpHeight
          );
+         console.log(`${tmpHeight}, ${super.height}, ${child.y}`);
          child.x = pos;
          pos += nWidth + this.globalProps.xPadding;
       }
@@ -949,7 +964,7 @@ class MenuBar extends WidgetContainer {
    >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
       return super.addChild(
          ctx, id, cons, props,
-         0, this.globalProps.menuBorderWidth
+         0, super.drawOutline ? this.globalProps.menuBorderWidth/2 : 0
       );
    }
 
@@ -965,8 +980,8 @@ class MenuBar extends WidgetContainer {
             }
          }
       }
-      console.log(`open popup (MenuBar): (${x}, ${y}); (${nX}, ${nY})`);
-      this.parent.openPopup(ctx, widget, nX, nY, nextRelative);
+      // console.log(`open popup (MenuBar): (${x}, ${y}); (${nX}, ${nY})`);
+      this.parent.openPopup(ctx, widget, nX, nY += this.globalProps.menuBorderWidth, nextRelative);
    }
 }
 
@@ -1021,7 +1036,7 @@ class RootWidgetManager implements WidgetManager {
             }
          }
       }
-      console.log(`open popup (Root): (${x}, ${y}); (${nX}, ${nY})`);
+      // console.log(`open popup (Root): (${x}, ${y}); (${nX}, ${nY})`);
       this.popupWidgets.set(widget, [nX, nY]);
       this.childUpdated(ctx, widget);
    }
@@ -1156,14 +1171,15 @@ class MenuButton extends Button implements WidgetManager {
       this.offset = props.offset ?? 0;
       this.menu = new Menu(ctx, this, 1, {
          width: props.menuWidth,
-         height: props.menuHeight
+         height: props.menuHeight,
+         drawOutline: true,
       }, globalProps);
 
       super.addEvent((() => {
          const [width,height] = super.getDimensions();
          let x = this.openToRight ? width + this.offset : 0;
          let y = this.openToRight ? 0 : height + this.offset;
-         console.log(`spawning menu at: (${x}, ${y})`)
+         // console.log(`spawning menu at: (${x}, ${y})`)
          this.parent.openPopup(ctx, this.menu, x, y, this);
          this.menuOpened = true;
       }).bind(this));
@@ -1565,12 +1581,13 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       //    buttonColor: "#B0B0B0B0"
       // };
       // this.manager.addChild(this.ctx, -10, Button, buttonOpts);
-      const menuBarCons: MenuBarWidgetConstructor = {
+      const menuBarCons: MenuWidgetConstructor = {
          // minChildWidth: 10,
          // menuColor: "#B0B0B0",
-         height: TOP_BAR_SIZE - 0.5,
+         height: TOP_BAR_SIZE - 2,
          // xPadding: MENU_PADDING_X,
       };
+      console.log(`Menu Bar target size: ${menuBarCons.height}, ${TOP_BAR_SIZE - 0.5}`);
       this.menu = this.manager.addChild(this.ctx, 0, MenuBar, menuBarCons, this.widgetSettings, BORDER_SIZE + MENU_PADDING_X, 0);
    }
 
@@ -1675,6 +1692,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          selectedButtonColor: "#D0D0D0",
          menuOptions: menuOptions,
          offset: 0.5,
+         reservePrefixSpace: false,
       });
 
       this.widgets.set(id, [WidgetType.SubMenu, button]);

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -418,7 +418,7 @@ abstract class ButtonBase extends WidgetImpl {
             textOffsets.y = (this.getUsedHeight() + getHeight(ctx, this.getFont()))/2.0;
          break;
          case ButtonWidgetVerticalCenteringMethod.StringCentering:
-            textOffsets.y = (this.getUsedHeight() + minHeight)/2.0;
+            textOffsets.y = (this.getUsedHeight() - minHeight)/2.0;
          break;
       }
       textOffsets.suffixX = minSuffix;
@@ -487,7 +487,8 @@ abstract class ButtonBase extends WidgetImpl {
 
       ctx.save();
 
-      // ctx.textBaseline = "top";
+      if (this._verticalCentering == ButtonWidgetVerticalCenteringMethod.StringCentering)
+         ctx.textBaseline = "top";
 
       const textOffsets = this.calculatedFields.textOffsets;
 
@@ -1617,6 +1618,10 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       | [WidgetType.SubMenu, MenuButton]
       | [WidgetType.CheckBox, CheckBox]
    > = new Map();
+
+   //list of events to run before drawing
+   // only example right now is resizing the window
+   private runBeforeDrawEvents: (() => void)[] = [];
    
    readonly manager: RootWidgetManager;
    readonly menu: MenuBar;
@@ -1797,6 +1802,11 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    }
 
    handleCanvasAnimationFrameEvent(event: CanvasEventTypes, delta: number) {
+      const newEvents = this.runBeforeDrawEvents;
+      this.runBeforeDrawEvents = [];
+      for (const event of newEvents) {
+         event();
+      }
       this.drawCanvas.handleCanvasAnimationFrameEvent(event, delta);
 
       this.ctx.reset();
@@ -2578,12 +2588,14 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    }
 
    resizeWindow(width: number, height: number) {
-      this.element.width = width;
-      this.element.height = height;
-      [this.drawCanvasWidth, this.drawCanvasHeight] = this.calculatedrawCanvasDims();
+      this.runBeforeDrawEvents.push((() => {
+         this.element.width = width;
+         this.element.height = height;
+         [this.drawCanvasWidth, this.drawCanvasHeight] = this.calculatedrawCanvasDims();
 
-      this.drawCanvas.resizeCanvas(this.drawCanvasWidth, this.drawCanvasHeight);
+         this.drawCanvas.resizeCanvas(this.drawCanvasWidth, this.drawCanvasHeight);
 
-      this.internalSendEvent(WindowEventTypes.WindowResize, width, height);
+         this.internalSendEvent(WindowEventTypes.WindowResize, width, height);
+      }).bind(this));
    }
 }

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -1618,7 +1618,8 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       twrWindowMenuWidgetListProps: {isAsyncFunction: true},
       twrWindowMenuWidgetGetPropDetails: {},
       twrWindowMenuListProps: {isAsyncFunction: true},
-      
+      twrWindowMenuSetProp: {},
+      twrWindowMenuGetProp: {isAsyncFunction: true},  
    };
 
    // every library should have this line
@@ -2000,10 +2001,16 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    }
 
    twrWindowMenuWidgetSetProp(mod: IWasmModuleAsync | IWasmModule, widgetID: number, propNamePtr: number, dataPtr: number) {
-      /* struct JSPropVal {
-         enum JSPropValType type;
-         const void* val;
-      }*/
+      /* struct twr_widget_prop_value {
+         union {
+            const char* string;
+            double number;
+            int boolean;
+         };
+         enum WindowWidgetPropVal type;
+      };*/
+      const valPtr = dataPtr + 0;
+      const typPtr = dataPtr + 8;
       const widget = this.widgets.get(widgetID);
       if (widget == undefined) throw new Error(`twrWindowMenuWidgetSetProp: Error! was given an invalid widgetID (${widgetID})`);
       
@@ -2012,8 +2019,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       if (propField == undefined) throw new Error(`twrWindowMenuWidgetSetProp: Couldn't find prop name "${propName}" in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
       if (propField[0] == PropPerms.ReadOnly) throw new Error(`twrWindowMenuWidgetSetProp: Property "${propName}" is read only in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
       
-      const typ = mod.getLong(dataPtr + 8) as PropBaseType;
-      const valPtr = dataPtr;
+      const typ = mod.getLong(typPtr) as PropBaseType;
       
       console.log(`Attempting to modify ${propName} in widget ${widgetID}`);
       switch (typ) {
@@ -2317,6 +2323,132 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          return await ret;
       } else {
          throw new Error(`internal error!!!`);
+      }
+   }
+
+   twrWindowMenuSetProp(mod: IWasmModuleAsync | IWasmModule, propNamePtr: number, dataPtr: number) {
+      // struct twr_widget_prop_value {
+      //    union {
+      //       const char* string;
+      //       double number;
+      //       int boolean;
+      //    };
+      //    enum WindowWidgetPropVal type;
+      // };
+      const valPos = dataPtr + 0;
+      const typPos = dataPtr + 8;
+
+      const typ = mod.getLong(typPos) as PropBaseType;
+
+      const propName = mod.getString(propNamePtr);
+
+      if (!(propName in this.widgetSettings)) throw new Error(`twrWindowMenuSetProp: property ${propName} isn't a valid property!`);
+
+      const assertType = (typ: "string" | "boolean" | "number") => {
+         const expectedTyp = typeof (this.widgetSettings as any)[propName];
+         if (expectedTyp != typ) 
+            throw new Error(`twrWindowMenuSetProp was given an invalid type. ${propName} is of type ${expectedTyp} but was given ${typ}!`);
+      }
+      switch (typ) {
+         case PropBaseType.Boolean:
+         {
+            assertType("boolean");
+            (this.widgetSettings as any)[propName] = mod.wasmMem.getLong(valPos) ? 1 : 0;
+         }
+         break;
+
+         case PropBaseType.Number:
+         {
+            assertType("number");
+            (this.widgetSettings as any)[propName] = mod.wasmMem.getDouble(valPos);
+         }
+         break;
+
+         case PropBaseType.String:
+         {
+            assertType("string");
+            (this.widgetSettings as any)[propName] = mod.wasmMem.getString(mod.wasmMem.getLong(valPos));
+         }
+         break;
+
+         default:
+            throw new Error(`twrWindowMenuSetProp was given an invalid type (${PropBaseType[typ] ?? typ})!`);
+      }
+   }
+
+   twrWindowMenuGetPropHelper(mod: IWasmModule | IWasmModuleAsync, propNamePtr: number) {
+      const propName = mod.wasmMem.getString(propNamePtr);
+      if (!(propName in this.widgetSettings)) throw new Error(`twrWindowMenuGetPropHelper: Error! property ${propName} isn't a valid property name!`);
+      const propVal = (this.widgetSettings as any)[propName];
+      /*struct twr_widget_prop_value {
+         union {
+            const char* string;
+            double number;
+            int boolean;
+         };
+         enum WindowWidgetPropVal type;
+      };*/
+      const valOffset = 0;
+      const typOffset = 8;
+      const baseStructSize = 12;
+
+      let retSize = baseStructSize;
+      let retVal: [PropBaseType.String, Uint8Array]
+         | [PropBaseType.Number, number]
+         | [PropBaseType.Boolean, boolean];
+      
+      switch (typeof propVal) {
+         case "number":
+            retVal = [PropBaseType.Number, propVal];
+         break;
+
+         case "string":
+            retVal = [PropBaseType.String, mod.wasmMem.stringToU8(propVal)];
+            retSize += retVal[1].length + 1;
+         break;
+
+         case "boolean":
+            retVal = [PropBaseType.Boolean, propVal];
+         break;
+
+         default:
+            throw new Error(`twrWindowMenuGetProp: internal error!`);
+      }
+
+      return unwrapPossibleSync(wrapPossibleSync(mod.wasmMem.malloc(retSize)).then((retPtr) => {
+         switch (retVal[0]) {
+            case PropBaseType.Number:
+               mod.wasmMem.setDouble(retPtr + valOffset, retVal[1]);
+            break;
+            case PropBaseType.String:
+               mod.wasmMem.setLong(retPtr + valOffset, baseStructSize + retPtr);
+               mod.wasmMem.mem8u.set(retVal[1], retPtr + baseStructSize); //load string at end of struct alloc
+               mod.wasmMem.mem8u[retVal[1].length + retPtr + baseStructSize + 1] = 0; //insert null character
+            break;
+            case PropBaseType.Boolean:
+               mod.wasmMem.setLong(retPtr + valOffset, retVal[1] ? 1 : 0);
+            break;
+         }
+         mod.wasmMem.setLong(retPtr + typOffset, retVal[0]);
+
+         return retPtr;
+      }));
+   }
+   twrWindowMenuGetProp(mod: IWasmModule, propNamePtr: number): number {
+      const ret = this.twrWindowMenuGetPropHelper(mod, propNamePtr);
+      if (ret instanceof Promise) {
+         throw new Error(`internal error!`);
+      } else {
+         return ret;
+      }
+   }
+
+   async twrWindowMenuGetProp_async(mod: IWasmModule, propNamePtr: number) {
+      const ret = this.twrWindowMenuGetPropHelper(mod, propNamePtr);
+      if (ret instanceof Promise) {
+         return await ret;
+      } else {
+         throw new Error(`internal error!`);
       }
    }
 

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -79,16 +79,25 @@ interface GlobalWidgetProperties {
    radioMenuUncheckedPrefix?: string;
 };
 enum PropBaseType {
-   String,
-   Boolean,
-   Number,
-   Undefined,
-   Combination
+   String = 1,
+   Boolean = 2,
+   Number = 4,
+   Undefined = 8,
+   Combination = 512
 };
 type PropType = [PropBaseType.String]
    | [PropBaseType.Boolean]
    | [PropBaseType.Number]
    | [PropBaseType.Combination, ...PropBaseType[]];
+
+type GetPropVal = [PropBaseType.String, string]
+   | [PropBaseType.Boolean, boolean]
+   | [PropBaseType.Number, number]
+   | [PropBaseType.Undefined];
+type AllocGetPropVal = [PropBaseType.String, string, number]
+   | [PropBaseType.Boolean, boolean]
+   | [PropBaseType.Number, number]
+   | [PropBaseType.Undefined];
 enum PropPerms {
    ReadOnly,
    SetOnly,
@@ -155,8 +164,8 @@ abstract class WidgetImpl implements Widget {
    abstract readonly handledEvents: MenuItemEvents[];
    get publicProperties(): PublicPropertiesType {
       return {
-         "width": [PropPerms.ReadAndSet, [PropBaseType.Combination, PropBaseType.Number, PropBaseType.Boolean]],
-         "height": [PropPerms.ReadAndSet, [PropBaseType.Combination, PropBaseType.Number, PropBaseType.Boolean]],
+         "width": [PropPerms.ReadAndSet, [PropBaseType.Combination, PropBaseType.Number, PropBaseType.Undefined]],
+         "height": [PropPerms.ReadAndSet, [PropBaseType.Combination, PropBaseType.Number, PropBaseType.Undefined]],
          "isVisible": [PropPerms.ReadAndSet, [PropBaseType.Boolean]],
          "isDisabled": [PropPerms.ReadAndSet, [PropBaseType.Boolean]],
          "minWidth": [PropPerms.ReadOnly, [PropBaseType.Number]],
@@ -1559,6 +1568,8 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       twrWindowMenuDeleteWidget: {},
       twrWindowMenuWidgetSetVisibility: {},
       twrWindowMenuRadioItemMerge: {},
+      twrWindowMenuWidgetSetProp: {},
+      twrWindowMenuWidgetGetProp: {isAsyncFunction: true},
    };
 
    // every library should have this line
@@ -1946,8 +1957,168 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       widget[1].isVisible = visibility > 0 ? true : false;
    }
 
-   twrWindowMenuWidgetSetProp(mod: IWasmModuleAsync | IWasmModule, widgetID: number, dataPtr: number) {
-
+   private checkValiditity(propField: [PropPerms, PropType], propName: string, typ: PropBaseType, widget: [WidgetType, Widget]) {
+      if (propField[1][0] == typ)
+         return;
+      else if (propField[1][0] == PropBaseType.Combination && propField[1].includes(typ)) {
+         return;
+      } else {
+         throw new Error(`twrWindowMenuWidgetSetProp: Property "${propName}" does not accept type ${PropBaseType[typ] ?? typ} in widget ${widget[1].id} of type ${WidgetType[widget[0]] ?? widget[0]}`);
+      }
    }
+
+   twrWindowMenuWidgetSetProp(mod: IWasmModuleAsync | IWasmModule, widgetID: number, propNamePtr: number, dataPtr: number) {
+      /* struct JSPropVal {
+         enum JSPropValType type;
+         const void* val;
+      }*/
+      const widget = this.widgets.get(widgetID);
+      if (widget == undefined) throw new Error(`twrWindowMenuWidgetSetProp: Error! was given an invalid widgetID (${widgetID})`);
+      
+      const propName = mod.getString(propNamePtr);
+      const propField = widget[1].publicProperties[propName];
+      if (propField == undefined) throw new Error(`twrWindowMenuWidgetSetProp: Couldn't find prop name "${propName}" in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
+      if (propField[0] == PropPerms.ReadOnly) throw new Error(`twrWindowMenuWidgetSetProp: Property "${propName}" is read only in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
+      
+      const typ = mod.getLong(dataPtr + 8) as PropBaseType;
+      const valPtr = dataPtr;
+      
+      console.log(`Attempting to modify ${propName} in widget ${widgetID}`);
+      switch (typ) {
+         case PropBaseType.String: 
+         {
+            this.checkValiditity(propField, propName, typ, widget);
+
+            let str;
+            const strPtr = mod.getLong(valPtr);
+            if (strPtr == 0) {
+               console.log("twrwindowMenuWidgetSetProp: Warning! Given a null ptr for string, default to empty string.");
+               str = "";
+            } else {
+               str = mod.getString(strPtr);
+            }
+
+            (widget[1] as any)[propName] = str;
+         }
+         break;
+         case PropBaseType.Boolean:
+         {
+            this.checkValiditity(propField, propName, typ, widget);
+
+            let val = mod.getLong(valPtr) != 0;
+            (widget[1] as any)[propName] = val;
+         }
+         break;
+         case PropBaseType.Number:
+         {
+            this.checkValiditity(propField, propName, typ, widget);
+
+            (widget[1] as any)[propName] = mod.getDouble(valPtr);
+         }
+         break;
+         case PropBaseType.Undefined:
+         {
+            this.checkValiditity(propField, propName, typ, widget);
+            (widget[1] as any)[propName] = undefined;
+         }
+         break;
+         default: 
+         {
+            throw new Error(`twrWindowMenuWidgetSetProp: Was given an invalid prop type. Expected a String (${PropBaseType.String}), Number (${PropBaseType.Number}), Boolean (${PropBaseType.Boolean}) or Undefined (${PropBaseType.Undefined})`);
+         }
+         break;
+      }
+   }
+
+   private twrWindowMenuWidgetGetPropPart1(mod: IWasmModuleAsync | IWasmModule, widgetID: number, propNamePtr: number): GetPropVal {
+      /* struct JSPropVal {
+         enum JSPropValType type;
+         const void* val;
+      }*/
+      const widget = this.widgets.get(widgetID);
+      if (widget == undefined) throw new Error(`twrWindowMenuWidgetGetProp: Error! was given an invalid widgetID (${widgetID})`);
+      
+      const propName = mod.getString(propNamePtr);
+      const propField = widget[1].publicProperties[propName];
+      if (propField == undefined) throw new Error(`twrWindowMenuWidgetGetProp: Couldn't find prop name "${propName}" in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
+      if (propField[0] == PropPerms.SetOnly) throw new Error(`twrWindowMenuWidgetGetProp: Property "${propName}" is set only in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
+
+      const val = (widget[1] as any)[propName];
+      switch (typeof val) {
+         case "string":
+            return [PropBaseType.String, val];
+         case "number":
+            return [PropBaseType.Number, val];
+         case "boolean":
+            return [PropBaseType.Boolean, val];
+         case "undefined":
+            return [PropBaseType.Undefined];
+         default:
+            throw new Error(`twrWindowMenuWidgetGetProp: Internal Error! Got unexpected type from property "${propName}" in Widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
+      }
+   }
+
+   private twrWindowMenuWidgetGetPropPart2(mod: IWasmModuleAsync | IWasmModule, retPtr: number, data: AllocGetPropVal) {
+      const valPtr = retPtr + 0;
+      const typePtr = retPtr + 8;
+      switch (data[0]) {
+         case PropBaseType.String:
+         {
+            mod.setLong(valPtr, data[2]);
+         }
+         break;
+         case PropBaseType.Number:
+         {
+            mod.setDouble(valPtr, data[1]);
+         }
+         break;
+         case PropBaseType.Undefined:
+         break;
+         case PropBaseType.Boolean:
+         {
+            mod.setLong(valPtr, data[1] ? 1 : 0);
+         }
+         break;
+         default:
+            throw new Error(`internal error, shouldn't be possible`);
+      }
+      mod.setLong(typePtr, data[0]);
+   }
+
+   twrWindowMenuWidgetGetProp(mod: IWasmModule, widgetID: number, propNamePtr: number) {
+      const val = this.twrWindowMenuWidgetGetPropPart1(mod, widgetID, propNamePtr);
+      
+      let alloc: AllocGetPropVal;
+      if (val[0] == PropBaseType.String)
+         alloc = [val[0], val[1], mod.putString(val[1])]
+      else
+         alloc = val;
+
+      //in struct, max unioned type is a double (8 bytes)
+      //and the type enum is a long (4 bytes)
+      const retPtr = mod.malloc(8 + 4);
+
+      this.twrWindowMenuWidgetGetPropPart2(mod, retPtr, alloc);
+
+      return retPtr;
+   }
+   async twrWindowMenuWidgetGetProp_async(mod: IWasmModuleAsync, widgetID: number, propNamePtr: number) {
+      const val = this.twrWindowMenuWidgetGetPropPart1(mod, widgetID, propNamePtr);
+   
+      let alloc: AllocGetPropVal;
+      if (val[0] == PropBaseType.String)
+         alloc = [val[0], val[1], await mod.putString(val[1])]
+      else
+         alloc = val;
+
+      //in struct, max unioned type is a double (8 bytes)
+      //and the type enum is a long (4 bytes)
+      const retPtr = await mod.malloc(8 + 4);
+
+      this.twrWindowMenuWidgetGetPropPart2(mod, retPtr, alloc);
+
+      return retPtr;
+   }
+
 
 }

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -38,7 +38,7 @@ type MenuItemEventData = [ MenuItemEvents.HOVERING ]
 interface GlobalWidgetProperties {
    borderColor: string,
    selectedColor: string,
-   menuOptionFont: string,
+   // menuOptionFont: string,
    widgetTextFont: string,
    menuOpenOffset: number,
    subMenuOpenOffset: number,
@@ -55,6 +55,7 @@ interface GlobalWidgetProperties {
    checkBoxUncheckedPrefix: string;
 };
 interface WidgetManager {
+   getCtx: () => CanvasRenderingContext2D;
    childUpdated: (ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) => void;
    //really, really long type. Basically accepts any class constructor that created a Widget
    // and accepts a CanvasRenderingContext2D, an id, a parent WidgetManager, and a set of properties of any type
@@ -70,13 +71,13 @@ interface Widget {
    readonly parent: WidgetManager; 
    readonly id: number;
    readonly handledEvents: MenuItemEvents[];
-   getMinSize: (ctx: CanvasRenderingContext2D) => [number, number];
+   getMinSize: () => [number, number];
    render: (ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) => void;
    handleMenuEvent: (ctx: CanvasRenderingContext2D, event: MenuItemEventData) => void;
    getDimensions: () => [number, number];
-   setDimensions: (ctx: CanvasRenderingContext2D, width?: number, height?: number) => void;
+   setDimensions: (width?: number, height?: number) => void;
    delete: (ctx: CanvasRenderingContext2D) => Widget[];
-   setVisibility: (ctx: CanvasRenderingContext2D, visibility: boolean) => void;
+   setVisibility: (visibility: boolean) => void;
    isVisible: () => boolean;
 
    fullUpdate: (ctx: CanvasRenderingContext2D) => void;
@@ -91,6 +92,7 @@ interface ButtonWidgetConstructor extends WidgetConstructor {
    prefixText?: string;
    suffixText?: string;
    centeredHorizontally?: boolean;
+
    reservedPrefixSpace?: number;
 }
 
@@ -109,7 +111,8 @@ class Button implements Widget, WidgetEvents {
 
    private textOffsets: [number, number, number];
 
-   private text: string;
+   private _text: string;
+   set text(val: string) {this._text = val; this.fullUpdate};
    private prefixText?: string;
    private suffixText?: string;
    private centeredHorizontally: boolean;
@@ -124,14 +127,14 @@ class Button implements Widget, WidgetEvents {
       this.parent = parent;
       this.id = id;
 
-      this.text = cons.text;
+      this._text = cons.text;
       this.prefixText = cons.prefixText;
       this.suffixText = cons.suffixText;
       this.centeredHorizontally = cons.centeredHorizontally ?? false;
       this.reservedPrefixSpace = cons.reservedPrefixSpace ?? 0;
       this.globalProps = globalProps;
 
-      const [minWidth, minHeight] = this.getMinSize(ctx);
+      const [minWidth, minHeight] = this.getMinSize();
 
       this.width = cons.width ?? minWidth;
       this.height = cons.height ?? minHeight;
@@ -141,15 +144,19 @@ class Button implements Widget, WidgetEvents {
    fullUpdate(ctx: CanvasRenderingContext2D) {
       this.textOffsets = this.getTextOffsets(ctx);
    }
-   delete(ctx: CanvasRenderingContext2D) {
+   delete(ctx: CanvasRenderingContext2D): Widget[] {
       this.parent.handleDelete(ctx, this);
       return [this];
    }
 
-   setVisibility(ctx: CanvasRenderingContext2D, visibility: boolean) {
+   private getFont() {
+      return this.globalProps.widgetTextFont;
+   }
+
+   setVisibility(visibility: boolean) {
       if (this.visibility != visibility) {
          this.visibility = visibility;
-         this.parent.childUpdated(ctx, this, false);
+         this.parent.childUpdated(this.parent.getCtx(), this, false);
          if (!this.visibility)
             this.visibility = false;
       }
@@ -161,9 +168,11 @@ class Button implements Widget, WidgetEvents {
    getDimensions(): [number, number] {
       return [this.width, this.height];
    }
-   setDimensions(ctx: CanvasRenderingContext2D, width?: number, height?: number) {
+   setDimensions(width?: number, height?: number) {
       this.height = height ?? this.height;
       this.width = width ?? this.width;
+
+      const ctx = this.parent.getCtx();
 
       if (height != undefined || width != undefined)
          this.textOffsets = this.getTextOffsets(ctx);
@@ -172,7 +181,7 @@ class Button implements Widget, WidgetEvents {
          this.parent.childUpdated(ctx);
    }
    setButtonText(ctx: CanvasRenderingContext2D, newText: string) {
-      this.text = newText;
+      this._text = newText;
       this.textOffsets = this.getTextOffsets(ctx);
       this.parent.childUpdated(ctx, this);
    }
@@ -184,7 +193,8 @@ class Button implements Widget, WidgetEvents {
 
    private getFullMinSize(ctx: CanvasRenderingContext2D): [number, number, number, number] {
       ctx.save();
-      ctx.font = this.globalProps.widgetTextFont;
+      // ctx.font = this.globalProps.widgetTextFont;
+      ctx.font = this.getFont();
 
       const spaceMeasure = ctx.measureText(" ");
       const spaceWidth = spaceMeasure.width;
@@ -199,7 +209,7 @@ class Button implements Widget, WidgetEvents {
          minSuffix = suffixMeasure.width + spaceWidth;
       }
 
-      const measure = ctx.measureText(this.text);
+      const measure = ctx.measureText(this._text);
       const minWidth = measure.width + minPrefix + minSuffix;
       const minHeight = measure.actualBoundingBoxAscent;
 
@@ -207,16 +217,26 @@ class Button implements Widget, WidgetEvents {
 
       return [minWidth, minHeight, minPrefix, minSuffix];
    }
-   getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
-      const [width, height,,] = this.getFullMinSize(ctx);
+   getMinSize(): [number, number] {
+      const [width, height,,] = this.getFullMinSize(this.parent.getCtx());
+      console.log(`button min size (${this._text}), (${width}, ${height})`)
       return [width, height];
    }
    getTextOffsets(ctx: CanvasRenderingContext2D): [number, number, number] {
       const [minWidth, minHeight, minPrefix, minSuffix] = this.getFullMinSize(ctx);
 
+      function getHeight(ctx: CanvasRenderingContext2D, font: string): number {
+         ctx.save();minHeight
+         ctx.font = font;
+         const measure = ctx.measureText("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.!?*&^%$#@)(0123456789-=_+`~[]{}\\|;:'\"");
+         ctx.restore();
+
+         return measure.actualBoundingBoxAscent;
+      }
+
       return [
          this.centeredHorizontally ? (this.width - (minWidth - minPrefix - minSuffix))/2.0 : minPrefix,
-         (this.height + minHeight)/2.0,
+         (this.height + getHeight(ctx, this.getFont()))/2.0,
          minSuffix
       ];
    }
@@ -230,7 +250,8 @@ class Button implements Widget, WidgetEvents {
       ctx.fillStyle = button_color;
       ctx.fillRect(offsetX, offsetY, this.width, this.height);
 
-      ctx.font = this.globalProps.widgetTextFont;
+      // ctx.font = this.globalProps.widgetTextFont;
+      ctx.font = this.getFont();
       ctx.fillStyle = this.globalProps.textColor;
       if (this.prefixText != undefined) {
          ctx.fillText(
@@ -240,7 +261,7 @@ class Button implements Widget, WidgetEvents {
          );
       } 
       ctx.fillText(
-         this.text,
+         this._text,
          this.textOffsets[0] + offsetX,
          this.textOffsets[1] + offsetY
       );
@@ -324,6 +345,7 @@ class Menu implements Widget, WidgetManager {
 
    private visibility: boolean = true;
    
+   
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
       this.globalProps = globalProps;
       this.parent = parent;
@@ -334,15 +356,19 @@ class Menu implements Widget, WidgetManager {
       this.childHeight = globalProps.emptyMenuHeight;
       this.childWidth = globalProps.emptyMenuWidth;
    }
+   getCtx() {
+      return this.parent.getCtx();
+   }
    fullUpdate(ctx: CanvasRenderingContext2D) {
       for (const [widget,] of this.children) {
          widget.fullUpdate(ctx);
       }
-      this.updateChildSize(ctx);
+      this.updateChildSize();
       this.selectedItem = undefined;
    }
 
-   setVisibility(ctx: CanvasRenderingContext2D, visibility: boolean) {
+   setVisibility(visibility: boolean) {
+      const ctx = this.parent.getCtx();
       if (this.visibility != visibility) {
          if (!visibility)
             this.handleMenuEvent(ctx, [MenuItemEvents.CLICKED_OFF]);
@@ -381,7 +407,7 @@ class Menu implements Widget, WidgetManager {
       //push self to list
       deleted.push(this);
       this.children = [];
-      this.updateChildSize(ctx);
+      this.updateChildSize();
       this.pauseDeleteHandle = false;
       return deleted;
 
@@ -412,14 +438,14 @@ class Menu implements Widget, WidgetManager {
    lastWidth: number = 0;
    lastHeight: number = 0;
    supressChildUpdates: boolean = false;
-   updateChildSize(ctx: CanvasRenderingContext2D, forceRun: boolean = false) {
+   updateChildSize(forceRun: boolean = false) {
       let childWidth = 0;
       // let maxChildHeight = this.minChildHeight;
       let childHeight = 0;
       for (const [widget,] of this.children) {
          if (!widget.isVisible())
             continue;
-         const [width, ] = widget.getMinSize(ctx);
+         const [width, ] = widget.getMinSize();
          childWidth = Math.max(childWidth, width);
          // maxChildHeight = Math.max(maxChildHeight, height+this.yPadding);
          const [, height] = widget.getDimensions();
@@ -441,7 +467,7 @@ class Menu implements Widget, WidgetManager {
 
       // console.log(newWidth, newHeight, this.childWidth, this.childHeight);
 
-      console.log(`updating width: ${newWidth}`);
+      console.log(`updating width: ${newWidth}; ${this.width}, ${childWidth}`);
       if (this.lastWidth != newWidth || this.lastHeight != newHeight || forceRun) {
          this.lastWidth = newWidth;
          this.lastHeight = newHeight;
@@ -452,7 +478,7 @@ class Menu implements Widget, WidgetManager {
                continue;
             const [, height] = widget[0].getDimensions();
             this.supressChildUpdates = true;
-            widget[0].setDimensions(ctx, newWidth - this.globalProps.menuBorderWidth * 2, undefined);
+            widget[0].setDimensions(newWidth - this.globalProps.menuBorderWidth * 2, undefined);
             widget[1] = curHeight;
             this.supressChildUpdates = false;
             // curHeight += maxChildHeight;
@@ -466,7 +492,7 @@ class Menu implements Widget, WidgetManager {
       if (sendToRoot) {
          this.parent.childUpdated(ctx, widget, true);
       } else if (!this.supressChildUpdates) {
-         this.updateChildSize(ctx);
+         this.updateChildSize();
          this.selectedItem = undefined;
          this.parent.childUpdated(ctx, this, false);
       }
@@ -479,13 +505,13 @@ class Menu implements Widget, WidgetManager {
       const widget: T = new cons(ctx, this, id, props, this.globalProps);
 
       this.children.push([widget, 0]);
-      this.updateChildSize(ctx, true);
+      this.updateChildSize(true);
       this.parent.childUpdated(ctx, this);
 
       return widget;
    }
 
-   getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
+   getMinSize(): [number, number] {
       return [
          this.childWidth, 
          this.childHeight
@@ -587,14 +613,15 @@ class Menu implements Widget, WidgetManager {
             const [, eX, eY, button] = event;
             this.updateSelectedObject(ctx, eX, eY);
             const selected = this.selectedItem;
-            if (selected) {
-               const [x, y] = [eX - this.globalProps.menuBorderWidth, eY - selected[1]];
-               this.dispatchEvent(ctx, selected[0], [MenuItemEvents.CLICKED, x, y, button]);
-            }
             for (const [widget,] of this.children) {
                if (selected == undefined || widget != selected[0])
                   this.dispatchEvent(ctx, widget, [MenuItemEvents.CLICKED_OFF]);
             }
+            if (selected) {
+               const [x, y] = [eX - this.globalProps.menuBorderWidth, eY - selected[1]];
+               this.dispatchEvent(ctx, selected[0], [MenuItemEvents.CLICKED, x, y, button]);
+            }
+            
          }
          break;
          case MenuItemEvents.UNHOVERED:
@@ -627,7 +654,7 @@ class Menu implements Widget, WidgetManager {
       ];
 	}
 
-   setDimensions(ctx: CanvasRenderingContext2D, width?: number, height?: number): void {
+   setDimensions(width?: number, height?: number): void {
       if (width != undefined){
          if (width == 0)
             this.width = undefined;
@@ -684,6 +711,7 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
 
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: RadioMenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
       this.globalProps = globalProps;
+      console.log(`Creating new radiomenu: ${props.height}, ${props.width}`);
       this.menu = new Menu(ctx, this, 0, props, globalProps);
       this.parent = parent;
       this.id = id;
@@ -692,13 +720,16 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
       
       this.handledEvents = this.menu.handledEvents;
    }
+   getCtx() {
+      return this.parent.getCtx();
+   }
    fullUpdate(ctx: CanvasRenderingContext2D) {
       if (this.selected != undefined)
          this.options.get(this.selected)!.setButtonPrefixText(ctx, this.globalProps.radioMenuPrefix);
       this.menu.fullUpdate(ctx);
    }
-   setVisibility(ctx: CanvasRenderingContext2D, visible: boolean) {
-      this.menu.setVisibility(ctx, visible);
+   setVisibility(visible: boolean) {
+      this.menu.setVisibility(visible);
    }
    isVisible() {
       return this.menu.isVisible();
@@ -714,8 +745,9 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
          prefix = this.globalProps.radioMenuPrefix;
       }
 
+      console.log(`Radio menu adding button: Menu width is: ${this.menu.getDimensions()[0]}`);
       const buttonOpts: ButtonWidgetConstructor = {
-         width: -1,
+         width: 20,
          height: this.optionHeight,
          text: opt,
          prefixText: prefix,
@@ -728,6 +760,8 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
       button.addEvent(((ctx: CanvasRenderingContext2D) => {
          this.changeSelected(ctx, opt);
       }).bind(this));
+
+      this.childUpdated(ctx, this);
    }
 
    changeSelected(ctx: CanvasRenderingContext2D, opt: string) {
@@ -747,8 +781,8 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
       }
    }
 
-   getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
-      return this.menu.getMinSize(ctx);
+   getMinSize(): [number, number] {
+      return this.menu.getMinSize();
    }
    render(ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) {
       this.menu.render(ctx, offsetX, offsetY);
@@ -757,13 +791,15 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
       this.menu.handleMenuEvent(ctx, event);
    }
    getDimensions(): [number, number] {
+      console.log(`Getting radio menu dimensions: ${this.menu.getDimensions()}`);
       return this.menu.getDimensions();
    }
-   setDimensions(ctx: CanvasRenderingContext2D, width?: number, height?: number) {
-      return this.menu.setDimensions(ctx, width, height);
+   setDimensions(width?: number, height?: number) {
+      return this.menu.setDimensions(width, height);
    }
 
    childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) {
+      console.log("radio menu updated!!!");
       this.parent.childUpdated(ctx, widget == this.menu ? this : widget, sendToRoot);
    }
 
@@ -833,13 +869,18 @@ class MenuBar implements Widget, WidgetManager {
       this.calcWidth = this.globalProps.emptyMenuWidth;
       this.calcHeight = this.globalProps.emptyMenuWidth;
    }
+   getCtx() {
+      return this.parent.getCtx();
+   }
+
    fullUpdate(ctx: CanvasRenderingContext2D) {
       for (const [widget,] of this.children) {
          widget.fullUpdate(ctx);
       }
    }
 
-   setVisibility(ctx: CanvasRenderingContext2D, visible: boolean) {
+   setVisibility(visible: boolean) {
+      const ctx = this.parent.getCtx();
       if (!this.visible != visible) {
          if (!visible)
             this.handleMenuEvent(ctx, [MenuItemEvents.CLICKED_OFF]);
@@ -851,7 +892,7 @@ class MenuBar implements Widget, WidgetManager {
       return this.visible;
    }
 
-   getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
+   getMinSize(): [number, number] {
       return [this.calcWidth, this.calcHeight];
    }
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
@@ -957,9 +998,10 @@ class MenuBar implements Widget, WidgetManager {
          this.height ?? this.calcHeight
       ];
    }
-   setDimensions(ctx: CanvasRenderingContext2D, width?: number, height?: number) {
+   setDimensions(width?: number, height?: number) {
       this.width = width ?? this.width;
       this.height = height ?? this.height;
+      const ctx = this.parent.getCtx();
       this.parent.childUpdated(ctx, this);
    }
    delete(ctx: CanvasRenderingContext2D): Widget[] {
@@ -972,7 +1014,7 @@ class MenuBar implements Widget, WidgetManager {
       this.supressChildUpdates = false;
       return deleted;
    }
-   private updateChildren(ctx: CanvasRenderingContext2D) {
+   private updateChildren() {
       this.selected = undefined;
 
       let minHeight = this.globalProps.emptyMenuWidth;
@@ -982,7 +1024,7 @@ class MenuBar implements Widget, WidgetManager {
             continue;
 
          const [widgetWidth, widgetHeight] = widget.getDimensions();
-         const [widgetMinWidth, widgetMinHeight] = widget.getMinSize(ctx);
+         const [widgetMinWidth, widgetMinHeight] = widget.getMinSize();
          
          minHeight = Math.max(minHeight, widgetHeight, widgetMinHeight);
          width += Math.max(this.globalProps.emptyMenuWidth, widgetWidth, widgetMinWidth) + this.globalProps.xPadding;
@@ -1002,10 +1044,9 @@ class MenuBar implements Widget, WidgetManager {
             continue;
 
          const [widgetWidth, widgetHeight] = widget[0].getDimensions();
-         const [minWidgetWidth,] = widget[0].getMinSize(ctx);
+         const [minWidgetWidth,] = widget[0].getMinSize();
          const nWidth = Math.max(this.globalProps.emptyMenuWidth, widgetWidth, minWidgetWidth);
          widget[0].setDimensions(
-            ctx,
             nWidth,
             tmpHeight
          );
@@ -1019,15 +1060,15 @@ class MenuBar implements Widget, WidgetManager {
       if (sendToRoot) {
          this.parent.childUpdated(ctx, widget, true);
       } else if(!this.supressChildUpdates) {
-         this.updateChildren(ctx);
+         this.updateChildren();
       }
    }
    addChild<
       T extends Widget, 
       U, 
-      O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U) => T
-   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
-      const widget: T = new cons(ctx, this, id, props);
+      O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U, globalProps: GlobalWidgetProperties) => T
+   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U, globalProps: GlobalWidgetProperties): T {
+      const widget: T = new cons(ctx, this, id, props, globalProps);
       
       this.children.push([widget, 0]);
       this.childUpdated(ctx, widget);
@@ -1058,7 +1099,7 @@ class MenuBar implements Widget, WidgetManager {
          for (let i = 0; i < this.children.length; i++) {
             if (this.children[i][0] == widget) {
                this.children.splice(i, 1);
-               this.updateChildren(ctx);
+               this.updateChildren();
                break;
             }
          }
@@ -1072,9 +1113,12 @@ class RootWidgetManager implements WidgetManager {
    private popupWidgets: Map<Widget, [number, number]> = new Map();
 
    private selectedWidget?: [Widget, number, number];
-
-   constructor() {
-
+   private ctx: CanvasRenderingContext2D;
+   constructor(ctx: CanvasRenderingContext2D) {
+      this.ctx = ctx;
+   }
+   getCtx() {
+      return this.ctx;
    }
    handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
       for (let i = 0; i < this.boundWidgets.length; i++) {
@@ -1089,9 +1133,9 @@ class RootWidgetManager implements WidgetManager {
    addChild<
       T extends Widget, 
       U, 
-      O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U) => T
-   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U, x: number, y: number): T {
-      const widget: T = new cons(ctx, this, id, props);
+      O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U, globalProps: GlobalWidgetProperties) => T
+   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U, globalProps: GlobalWidgetProperties, x: number, y: number): T {
+      const widget: T = new cons(ctx, this, id, props, globalProps);
       
       this.boundWidgets.push([widget, x, y]);
 
@@ -1228,10 +1272,7 @@ interface MenuButtonWidgetConstructor extends ButtonWidgetConstructor {
    openToRight?: boolean,
    offset?: number,
 }
-class MenuButton implements Widget, WidgetManager {
-   readonly globalProps: GlobalWidgetProperties;
-   readonly parent: WidgetManager;
-   readonly id: number;
+class MenuButton extends Button implements WidgetManager {
    readonly handledEvents: MenuItemEvents[] = [
       MenuItemEvents.CLICKED,
       MenuItemEvents.HOVERING,
@@ -1239,7 +1280,6 @@ class MenuButton implements Widget, WidgetManager {
       MenuItemEvents.CLICKED_OFF
    ];
 
-   readonly button: Button;
    readonly menu: Menu;
 
    private openToRight: boolean;
@@ -1247,28 +1287,18 @@ class MenuButton implements Widget, WidgetManager {
 
    private menuOpened: boolean = false;
 
-   private visible: boolean = true;
-
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuButtonWidgetConstructor, globalProps: GlobalWidgetProperties) {
-      this.globalProps = globalProps;
-      this.parent = parent;
-      this.id = id;
+      super(ctx, parent, id, props, globalProps);
 
       this.openToRight = props.openToRight ?? false;
       this.offset = props.offset ?? 0;
-
-      this.button = new Button(ctx, this, 0, props, this.globalProps);
-
-      const [width, ] = this.button.getDimensions();
-
-      // menuOptions.minimumWidth = menuOptions.minimumWidth ?? width; 
       this.menu = new Menu(ctx, this, 1, {
          width: props.menuWidth,
          height: props.menuHeight
       }, globalProps);
 
-      this.button.addEvent((() => {
-         const [width,height] = this.button.getDimensions();
+      super.addEvent((() => {
+         const [width,height] = super.getDimensions();
          let x = this.openToRight ? width + this.offset : 0;
          let y = this.openToRight ? 0 : height + this.offset;
          console.log(`spawning menu at: (${x}, ${y})`)
@@ -1279,54 +1309,33 @@ class MenuButton implements Widget, WidgetManager {
          this.parent.closePopup(ctx, this.menu);
          this.menuOpened = false;
       }).bind(this));
-
+   }
+   getCtx() {
+      return this.parent.getCtx();
    }
    fullUpdate(ctx: CanvasRenderingContext2D) {
-      this.button.fullUpdate(ctx);
+      super.fullUpdate(ctx);
       this.menu.fullUpdate(ctx);
-   }
-
-   setVisibility(ctx: CanvasRenderingContext2D, visible: boolean) {
-      if (this.visible != visible) {
-         if (!visible)
-            this.handleMenuEvent(ctx, [MenuItemEvents.CLICKED_OFF]);
-         this.visible = visible;
-         this.parent.childUpdated(ctx, this, false);
-      }
-   }
-   isVisible() {
-      return this.visible;
    }
 
    private supressHandleDelete: boolean = false;
    handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
       if (this.supressHandleDelete)
          return;
-      if (widget == this.button)
-         throw new Error("MenuButton's internal button shouldn't be externally accesible");
       else if (widget == this.menu)
          throw new Error("MenuButton's internal menu shouldn't be externally accesible");
       else
          throw new Error("MenuButton shouldn't be handling any deletions?");
    }
-   delete(ctx: CanvasRenderingContext2D) {
+   delete(ctx: CanvasRenderingContext2D): Widget[] {
       this.supressHandleDelete = true;
       this.parent.handleDelete(ctx, this);
       let deleted: Widget[] = this.menu.delete(ctx);
-      this.button.delete(ctx);
       //delete menu from list since it's not exposed externally
       deleted.splice(deleted.indexOf(this.menu), 1);
       deleted.push(this); //push self
       this.supressHandleDelete = false;
       return deleted;
-   }
-
-   getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
-      return this.button.getMinSize(ctx);
-   }
-   render(ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) {
-      if (this.visible)
-         this.button.render(ctx, offsetX, offsetY);
    }
    handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
       if (event[0] == MenuItemEvents.CLICKED_OFF) {
@@ -1335,14 +1344,9 @@ class MenuButton implements Widget, WidgetManager {
             this.parent.closePopup(ctx, this.menu);
          }
       } else {
-         this.button.handleMenuEvent(ctx, event);
+         // this.button.handleMenuEvent(ctx, event);
+         super.handleMenuEvent(ctx, event);
       }
-   }
-   getDimensions(): [number, number] {
-      return this.button.getDimensions();
-   }
-   setDimensions(ctx: CanvasRenderingContext2D, width?: number, height?: number) {
-      this.button.setDimensions(ctx, width, height);
    }
 
    childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) {
@@ -1400,10 +1404,10 @@ class Seperator implements Widget {
       this.updateText(ctx);
    }
 
-   setVisibility(ctx: CanvasRenderingContext2D, visible: boolean) {
+   setVisibility(visible: boolean) {
       if (this.visible != visible) {
          this.visible = visible;
-         this.parent.childUpdated(ctx, this, false);
+         this.parent.childUpdated(this.parent.getCtx(), this, false);
       }
    }
    isVisible() {
@@ -1435,7 +1439,7 @@ class Seperator implements Widget {
       ctx.restore();
    }
 
-   getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
+   getMinSize(): [number, number] {
       return [0, this.minHeight];
    }
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
@@ -1462,11 +1466,11 @@ class Seperator implements Widget {
    getDimensions(): [number, number] {
       return [this.width, this.height];
    }
-   setDimensions(ctx: CanvasRenderingContext2D, width?: number, height?: number) {
+   setDimensions(width?: number, height?: number) {
       this.width = width ?? this.width;
       this.height = height ?? this.height;
       if (width != undefined || height != undefined) {
-         this.updateText(ctx);
+         this.updateText(this.parent.getCtx());
       }
    }
 }
@@ -1492,7 +1496,8 @@ class CheckBox implements Widget, WidgetManager, WidgetEvents {
       const buttonCons: ButtonWidgetConstructor = {
          text: props.text,
          width: props.width,
-         height: props.height
+         height: props.height,
+         prefixText: this.globalProps.checkBoxUncheckedPrefix,
       };
       this.button = new Button(ctx, this, 0, buttonCons, this.globalProps);
       this.handledEvents = this.button.handledEvents;
@@ -1509,6 +1514,9 @@ class CheckBox implements Widget, WidgetManager, WidgetEvents {
          }
       })
    }
+   getCtx() {
+      return this.parent.getCtx();
+   }
    fullUpdate(ctx: CanvasRenderingContext2D) {
       this.button.fullUpdate(ctx);
       this.button.setButtonPrefixText(
@@ -1518,8 +1526,8 @@ class CheckBox implements Widget, WidgetManager, WidgetEvents {
             : this.globalProps.checkBoxUncheckedPrefix
       );
    }
-   setVisibility(ctx: CanvasRenderingContext2D, visibility: boolean) {
-      this.button.setVisibility(ctx, visibility);
+   setVisibility(visibility: boolean) {
+      this.button.setVisibility(visibility);
    }
    isVisible() {
       return this.button.isVisible();
@@ -1531,8 +1539,8 @@ class CheckBox implements Widget, WidgetManager, WidgetEvents {
       this.changeEventHandlers.delete(callback);
    }
 
-   getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
-      return this.button.getMinSize(ctx);
+   getMinSize(): [number, number] {
+      return this.button.getMinSize();
    }
    render(ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) {
       this.button.render(ctx, offsetX, offsetY);
@@ -1543,8 +1551,8 @@ class CheckBox implements Widget, WidgetManager, WidgetEvents {
    getDimensions(): [number, number] {
       return this.button.getDimensions();
    }
-   setDimensions(ctx: CanvasRenderingContext2D, width?: number, height?: number) {
-      this.button.setDimensions(ctx, width, height);
+   setDimensions(width?: number, height?: number) {
+      this.button.setDimensions(width, height);
    }
    delete(ctx: CanvasRenderingContext2D): Widget[] {
       this.button.delete(ctx);
@@ -1604,13 +1612,13 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    
    nextWidgetID: number = 0;
 
-   readonly manager: RootWidgetManager = new RootWidgetManager();
+   readonly manager: RootWidgetManager;
    readonly menu: MenuBar;
 
-   widgetSettings = {
+   widgetSettings: GlobalWidgetProperties = {
       borderColor: "#B0B0B0",
       selectedColor: "#D0D0D0",
-      menuOptionFont: "16px Seriph",
+      // menuOptionFont: "16px Seriph",
       widgetTextFont: "12px Seriph",
       menuOpenOffset: 5,
       subMenuOpenOffset: 1,
@@ -1619,6 +1627,13 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       yPadding: 5,
       menuBorderWidth: 1.0,
       menuBorderColor: "Black",
+
+      xPadding: 5,
+      emptyMenuHeight: 20,
+      emptyMenuWidth: 20,
+      radioMenuPrefix: "*",
+      checkBoxCheckedPrefix: "[*]",
+      checkBoxUncheckedPrefix: "[  ]"
    };
    
 
@@ -1642,6 +1657,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
 
       this.element = canvas;
       this.ctx = canvas.getContext("2d")!;
+      this.manager = new RootWidgetManager(this.ctx);
 
       // const perimiterThickness = Math.min(canvas.height, canvas.width) * 0.025;
       // const menuThickness = Math.min(canvas.height, canvas.width) * 0.1;
@@ -1677,12 +1693,12 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       // };
       // this.manager.addChild(this.ctx, -10, Button, buttonOpts);
       const menuBarCons: MenuBarWidgetConstructor = {
-         minChildWidth: 10,
-         menuColor: "#B0B0B0",
+         // minChildWidth: 10,
+         // menuColor: "#B0B0B0",
          height: TOP_BAR_SIZE - 0.5,
-         xPadding: MENU_PADDING_X,
+         // xPadding: MENU_PADDING_X,
       };
-      this.menu = this.manager.addChild(this.ctx, 0, MenuBar, menuBarCons, BORDER_SIZE + MENU_PADDING_X, 0);
+      this.menu = this.manager.addChild(this.ctx, 0, MenuBar, menuBarCons, this.widgetSettings, BORDER_SIZE + MENU_PADDING_X, 0);
    }
 
    getProp(propName: string) {
@@ -1771,11 +1787,11 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       const id = ++this.nextWidgetID;
 
       const menuOptions: MenuWidgetConstructor = {
-         menuColor: "#B0B0B0",
-         minimumHeight: TOP_BAR_SIZE/2.0,
-         yPadding: 2,
-         borderWidth: 1.0,
-         borderColor: "black"
+         // menuColor: "#B0B0B0",
+         // minimumHeight: TOP_BAR_SIZE/2.0,
+         // yPadding: 2,
+         // borderWidth: 1.0,
+         // borderColor: "black"
       };
 
       const button: MenuButton = this.menu.addChild(this.ctx, id, MenuButton, {
@@ -1786,7 +1802,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          selectedButtonColor: "#D0D0D0",
          menuOptions: menuOptions,
          offset: 0.5,
-      });
+      }, this.widgetSettings);
 
       this.widgets.set(id, [WidgetType.SubMenu, button]);
 
@@ -1883,10 +1899,10 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
                width: width,
                height: height,
                text: getStringOrDef(extraPtr + 0, "Lorem Ipsum"),
-               textFont: this.widgetSettings.widgetTextFont,
-               textColor: this.widgetSettings.textColor,
-               buttonColor: this.widgetSettings.borderColor,
-               selectedButtonColor: this.widgetSettings.selectedColor,
+               // textFont: this.widgetSettings.widgetTextFont,
+               // textColor: this.widgetSettings.textColor,
+               // buttonColor: this.widgetSettings.borderColor,
+               // selectedButtonColor: this.widgetSettings.selectedColor,
             };
             const widget: Button = menu.addChild(this.ctx, id, Button, button);
             this.widgets.set(id, [WidgetType.Button, widget]);
@@ -1907,8 +1923,8 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
                width: width,
                height: height,
                seperatorText: getStringOrDef(extraPtr + 0, "-"),
-               seperatorFont: getStringOrDef(extraPtr + 4, this.widgetSettings.widgetTextFont),
-               seperatorColor: this.widgetSettings.textColor
+               // seperatorFont: getStringOrDef(extraPtr + 4, this.widgetSettings.widgetTextFont),
+               // seperatorColor: this.widgetSettings.textColor
             };
             const widget: Seperator = menu.addChild(this.ctx, id, Seperator, seperator);
             this.widgets.set(id, [WidgetType.Seperator, widget]);
@@ -1935,16 +1951,16 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             const cons: RadioMenuWidgetConstructor = {
                width: width,
                height: height,
-               minimumWidth: getLongOrDef(extraPtr + 0, 0),            
-               minimumHeight: getLongOrDef(extraPtr + 4, 0),
-               yPadding: this.widgetSettings.yPadding,
-               menuColor: this.widgetSettings.borderColor,
-               hoveredBackgroundColor: this.widgetSettings.selectedColor,
-               selectedSymbol: getStringOrDef(extraPtr + 8, "*"),
-               reservedPrefixLength: this.widgetSettings.reservedPrefixLen,
+               // minimumWidth: getLongOrDef(extraPtr + 0, 0),            
+               // minimumHeight: getLongOrDef(extraPtr + 4, 0),
+               // yPadding: this.widgetSettings.yPadding,
+               // menuColor: this.widgetSettings.borderColor,
+               // hoveredBackgroundColor: this.widgetSettings.selectedColor,
+               // selectedSymbol: getStringOrDef(extraPtr + 8, "*"),
+               // reservedPrefixLength: this.widgetSettings.reservedPrefixLen,
                optionHeight: getLongOrDef(extraPtr + 12, 20),
-               optionTextFont: this.widgetSettings.widgetTextFont,
-               optionTextColor: this.widgetSettings.textColor,
+               // optionTextFont: this.widgetSettings.widgetTextFont,
+               // optionTextColor: this.widgetSettings.textColor,
             };
             const radio: RadioMenu = menu.addChild(this.ctx, id, RadioMenu, cons);
             this.widgets.set(id, [WidgetType.RadioMenu, radio]);
@@ -1974,20 +1990,22 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
                width: width,
                height: height,
                text: getStringOrDef(extraPtr + 0, "Lorem Ipsum"),
-               textFont: this.widgetSettings.widgetTextFont,
-               textColor: this.widgetSettings.textColor,
-               buttonColor: this.widgetSettings.borderColor,
-               selectedButtonColor: this.widgetSettings.selectedColor,
+               // textFont: this.widgetSettings.widgetTextFont,
+               // textColor: this.widgetSettings.textColor,
+               // buttonColor: this.widgetSettings.borderColor,
+               // selectedButtonColor: this.widgetSettings.selectedColor,
 
-               menuOptions: {
-                  minimumWidth: getLongOrDef(extraPtr + 4, 10),
-                  minimumHeight: getLongOrDef(extraPtr + 8, 10),
-                  menuColor: this.widgetSettings.borderColor,
-                  yPadding: this.widgetSettings.yPadding,
-                  minChildHeight: getLongOrDef(extraPtr + 12, 10),
-                  borderColor: this.widgetSettings.menuBorderColor,
-                  borderWidth: this.widgetSettings.menuBorderWidth,
-               },
+               // menuOptions: {
+                  // minimumWidth: getLongOrDef(extraPtr + 4, 10),
+                  // minimumHeight: getLongOrDef(extraPtr + 8, 10),
+                  // menuColor: this.widgetSettings.borderColor,
+                  // yPadding: this.widgetSettings.yPadding,
+                  // minChildHeight: getLongOrDef(extraPtr + 12, 10),
+                  // borderColor: this.widgetSettings.menuBorderColor,
+                  // borderWidth: this.widgetSettings.menuBorderWidth,
+               // },
+               menuWidth: getLongOrDef(extraPtr + 4, undefined),
+               menuHeight: getLongOrDef(extraPtr + 8, undefined),
 
                offset: this.widgetSettings.subMenuOpenOffset,
                openToRight: true,
@@ -2022,13 +2040,13 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
 
             const props: CheckBoxWidgetConstructor = {
                text: getStringOrDef(extraPtr + 0, "Lorem Ipsum"),
-               checkedSymbol: getStringOrDef(extraPtr + 4, "*"),
-               unCheckedSymbol: getStringOrDef(extraPtr + 8, ""),
-               reservedPrefixSpace: this.widgetSettings.reservedPrefixLen,
-               textFont: this.widgetSettings.widgetTextFont,
-               textColor: this.widgetSettings.textColor,
-               buttonColor: this.widgetSettings.borderColor,
-               selectedButtonColor: this.widgetSettings.selectedColor,
+               // checkedSymbol: getStringOrDef(extraPtr + 4, "*"),
+               // unCheckedSymbol: getStringOrDef(extraPtr + 8, ""),
+               // reservedPrefixSpace: this.widgetSettings.reservedPrefixLen,
+               // textFont: this.widgetSettings.widgetTextFont,
+               // textColor: this.widgetSettings.textColor,
+               // buttonColor: this.widgetSettings.borderColor,
+               // selectedButtonColor: this.widgetSettings.selectedColor,
             };
             const widget: CheckBox = menu.addChild(this.ctx, id, CheckBox, props);
             this.widgets.set(id, [WidgetType.CheckBox, widget]);
@@ -2112,7 +2130,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       if (!this.widgets.has(widgetID)) throw new Error(`twrWindowMenuWidgetSetVisibility: Error! was given an invalid widgetID (${widgetID})`);
       const widget = this.widgets.get(widgetID)!;
 
-      widget[1].setVisibility(this.ctx, visibility > 0 ? true : false);
+      widget[1].setVisibility(visibility > 0 ? true : false);
    }
 
 }

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -21,23 +21,120 @@ enum twrWindowEvents {
    
 }
 
+const BUTTON_FONT = "16px Serif";
+const BUTTON_PADDING_Y = 2.5;
+const BUTTON_PADDING_X = 5;
+const BUTTON_HEIGHT = 5;
+class Button {
+   text: string;
+   minWidth: number;
+   events: Map<number, [IWasmModule|IWasmModuleAsync, Map<number, number>]> = new Map();
+
+   constructor(text: string, ctx: CanvasRenderingContext2D) {
+      this.text = text;
+
+      ctx.save();
+      
+      ctx.font = BUTTON_FONT;
+      const measure = ctx.measureText(text);
+      this.minWidth = measure.width + BUTTON_PADDING_X*2.0;
+
+      ctx.restore();
+   }
+
+   addEvent(mod: IWasmModule|IWasmModuleAsync, eventID: number, extraPtr: number) {
+      if (!(mod.id in this.events))
+         this.events.set(mod.id, [mod, new Map()]);
+
+      const [_, event_map] = this.events.get(mod.id)!;
+
+      if (eventID in event_map)
+         throw new Error(`Error: button addEvent was given an eventID (${eventID}) that's already been registered!`);
+      
+      event_map.set(eventID, extraPtr);
+   }
+
+   removeEvent(mod: IWasmModule|IWasmModuleAsync, eventID: number) {
+      if (!(mod.id in this.events))
+         throw new Error(`Error: button removeEvent tried to remove event from a module (${mod.id}) that's never registered one!`);
+      
+      const [_, event_map] = this.events.get(mod.id)!;
+
+      if (!(eventID in event_map))
+         throw new Error(`Error: button removeEvent tried to remove an eventID (${eventID}) that isn't registered!`);
+
+      event_map.delete(eventID);
+   }
+
+   removeAllModEvents(mod: IWasmModule|IWasmModuleAsync) {
+      if (!(mod.id in this.events))
+         throw new Error(`Error: button removeAllModEvents trying to remove events from a module (${mod.id}) that's never registered any!`);
+
+      this.events.delete(mod.id);
+   }
+}
+
+const MENU_TEXT_FONT = "20px Serif";
+const MENU_PADDING_X = 5;
+const MENU_PADDING_Y = 4;
+const TOP_BAR_SIZE: number = 30;
+const BORDER_SIZE: number = 5;
+const MENU_START_X = BORDER_SIZE;
+class Menu {
+   text: string;
+   buttons: number[] = [];
+   
+   xOffset = MENU_PADDING_X;
+   width: number;
+   yOffset: number;
+
+   hovering: boolean = false;
+   selected: boolean = false;
+
+   constructor(text: string, ctx: CanvasRenderingContext2D) {
+      this.text = text;
+      ctx.save();
+      
+      ctx.font = MENU_TEXT_FONT;
+      const measure = ctx.measureText(text);
+
+      ctx.restore();
+
+      this.width = MENU_PADDING_X*2 + measure.width;
+      // console.log(`menu: ${measure.actualBoundingBoxAscent}, ${measure.actualBoundingBoxDescent}`);
+      this.yOffset = (TOP_BAR_SIZE + measure.actualBoundingBoxAscent)/2;
+   }
+
+   addButton(buttonID: number, buttons: Map<number, Button>) {
+      if (!(buttonID in buttons))
+         throw new Error(`Error! Menu addButton was given an unregisted buttonID ${buttonID}!`);
+
+
+   }
+
+}
+
 export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, IConsoleWindow {
    id: number;
    props: IConsoleBaseProps;
 
    element: HTMLCanvasElement;
    ctx: CanvasRenderingContext2D;
-   readonly topBarSize: number;
-   readonly borderSize: number;
    
    appCanvasWidth: number;
    appCanvasHeight: number;
    readonly appCanvas: twrConsoleCanvas;
 
-   appCanvasConNames: { [modID: number]: string } = {};
+   buttons: Map<number, Button> = new Map();
+   nextButtonID: number = 0;
+
+   menus: Map<number, Menu> = new Map();
+   nextMenuID: number = 0;
+   
 
    imports: TLibImports = {
       twrGetAppCanvasJSID: {},
+      twrWindowAddMenu: {},
    };
 
    // every library should have this line
@@ -51,14 +148,14 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       this.element = canvas;
       this.ctx = canvas.getContext("2d")!;
 
-      const perimiterThickness = Math.min(canvas.height, canvas.width) * 0.025;
-      const menuThickness = Math.min(canvas.height, canvas.width) * 0.1;
+      // const perimiterThickness = Math.min(canvas.height, canvas.width) * 0.025;
+      // const menuThickness = Math.min(canvas.height, canvas.width) * 0.1;
 
-      this.appCanvasHeight = Math.floor(canvas.height - perimiterThickness - menuThickness);
-      this.appCanvasWidth = Math.floor(canvas.width - perimiterThickness*2.0);
+      this.appCanvasHeight = Math.floor(canvas.height - BORDER_SIZE - TOP_BAR_SIZE);
+      this.appCanvasWidth = Math.floor(canvas.width - BORDER_SIZE*2.0);
 
-      this.topBarSize = menuThickness;
-      this.borderSize = perimiterThickness;
+      // this.topBarSize = menuThickness;
+      // this.borderSize = perimiterThickness;
 
       const appCanvas = document.createElement("canvas");
       appCanvas.height = this.appCanvasHeight;
@@ -74,6 +171,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          type: 0
       };
    }
+
    getProp(propName: string) {
       return this.props[propName];
    };
@@ -95,40 +193,108 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
 
    handleCanvasKeyEvent(event: CanvasEventTypes, key: number) {
       this.appCanvas.handleCanvasKeyEvent(event, key);
+      return true;
    }
+
+   mouseWasOnTopBar: boolean = false;
    handleCanvasMouseEvent(event: CanvasEventTypes, x: number, y: number) {
-      const n_x = x - this.borderSize;
-      const n_y = y - this.topBarSize;
+      const n_x = x - BORDER_SIZE;
+      const n_y = y - TOP_BAR_SIZE;
+      let topBar = false;
       if (
          n_x >= 0 && n_y >= 0
          && n_x <= this.appCanvasWidth
          && n_y <= this.appCanvasHeight
       ) {
          this.appCanvas.handleCanvasMouseEvent(event, n_x, n_y);
+      } else if (y <= TOP_BAR_SIZE) {
+         topBar = true;
+         this.mouseWasOnTopBar = true;
+         let widthOffset = MENU_START_X;
+         for (const menu of this.menus.values()) {
+            menu.hovering = x >= widthOffset
+               && x < widthOffset+menu.width;
+            // console.log(`${x >= widthOffset}, ${x < widthOffset+menu.width}, ${menu.hovering}`);
+
+            widthOffset += menu.width;
+         }
       }
-         
+
+      if (!topBar && this.mouseWasOnTopBar) {
+         this.mouseWasOnTopBar = false;
+         for (const menu of this.menus.values()) {
+            menu.hovering = false;
+         }
+      }
+      return true;
    }
    handleCanvasWheelEvent(event: CanvasEventTypes, deltaX: number, deltaY: number, deltaZ: number, deltaMode: number) {
       this.appCanvas.handleCanvasWheelEvent(event, deltaX, deltaY, deltaZ, deltaMode);
+      return true;
    }
    handleCanvasAnimationFrameEvent(event: CanvasEventTypes, delta: number) {
       this.appCanvas.handleCanvasAnimationFrameEvent(event, delta);
 
       this.ctx.reset();
       //draw "app" canvas
-      this.ctx.drawImage(this.appCanvas.element, this.borderSize, this.topBarSize);
+      this.ctx.drawImage(this.appCanvas.element, BORDER_SIZE, TOP_BAR_SIZE);
 
+      const SELECT_GREY = "#D0D0D0";
       //draw border around it
-      this.ctx.fillStyle = "blue";
-      this.ctx.fillRect(0, 0, this.borderSize, this.element.height);
-      this.ctx.fillRect(this.element.width - this.borderSize, 0, this.element.width, this.element.height);
-      this.ctx.fillRect(0, this.element.height - this.borderSize, this.element.width, this.element.height);
+      this.ctx.fillStyle = "#B0B0B0";
+      this.ctx.fillRect(0, 0, BORDER_SIZE, this.element.height);
+      this.ctx.fillRect(this.element.width - BORDER_SIZE, 0, this.element.width, this.element.height);
+      this.ctx.fillRect(0, this.element.height - BORDER_SIZE, this.element.width, this.element.height);
       
-      this.ctx.fillRect(0, 0, this.element.width, this.topBarSize);
+      this.ctx.fillRect(0, 0, this.element.width, TOP_BAR_SIZE);
+
+      this.ctx.fillStyle = "grey";
+      this.ctx.lineWidth = 1.0;
+      
+      this.ctx.beginPath();
+      this.ctx.moveTo(0, TOP_BAR_SIZE - this.ctx.lineWidth/2.0);
+      this.ctx.lineTo(this.element.width, TOP_BAR_SIZE - this.ctx.lineWidth/2.0);
+      this.ctx.stroke();
+      this.ctx.closePath();
+
+      this.ctx.fillStyle = "black";
+      this.ctx.font = MENU_TEXT_FONT;
+      let widthOffset = MENU_START_X; 
+      for (const menu of this.menus.values()) {
+         // console.log(`${widthOffset + menu.xOffset}, ${menu.yOffset}`);
+         if (menu.hovering ) {
+            this.ctx.save();
+            this.ctx.fillStyle = SELECT_GREY;
+
+            this.ctx.beginPath();
+            this.ctx.roundRect(widthOffset, MENU_PADDING_Y, menu.width, TOP_BAR_SIZE - MENU_PADDING_Y*2.0, Math.PI);
+            this.ctx.fill();
+            this.ctx.closePath();
+
+            this.ctx.restore();
+         }
+         this.ctx.fillText(
+            menu.text, 
+            widthOffset + menu.xOffset,
+            menu.yOffset,
+         );
+
+         widthOffset += menu.width;
+      }
    }
 
    twrGetAppCanvasJSID(mod:IWasmModule|IWasmModuleAsync) {
       return this.appCanvas.id;
+   }
+
+   twrWindowAddMenu(mod: IWasmModuleAsync | IWasmModule, textPtr: number) {
+      const text = mod.getString(textPtr);
+
+      const id = ++this.nextButtonID;
+
+      this.menus.set(id, new Menu(text, this.ctx));
+
+      return id;
    }
 
 

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -26,11 +26,13 @@ enum MenuItemEvents {
    UNHOVERED,
    CLICKED,
    MOUSE_MOVE,
+   CLICKED_OFF,
 }
 type MenuItemEventData = [ MenuItemEvents.HOVERING ]
    | [ MenuItemEvents.UNHOVERED ]
    | [ MenuItemEvents.CLICKED, number, number ]
-   | [ MenuItemEvents.MOUSE_MOVE, number, number ];
+   | [ MenuItemEvents.MOUSE_MOVE, number, number ]
+   | [ MenuItemEvents.CLICKED_OFF];
 
 interface MenuItem {
    id: number;
@@ -46,6 +48,9 @@ interface WidgetManager {
    // and accepts a CanvasRenderingContext2D, an id, a parent WidgetManager, and a set of properties of any type
    // the idea is that you give the manager a widget and it constructs it internally.
    addChild: <T extends Widget, U, O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U) => T>(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U) => T;
+
+   openPopup: (ctx: CanvasRenderingContext2D, widget: Widget) => void;
+   closePopup: (ctx: CanvasRenderingContext2D, widget: Widget) => void;
 }
 interface Widget {
    readonly parent: WidgetManager; 
@@ -91,7 +96,7 @@ class DefaultMap<K, V> extends Map<K, V> {
    }
 }
 
-class NewButton implements Widget, WidgetEvents {
+class Button implements Widget, WidgetEvents {
    readonly parent: WidgetManager; 
    readonly id: number;
    readonly handledEvents: MenuItemEvents[] = [
@@ -231,14 +236,15 @@ interface MenuWidgetConstructor extends WidgetConstructor {
    yPadding?: number;
 }
 
-class NewMenu implements Widget, WidgetManager {
+class Menu implements Widget, WidgetManager {
    readonly parent: WidgetManager;
    readonly id: number;
 
    readonly handledEvents: MenuItemEvents[] = [
       MenuItemEvents.CLICKED,
       MenuItemEvents.UNHOVERED,
-      MenuItemEvents.MOUSE_MOVE
+      MenuItemEvents.MOUSE_MOVE,
+      MenuItemEvents.CLICKED_OFF
    ];
 
    private absoluteMinWidth: number;
@@ -258,6 +264,7 @@ class NewMenu implements Widget, WidgetManager {
    private children: Widget[] = [];
 
    private unhoverHandlers: (() => void)[] = [];
+   private clickedOffHandlers: (() => void)[] = [];
 
 
    //the currently hovered over/selected item 
@@ -282,6 +289,12 @@ class NewMenu implements Widget, WidgetManager {
 
       this.menuColor = props.menuColor ?? "gray";
    }
+   openPopup(ctx: CanvasRenderingContext2D, widget: Widget) {
+      this.parent.openPopup(ctx, widget);
+   }
+   closePopup(ctx: CanvasRenderingContext2D, widget: Widget) {
+      this.parent.closePopup(ctx, widget);
+   }
 
    lastWidth: number = 0;
    lastHeight: number = 0;
@@ -305,7 +318,7 @@ class NewMenu implements Widget, WidgetManager {
       this.childHeight = childHeight;
       this.childWidth = childWidth;
 
-      console.log(newWidth, newHeight, this.childWidth, this.childHeight);
+      // console.log(newWidth, newHeight, this.childWidth, this.childHeight);
 
       if (this.lastWidth != newWidth || this.lastHeight != newHeight || forceRun) {
          this.lastWidth = newWidth;
@@ -372,7 +385,7 @@ class NewMenu implements Widget, WidgetManager {
 	}
    
    private dispatchEvent(widget: Widget, event: MenuItemEventData) {
-      if (event[0] in widget.handledEvents) {
+      if (widget.handledEvents.includes(event[0])) {
          widget.handleMenuEvent(event);
       }
    }
@@ -393,6 +406,7 @@ class NewMenu implements Widget, WidgetManager {
          } else {
             //selected item is out of bounds
             this.dispatchEvent(this.selectedItem, [MenuItemEvents.UNHOVERED]);
+            this.selectedItem = undefined;
          }
       }
       //otherwise, find what object (if any) are hovered over
@@ -407,7 +421,6 @@ class NewMenu implements Widget, WidgetManager {
       }
    }
    handleMenuEvent(event: MenuItemEventData): void {
-      console.log(event, this.selectedItem);
 		switch (event[0]) {
          case MenuItemEvents.MOUSE_MOVE:
          {
@@ -438,7 +451,13 @@ class NewMenu implements Widget, WidgetManager {
             }
          }
          break;
-
+         case MenuItemEvents.CLICKED_OFF:
+         {
+            for (const handler of this.clickedOffHandlers) {
+               handler();
+            }
+         }
+         break;
       }
 	}
 
@@ -478,21 +497,17 @@ class NewMenu implements Widget, WidgetManager {
          this.unhoverHandlers.splice(index);
    }
 
-}
-
-class TmpManager implements WidgetManager {
-   addChild<
-      T extends Widget, 
-      U, 
-      O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U) => T
-   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
-      return new cons(ctx, this as WidgetManager, id, props);
+   bindClickedOffEvent(callback: () => void) {
+      this.clickedOffHandlers.push(callback);
    }
-   childUpdated(ctx: CanvasRenderingContext2D) {
-
+   unbindClickedOffEvent(callback: () => void) {
+      const index = this.clickedOffHandlers.indexOf(callback);
+      if (index >= 0) {
+         this.clickedOffHandlers.splice(index);
+      }
    }
+
 }
-const tmpManager = new TmpManager();
 
 class RootWidgetManager implements WidgetManager {
    private boundWidgets: Widget[] = [];
@@ -538,7 +553,7 @@ class RootWidgetManager implements WidgetManager {
          && wY <= y && y <= wY + wH;
    }
    private dispatchEvent(widget: Widget, event: MenuItemEventData) {
-      if (event[0] in widget.handledEvents) {
+      if (widget.handledEvents.includes(event[0])) {
          widget.handleMenuEvent(event);
       }
    }
@@ -552,7 +567,20 @@ class RootWidgetManager implements WidgetManager {
          }
       }
 
-      for (const widget of this.boundWidgets) {
+      //most recently added is on top in order of popups -> bound
+
+      const widgetList = Array.from(this.popupWidgets.keys());
+      for (let i = widgetList.length-1; i >= 0; i--) {
+         const widget = widgetList[i];
+         if (this.widgetInBounds(widget, x, y)) {
+            this.selectedWidget = widget;
+            this.dispatchEvent(widget, [MenuItemEvents.HOVERING]);
+            return;
+         }
+      }
+
+      for (let i = this.boundWidgets.length-1; i >= 0; i--) {
+         const widget = this.boundWidgets[i];
          if (this.widgetInBounds(widget, x, y)) {
             this.selectedWidget = widget;
             this.dispatchEvent(widget, [MenuItemEvents.HOVERING]);
@@ -563,7 +591,14 @@ class RootWidgetManager implements WidgetManager {
 
    handleCanvasMouseEvent(ctx: CanvasRenderingContext2D, event: CanvasEventTypes, x: number, y: number): boolean {
       this.updateSelected(x, y);
-      if (!this.selectedWidget) return false;
+      if (!this.selectedWidget) {
+         if (event == CanvasEventTypes.MOUSE_CLICK) {
+            for (const popup of this.popupWidgets) {
+               this.dispatchEvent(popup, [MenuItemEvents.CLICKED_OFF]);
+            }
+         }
+         return false;
+      }
 
       switch (event) {
          case CanvasEventTypes.MOUSE_MOVE:
@@ -571,7 +606,13 @@ class RootWidgetManager implements WidgetManager {
          break;
 
          case CanvasEventTypes.MOUSE_CLICK:
-            this.dispatchEvent(this.selectedWidget, [MenuItemEvents.CLICKED, x, y]);
+            const selected = this.selectedWidget;
+            for (const popup of this.popupWidgets) {
+               if (selected != popup)
+                  this.dispatchEvent(popup, [MenuItemEvents.CLICKED_OFF]);
+            }
+            this.dispatchEvent(selected, [MenuItemEvents.CLICKED, x, y]);
+            
          break;
       }
 
@@ -583,9 +624,171 @@ class RootWidgetManager implements WidgetManager {
    }
 
    handleCanvasAnimationFrameEvent(ctx: CanvasRenderingContext2D, event: CanvasEventTypes, delta: number) {
+      //render in reverse order of the way events are handled
+      //that way top most items are drawn last so they appear on top
+      for (const widget of this.popupWidgets)
+         widget.render(ctx);
       for (const widget of this.boundWidgets)
-         widget.render(ctx)
+         widget.render(ctx);
    }
+}
+
+interface MenuButtonwidgetConstructor extends ButtonWidgetConstructor {
+   menuOptions: MenuWidgetConstructor
+}
+class MenuButton implements Widget, WidgetManager {
+   readonly parent: WidgetManager;
+   readonly id: number;
+   readonly handledEvents: MenuItemEvents[];
+
+   readonly button: Button;
+   readonly menu: Menu;
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuButtonwidgetConstructor) {
+      this.parent = parent;
+      this.id = id;
+
+      this.button = new Button(ctx, this, 0, props);
+
+      const menuOptions = structuredClone(props.menuOptions);
+      const [, , width, _] = this.button.getDimensions();
+
+      menuOptions.minimumWidth = menuOptions.minimumWidth ?? width; 
+      this.menu = new Menu(ctx, this, 1, menuOptions);
+
+      this.button.addEvent((() => {
+         this.parent.openPopup(ctx, this.menu);
+      }).bind(this));
+      this.menu.bindClickedOffEvent((() => {
+         this.parent.closePopup(ctx, this.menu);
+      }).bind(this));
+
+      this.handledEvents = this.button.handledEvents;
+   }
+
+   getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
+      return this.button.getMinSize(ctx);
+   }
+   render(ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) {
+      this.button.render(ctx, offsetX, offsetY);
+   }
+   handleMenuEvent(event: MenuItemEventData) {
+      this.button.handleMenuEvent(event);
+   }
+   getDimensions(): [number, number, number, number] {
+      return this.button.getDimensions();
+   }
+   setDimensions(ctx: CanvasRenderingContext2D, x?: number, y?: number, width?: number, height?: number) {
+      this.button.setDimensions(ctx, x, y, width, height);
+   }
+
+   childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) {
+      this.parent.childUpdated(ctx, widget, sendToRoot);   
+   }
+   addChild<
+      T extends Widget, 
+      U, 
+      O extends new (ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: U) => T
+   >(ctx: CanvasRenderingContext2D, id: number, cons: O, props: U): T {
+      return this.menu.addChild(ctx, id, cons, props);
+   }
+   openPopup(ctx: CanvasRenderingContext2D, widget: Widget) {
+      this.parent.openPopup(ctx, widget);
+   }
+   closePopup(ctx: CanvasRenderingContext2D, widget: Widget) {
+      this.parent.closePopup(ctx, widget);
+   }
+}
+
+interface SeperatorWidgetConstructor extends WidgetConstructor {
+   seperatorText: string,
+   seperatorFont?: string,
+   seperatorColor?: string
+}
+class Seperator implements Widget {
+   readonly parent: WidgetManager;
+   readonly id: number;
+   readonly handledEvents: MenuItemEvents[] = [];
+
+   private seperatorText: string;
+   private seperatorFont: string;
+   private seperatorColor: string;
+
+   private x: number;
+   private y: number;
+   private width: number;
+   private height: number;
+
+   private text: string = "";
+   private textXOffset: number = 0;
+   private textYOffset: number = 0;
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: SeperatorWidgetConstructor) {
+      this.parent = parent;
+      this.id = id;
+      
+      this.seperatorText = props.seperatorText;
+      this.seperatorColor = props.seperatorColor ?? "black";
+      this.seperatorFont = props.seperatorFont ?? "16px Seriph";
+
+      this.x = props.x;
+      this.y = props.y;
+      this.width = props.width ?? 0;
+      this.height = props.height ?? 0;
+      
+      this.updateText(ctx);
+   }
+   private updateText(ctx: CanvasRenderingContext2D) {
+      ctx.save();
+      // console.log(this.width);
+
+      ctx.font = this.seperatorFont;
+      const metrics = ctx.measureText(this.seperatorText);
+
+      const repeats = Math.floor(this.width/metrics.width);
+      const width = repeats*metrics.width;
+      const height = metrics.actualBoundingBoxAscent;
+
+      this.text = this.seperatorText.repeat(repeats);
+
+      this.textXOffset = (this.width - width)/2.0;
+      console.log(width, this.width, this.textXOffset);
+      this.textYOffset = (this.height + height)/2.0;
+
+      ctx.restore();
+   }
+
+   getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
+      return [0, 0];
+   }
+   render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
+      ctx.save();
+
+      ctx.font = this.seperatorFont;
+      ctx.fillStyle = this.seperatorColor;
+
+      ctx.fillText(
+         this.text,
+         this.x + offsetX + this.textXOffset,
+         this.y + offsetY + this.textYOffset
+      );
+
+      ctx. restore();
+   }
+   handleMenuEvent(event: MenuItemEventData) {
+      throw new Error(`Seperator widget doesn't accept events!!`);
+   }
+   getDimensions(): [number, number, number, number] {
+      return [this.x, this.y, this.width, this.height];
+   }
+   setDimensions(ctx: CanvasRenderingContext2D, x?: number, y?: number, width?: number, height?: number) {
+      this.x = x ?? this.x;
+      this.y = y ?? this.y;
+      this.width = width ?? this.width;
+      this.height = height ?? this.height;
+      if (width != undefined || height != undefined) {
+         this.updateText(ctx);
+      }
+   }
+
 }
 interface WidgetEvents {
    addEvent: (callback: () => void) => void;
@@ -612,10 +815,10 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    menuItems: Map<number, MenuItem> = new Map();
    nextMenuItem: number = 0;
 
-   menus: Map<number, [NewButton, NewMenu]> = new Map();
+   menus: Map<number, MenuButton> = new Map();
    nextMenuID: number = 0;
 
-   openMenu: NewMenu|undefined = undefined;
+   openMenu: Menu|undefined = undefined;
 
    readonly manager: RootWidgetManager = new RootWidgetManager();
 
@@ -669,7 +872,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          height: 300,
          buttonColor: "#B0B0B0B0"
       };
-      this.manager.addChild(this.ctx, -10, NewButton, buttonOpts);
+      this.manager.addChild(this.ctx, -10, Button, buttonOpts);
    }
 
    getProp(propName: string) {
@@ -701,76 +904,17 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    handleCanvasMouseEvent(event: CanvasEventTypes, x: number, y: number) {
       const n_x = x - BORDER_SIZE;
       const n_y = y - TOP_BAR_SIZE;
-      let topBar = false;
-      let [menX, menY, menWidth, menHeight] = this.openMenu?.getDimensions() ?? [0, 0, 0, 0];
-      let mouseOnMenu = false;
 
       if (this.manager.handleCanvasMouseEvent(this.ctx, event, x, y)) {
 
-      } else if (
-         this.openMenu
-         && x >= menX && x <= menX+menWidth
-         && y >= menY && y <= menY+menHeight
-      ) {
-         // console.log(event);
-         if (event == CanvasEventTypes.MOUSE_MOVE) {
-            this.openMenu.handleMenuEvent([MenuItemEvents.MOUSE_MOVE, x, y]);
-         } else if (event == CanvasEventTypes.MOUSE_CLICK) {
-            this.openMenu.handleMenuEvent([MenuItemEvents.CLICKED, x, y]);
-         }
-         this.mouseWasOnMenu = true;
-         mouseOnMenu = true;
       } else if (
          n_x >= 0 && n_y >= 0
          && n_x <= this.appCanvasWidth
          && n_y <= this.appCanvasHeight
       ) {
          this.appCanvas.handleCanvasMouseEvent(event, n_x, n_y);
-      } else if (y <= TOP_BAR_SIZE) {
-         topBar = true;
-         this.mouseWasOnTopBar = true;
-         let widthOffset = MENU_START_X;
-
-         for (const [button, ] of this.menus.values()) {
-            const [bX, bY, bWidth, bHeight] = button.getDimensions();
-            const xInBounds = bX <= x && x <= bX + bWidth;
-            const yInBounds = bY <= y && y <= bY + bHeight;
-
-            const inBounds = xInBounds && yInBounds;
-
-            switch (event) {
-               case CanvasEventTypes.MOUSE_MOVE:
-               {
-                  if (inBounds)
-                     button.handleMenuEvent([MenuItemEvents.HOVERING])
-                  else
-                     button.handleMenuEvent([MenuItemEvents.UNHOVERED])
-               }
-               break;
-
-               case CanvasEventTypes.MOUSE_CLICK:
-               {
-                  if (inBounds) {
-                     button.handleMenuEvent([MenuItemEvents.CLICKED, n_x, n_y])
-                  }
-               }
-               break;
-            }
-               
-            
-         }
       }
 
-      if (!topBar && this.mouseWasOnTopBar) {
-         this.mouseWasOnTopBar = false;
-         for (const menu of this.menus.values()) {
-            menu[0].handleMenuEvent([MenuItemEvents.UNHOVERED]);
-         }
-      }
-      if (!mouseOnMenu && this.mouseWasOnMenu) {
-         this.mouseWasOnMenu = false;
-         this.openMenu?.handleMenuEvent([MenuItemEvents.UNHOVERED]);
-      }
       return true;
    }
    handleCanvasWheelEvent(event: CanvasEventTypes, deltaX: number, deltaY: number, deltaZ: number, deltaMode: number) {
@@ -803,9 +947,9 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       this.ctx.stroke();
       this.ctx.closePath();
 
-      for (const [button, ] of this.menus.values()) {
-         button.render(this.ctx, 0, 0);
-      }
+      // for (const [button, ] of this.menus.values()) {
+      //    button.render(this.ctx, 0, 0);
+      // }
 
       this.openMenu?.render(this.ctx);
 
@@ -822,36 +966,46 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       const id = ++this.nextMenuID;
 
       let maxX = MENU_START_X;
-      for (const [button, ] of this.menus.values()) {
+      for (const button of this.menus.values()) {
          const [x, , width, ] = button.getDimensions();
          const rX = x + width;
 
          maxX = Math.max(maxX, rX);
       }
 
-      const button: NewButton = tmpManager.addChild(this.ctx, id, NewButton, {
+
+      const menuOptions: MenuWidgetConstructor = {
+         x: maxX,
+         y: TOP_BAR_SIZE,
+         menuColor: "#B0B0B0",
+         minimumHeight: TOP_BAR_SIZE/2.0,
+      };
+
+      const button: MenuButton = this.manager.addChild(this.ctx, id, MenuButton, {
          x: maxX,
          y: 0,
          height: TOP_BAR_SIZE - 0.5,
          text: text,
          textColor: "black",
          buttonColor: "#B0B0B0",
-         selectedButtonColor: "#D0D0D0"
+         selectedButtonColor: "#D0D0D0",
+         menuOptions: menuOptions
       });
 
       const [, , width, ] = button.getDimensions();
       button.setDimensions(this.ctx, undefined, undefined, width + MENU_PADDING_X, undefined);
 
-      const menuID = ++this.nextMenuID;
-      const menuOptions: MenuWidgetConstructor = {
-         x: maxX,
-         y: TOP_BAR_SIZE,
-         menuColor: "#B0B0B0",
-         minimumWidth: width + MENU_PADDING_X,
-         minimumHeight: TOP_BAR_SIZE/2.0,
-      };
-      const menu: NewMenu = tmpManager.addChild(this.ctx, menuID, NewMenu, menuOptions);
-      this.menus.set(id, [button, menu]);
+      const seperatorOptions: SeperatorWidgetConstructor = {
+         x: 0,
+         y: 0,
+         height: 10,
+         seperatorText: "-",
+         seperatorColor: "black",
+         seperatorFont: "20px Seriph"
+      }
+      button.addChild(this.ctx, ++this.nextMenuItem, Seperator, seperatorOptions);
+
+      this.menus.set(id, button);
 
       const buttonOptions: ButtonWidgetConstructor = {
          x: 0,
@@ -861,14 +1015,14 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          buttonColor: "#B0B0B0",
          selectedButtonColor: "#D0D0D0"
       };
-      const secondButton: NewButton = menu.addChild(this.ctx, ++this.nextMenuItem, NewButton, buttonOptions);
+      const secondButton: Button = button.addChild(this.ctx, ++this.nextMenuItem, Button, buttonOptions);
       secondButton.addEvent(() => {
          console.log("pressed!!!");
       });
 
-      button.addEvent((() => {
-         this.openMenu = menu;
-      }).bind(this));
+      // button.addEvent((() => {
+      //    // this.openMenu = menu;
+      // }).bind(this));
       return id;
    }
 

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -55,6 +55,8 @@ interface Widget {
    getDimensions: () => [number, number];
    setDimensions: (ctx: CanvasRenderingContext2D, width?: number, height?: number) => void;
    delete: (ctx: CanvasRenderingContext2D) => Widget[];
+   setVisibility: (ctx: CanvasRenderingContext2D, visibility: boolean) => void;
+   isVisible: () => boolean;
 }
 
 interface WidgetConstructor {
@@ -119,6 +121,8 @@ class Button implements Widget, WidgetEvents {
    private selected: boolean = false;
    private events: Set<((ctx: CanvasRenderingContext2D) => void)> = new Set();
 
+   private visibility: boolean = true;
+
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, cons: ButtonWidgetConstructor) {
       this.parent = parent;
       this.id = id;
@@ -143,6 +147,18 @@ class Button implements Widget, WidgetEvents {
    delete(ctx: CanvasRenderingContext2D) {
       this.parent.handleDelete(ctx, this);
       return [this];
+   }
+
+   setVisibility(ctx: CanvasRenderingContext2D, visibility: boolean) {
+      if (this.visibility != visibility) {
+         this.visibility = visibility;
+         this.parent.childUpdated(ctx, this, false);
+         if (!this.visibility)
+            this.visibility = false;
+      }
+   }
+   isVisible() {
+      return this.visibility;
    }
 
    getDimensions(): [number, number] {
@@ -208,6 +224,9 @@ class Button implements Widget, WidgetEvents {
       ];
    }
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
+      if (!this.visibility)
+         return;
+
       ctx.save();
 
       const button_color = this.selected ? this.selectedButtonColor : this.buttonColor ;
@@ -239,6 +258,9 @@ class Button implements Widget, WidgetEvents {
       ctx.restore();
    }
    handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
+      if (!this.visibility)
+         return;
+
       switch (event[0]) {
          case MenuItemEvents.CLICKED:
          {
@@ -319,6 +341,8 @@ class Menu implements Widget, WidgetManager {
 
    private borderColor: string;
    private borderWidth: number;
+
+   private visibility: boolean = true;
    
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuWidgetConstructor) {
       this.parent = parent;
@@ -339,6 +363,20 @@ class Menu implements Widget, WidgetManager {
 
       this.menuColor = props.menuColor ?? "gray";
    }
+
+   setVisibility(ctx: CanvasRenderingContext2D, visibility: boolean) {
+      if (this.visibility != visibility) {
+         if (!visibility)
+            this.handleMenuEvent(ctx, [MenuItemEvents.CLICKED_OFF]);
+
+         this.visibility = visibility;
+         this.parent.childUpdated(ctx, this, false);
+      }
+   }
+   isVisible() {
+      return this.visibility;
+   }
+
    pauseDeleteHandle: boolean = false;
    handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
       if (this.pauseDeleteHandle)
@@ -401,6 +439,8 @@ class Menu implements Widget, WidgetManager {
       // let maxChildHeight = this.minChildHeight;
       let childHeight = 0;
       for (const [widget,] of this.children) {
+         if (!widget.isVisible())
+            continue;
          const [width, ] = widget.getMinSize(ctx);
          childWidth = Math.max(childWidth, width);
          // maxChildHeight = Math.max(maxChildHeight, height+this.yPadding);
@@ -430,6 +470,8 @@ class Menu implements Widget, WidgetManager {
          
          let curHeight = this.borderWidth;
          for (const widget of this.children) {
+            if (!widget[0].isVisible())
+               continue;
             const [, height] = widget[0].getDimensions();
             this.supressChildUpdates = true;
             widget[0].setDimensions(ctx, newWidth - this.borderWidth * 2, undefined);
@@ -473,6 +515,9 @@ class Menu implements Widget, WidgetManager {
    }
 
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0): void {
+      if (!this.visibility)
+         return;
+
 		ctx.save();
 
       const width = this.width ?? this.childWidth;
@@ -508,7 +553,7 @@ class Menu implements Widget, WidgetManager {
 	}
    
    private dispatchEvent(ctx: CanvasRenderingContext2D, widget: Widget, event: MenuItemEventData) {
-      if (widget.handledEvents.includes(event[0])) {
+      if (widget.handledEvents.includes(event[0]) && widget.isVisible()) {
          widget.handleMenuEvent(ctx, event);
       }
    }
@@ -524,7 +569,7 @@ class Menu implements Widget, WidgetManager {
    private updateSelectedObject(ctx: CanvasRenderingContext2D,x: number, y: number) {
       //check if hovering over selected item
       if (this.selectedItem) {
-         if (this.mouseInWidgetBounds(this.selectedItem[0], this.selectedItem[1], x, y)) {
+         if (this.mouseInWidgetBounds(this.selectedItem[0], this.selectedItem[1], x, y) && this.selectedItem[0].isVisible()) {
             return; //the selected item is in bounds
          } else {
             //selected item is out of bounds
@@ -535,7 +580,7 @@ class Menu implements Widget, WidgetManager {
       //otherwise, find what object (if any) are hovered over
       for (const child of this.children) {
          //found child it's hovering over
-         if (this.mouseInWidgetBounds(child[0], child[1], x, y)) {
+         if (this.mouseInWidgetBounds(child[0], child[1], x, y) && child[0].isVisible()) {
             this.selectedItem = child;
             this.dispatchEvent(ctx, child[0], [MenuItemEvents.HOVERING]);
             //break early
@@ -544,6 +589,8 @@ class Menu implements Widget, WidgetManager {
       }
    }
    handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData): void {
+      if (!this.visibility)
+         return;
 		switch (event[0]) {
          case MenuItemEvents.MOUSE_MOVE:
          {
@@ -688,6 +735,13 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
       this.handledEvents = this.menu.handledEvents;
    }
 
+   setVisibility(ctx: CanvasRenderingContext2D, visible: boolean) {
+      this.menu.setVisibility(ctx, visible);
+   }
+   isVisible() {
+      return this.menu.isVisible();
+   }
+
    addOption(ctx: CanvasRenderingContext2D, opt: string) {
       if (this.options.has(opt))
          throw new Error(`RadioMenu: addOption already has the ${opt} option!`);
@@ -751,7 +805,7 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
    }
 
    childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) {
-      this.parent.childUpdated(ctx, widget, sendToRoot);
+      this.parent.childUpdated(ctx, widget == this.menu ? this : widget, sendToRoot);
    }
 
    openPopup(ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) {
@@ -816,6 +870,8 @@ class MenuBar implements Widget, WidgetManager {
 
    private supressChildUpdates = false;
 
+   private visible: boolean = true;
+
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuBarWidgetConstructor) {
       this.parent = parent;
       this.id = id;
@@ -831,10 +887,26 @@ class MenuBar implements Widget, WidgetManager {
       this.xPadding = props.xPadding ?? 5;
       this.minChildWidth = props.minChildWidth ?? 10;
    }
+
+   setVisibility(ctx: CanvasRenderingContext2D, visible: boolean) {
+      if (!this.visible != visible) {
+         if (!visible)
+            this.handleMenuEvent(ctx, [MenuItemEvents.CLICKED_OFF]);
+         this.visible = visible;
+         this.parent.childUpdated(ctx, this, false);
+      }
+   }
+   isVisible() {
+      return this.visible;
+   }
+
    getMinSize(ctx: CanvasRenderingContext2D): [number, number] {
       return [this.calcWidth, this.calcHeight];
    }
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
+      if (!this.visible)
+         return;
+
       for (let i = this.children.length-1; i >= 0; i--) {
          const [widget, widgetX] = this.children[i];
          widget.render(
@@ -858,7 +930,7 @@ class MenuBar implements Widget, WidgetManager {
    }
    private updateSelected(ctx: CanvasRenderingContext2D, x: number, y: number) {
       if (this.selected) {
-         if (this.mouseInWidgetBounds(this.selected[0], this.selected[1], x, y)) {
+         if (this.mouseInWidgetBounds(this.selected[0], this.selected[1], x, y) && this.selected[0].isVisible()) {
             return;
          } else {
             this.dispatchEvent(ctx, this.selected[0], [MenuItemEvents.UNHOVERED]);
@@ -867,7 +939,7 @@ class MenuBar implements Widget, WidgetManager {
       }
 
       for (const widget of this.children) {
-         if (this.mouseInWidgetBounds(widget[0], widget[1], x, y)) {
+         if (this.mouseInWidgetBounds(widget[0], widget[1], x, y) && widget[0].isVisible()) {
             this.selected = widget;
             this.dispatchEvent(ctx, widget[0], [MenuItemEvents.HOVERING]);
             return;
@@ -875,6 +947,9 @@ class MenuBar implements Widget, WidgetManager {
       }
    }
    handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
+      if (!this.visible)
+         return;
+
       switch (event[0]) {
          case MenuItemEvents.MOUSE_MOVE:
          {
@@ -952,6 +1027,9 @@ class MenuBar implements Widget, WidgetManager {
       let minHeight = this.minimumHeight;
       let width = 0;
       for (const [widget,] of this.children) {
+         if (!widget.isVisible())
+            continue;
+
          const [widgetWidth, widgetHeight] = widget.getDimensions();
          const [widgetMinWidth, widgetMinHeight] = widget.getMinSize(ctx);
          
@@ -969,6 +1047,9 @@ class MenuBar implements Widget, WidgetManager {
       let pos = 0;
       this.supressChildUpdates = true;
       for (const widget of this.children) {
+         if (!widget[0].isVisible())
+            continue;
+
          const [widgetWidth, widgetHeight] = widget[0].getDimensions();
          const [minWidgetWidth,] = widget[0].getMinSize(ctx);
          const nWidth = Math.max(this.minChildWidth, widgetWidth, minWidgetWidth);
@@ -1108,7 +1189,7 @@ class RootWidgetManager implements WidgetManager {
    }
    private updateSelected(ctx: CanvasRenderingContext2D, x: number, y: number) {
       if (this.selectedWidget) {
-         if (this.widgetInBounds(this.selectedWidget[0], this.selectedWidget[1], this.selectedWidget[2], x, y)) {
+         if (this.widgetInBounds(this.selectedWidget[0], this.selectedWidget[1], this.selectedWidget[2], x, y) && this.selectedWidget[0].isVisible()) {
             return;
          } else {
             this.dispatchEvent(ctx, this.selectedWidget[0], [MenuItemEvents.UNHOVERED]);
@@ -1130,7 +1211,8 @@ class RootWidgetManager implements WidgetManager {
 
       for (let i = this.boundWidgets.length-1; i >= 0; i--) {
          const [widget, widgetX, widgetY] = this.boundWidgets[i];
-         if (this.widgetInBounds(widget, widgetX, widgetY, x, y)) {
+
+         if (this.widgetInBounds(widget, widgetX, widgetY, x, y) && widget.isVisible()) {
             this.selectedWidget = [widget, widgetX, widgetY];
             this.dispatchEvent(ctx, widget, [MenuItemEvents.HOVERING]);
             return;
@@ -1211,6 +1293,9 @@ class MenuButton implements Widget, WidgetManager {
    private offset: number;
 
    private menuOpened: boolean = false;
+
+   private visible: boolean = true;
+
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuButtonWidgetConstructor) {
       this.parent = parent;
       this.id = id;
@@ -1240,6 +1325,19 @@ class MenuButton implements Widget, WidgetManager {
       }).bind(this));
 
    }
+
+   setVisibility(ctx: CanvasRenderingContext2D, visible: boolean) {
+      if (this.visible != visible) {
+         if (!visible)
+            this.handleMenuEvent(ctx, [MenuItemEvents.CLICKED_OFF]);
+         this.visible = visible;
+         this.parent.childUpdated(ctx, this, false);
+      }
+   }
+   isVisible() {
+      return this.visible;
+   }
+
    private supressHandleDelete: boolean = false;
    handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
       if (this.supressHandleDelete)
@@ -1325,6 +1423,9 @@ class Seperator implements Widget {
    private text: string = "";
    private textXOffset: number = 0;
    private textYOffset: number = 0;
+
+   private visible: boolean = true;
+
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: SeperatorWidgetConstructor) {
       this.parent = parent;
       this.id = id;
@@ -1338,6 +1439,17 @@ class Seperator implements Widget {
       
       this.updateText(ctx);
    }
+
+   setVisibility(ctx: CanvasRenderingContext2D, visible: boolean) {
+      if (this.visible != visible) {
+         this.visible = visible;
+         this.parent.childUpdated(ctx, this, false);
+      }
+   }
+   isVisible() {
+      return this.visible;
+   }
+
    delete(ctx: CanvasRenderingContext2D) {
       this.parent.handleDelete(ctx, this);
       return [this];
@@ -1453,6 +1565,12 @@ class CheckBox implements Widget, WidgetManager, WidgetEvents {
          }
       })
    }
+   setVisibility(ctx: CanvasRenderingContext2D, visibility: boolean) {
+      this.button.setVisibility(ctx, visibility);
+   }
+   isVisible() {
+      return this.button.isVisible();
+   }
    addEvent(callback: (ctx: CanvasRenderingContext2D, selected: boolean) => void) {
       this.changeEventHandlers.add(callback);
    }
@@ -1535,6 +1653,20 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
 
    readonly manager: RootWidgetManager = new RootWidgetManager();
    readonly menu: MenuBar;
+
+   widgetSettings = {
+      borderColor: "#B0B0B0",
+      selectedColor: "#D0D0D0",
+      menuOptionFont: "16px Seriph",
+      widgetTextFont: "12px Seriph",
+      menuOpenOffset: 5,
+      subMenuOpenOffset: 5,
+      textColor: "black",
+      reservedPrefixLen: 10,
+      yPadding: 5,
+      menuBorderWidth: 1.0,
+      menuBorderColor: "Black",
+   };
    
 
    imports: TLibImports = {
@@ -1544,6 +1676,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       twrWindowMenuWidgetAddCallback: {},
       twrWindowMenuDeleteWidget: {},
       twrWindowMenuRadioMenuAddOption: {},
+      twrWindowMenuWidgetSetVisibility: {},
    };
 
    // every library should have this line
@@ -1792,23 +1925,15 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             //    struct twr_widget_constructor base;
             //    /// @brief defaults to "Lorem Ipsum"
             //    const char* text;
-            //    /// @brief defaults to 16px Seriph
-            //    const char* text_font;
-            //    /// @brief defaults to Black
-            //    const char* text_color;
-            //    /// @brief defaults to #B0B0B0
-            //    const char* button_color;
-            //    /// @brief defaults to #D0D0D0
-            //    const char* selected_button_color;
             // };
             let button: ButtonWidgetConstructor = {
                width: width,
                height: height,
                text: getStringOrDef(extraPtr + 0, "Lorem Ipsum"),
-               textFont: getStringOrDef(extraPtr + 4, "16px Seriph"),
-               textColor: getStringOrDef(extraPtr + 8, "black"),
-               buttonColor: getStringOrDef(extraPtr + 12, "#B0B0B0"),
-               selectedButtonColor: getStringOrDef(extraPtr + 16, "#D0D0D0")
+               textFont: this.widgetSettings.widgetTextFont,
+               textColor: this.widgetSettings.textColor,
+               buttonColor: this.widgetSettings.borderColor,
+               selectedButtonColor: this.widgetSettings.selectedColor,
             };
             const widget: Button = menu.addChild(this.ctx, id, Button, button);
             this.widgets.set(id, [WidgetType.Button, widget]);
@@ -1824,15 +1949,13 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             //    const char* seperator_text;
             //    /// @brief defaults to 16px Seriph
             //    const char* seperator_font;
-            //    /// @brief defaults to black
-            //    const char* seperator_color;
             // };
             let seperator: SeperatorWidgetConstructor = {
                width: width,
                height: height,
                seperatorText: getStringOrDef(extraPtr + 0, "-"),
-               seperatorFont: getStringOrDef(extraPtr + 4, "16px Seriph"),
-               seperatorColor: getStringOrDef(extraPtr + 8, "black")
+               seperatorFont: getStringOrDef(extraPtr + 4, this.widgetSettings.widgetTextFont),
+               seperatorColor: this.widgetSettings.textColor
             };
             const widget: Seperator = menu.addChild(this.ctx, id, Seperator, seperator);
             this.widgets.set(id, [WidgetType.Seperator, widget]);
@@ -1848,47 +1971,28 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             //    long minimum_width;
             //    /// @brief defaults to 0
             //    long minimum_height;
-            //    /// @brief defaults to 0
-            //    long y_padding;
-            //    /// @brief defaults to gray
-            //    const char* menu_color;
-            //    /**
-            //     * Color options change to when hovered over
-            //     * defaults to light gray
-            //     */
-            //    const char* hovered_background_color;
             //    /**
             //     * Symbol used to denote that the option is selected
             //     * defaults to *
             //     */
             //    const char* selected_symbol;
-            //    /**
-            //     * Amount of space before option text reserved for the select symbol
-            //     * defaults to width of (selected_symbol + "  ")
-            //     */
-            //    long reserved_prefix_length;
             //    /// @brief default to 20
             //    long option_height;
-            //    /// @brief defaults to 16px Seriph
-            //    const char* option_text_font;
-            //    /// @brief defaults to black
-            //    const char* option_text_color;
             // };
             const cons: RadioMenuWidgetConstructor = {
                width: width,
                height: height,
                minimumWidth: getLongOrDef(extraPtr + 0, 0),            
                minimumHeight: getLongOrDef(extraPtr + 4, 0),
-               yPadding: getLongOrDef(extraPtr + 8, 0),
-               menuColor: getStringOrDef(extraPtr + 12, "gray"),
-               hoveredBackgroundColor: getStringOrDef(extraPtr + 16, "lightgray"),
-               selectedSymbol: getStringOrDef(extraPtr + 20, "*"),
-               reservedPrefixLength: getLongOrDef(extraPtr + 24, undefined),
-               optionHeight: getLongOrDef(extraPtr + 28, 20),
-               optionTextFont: getStringOrDef(extraPtr + 32, "16px Seriph"),
-               optionTextColor: getStringOrDef(extraPtr + 36, "black"),
+               yPadding: this.widgetSettings.yPadding,
+               menuColor: this.widgetSettings.borderColor,
+               hoveredBackgroundColor: this.widgetSettings.selectedColor,
+               selectedSymbol: getStringOrDef(extraPtr + 8, "*"),
+               reservedPrefixLength: this.widgetSettings.reservedPrefixLen,
+               optionHeight: getLongOrDef(extraPtr + 12, 20),
+               optionTextFont: this.widgetSettings.widgetTextFont,
+               optionTextColor: this.widgetSettings.textColor,
             };
-            console.log(cons);
             const radio: RadioMenu = menu.addChild(this.ctx, id, RadioMenu, cons);
             this.widgets.set(id, [WidgetType.RadioMenu, radio]);
          }
@@ -1904,53 +2008,35 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             //     * defaults to Lorem Ipsum
             //     */
             //    const char* button_text;
-            //    /// @brief defaults to 16px Seriph
-            //    const char* button_text_font;
-            //    /// @brief defaults to "black"
-            //    const char* button_text_color;
-            //    /// @brief defaults to #B0B0B0
-            //    const char* button_color;
-            //    /// @brief defaults to #D0D0D0
-            //    const char* selected_button_color;
             
             //    /// @brief defaults to 10
             //    long minimum_menu_width;
             //    /// @brief defaults to 10
             //    long minimum_menu_height;
-            //    /// @brief defaults to #B0B0B0
-            //    const char* menu_color;
-            //    /// @brief defaults to 5
-            //    long menu_y_padding;
             //    /// @brief defaults to 10
             //    long min_child_height;
-            //    /// @brief defaults to black
-            //    const char* menu_border_color;
-            //    /// @brief defaults to 0
-            //    long menu_border_width;
-            //    ///@brief defaults to 0
-            //    long menu_open_offset;
             // };
 
             const cons: MenuButtonWidgetConstructor = {
                width: width,
                height: height,
                text: getStringOrDef(extraPtr + 0, "Lorem Ipsum"),
-               textFont: getStringOrDef(extraPtr + 4, "16px Seriph"),
-               textColor: getStringOrDef(extraPtr + 8, "black"),
-               buttonColor: getStringOrDef(extraPtr + 12, "#B0B0B0"),
-               selectedButtonColor: getStringOrDef(extraPtr + 16, "#D0D0D0"),
+               textFont: this.widgetSettings.widgetTextFont,
+               textColor: this.widgetSettings.textColor,
+               buttonColor: this.widgetSettings.borderColor,
+               selectedButtonColor: this.widgetSettings.selectedColor,
 
                menuOptions: {
-                  minimumWidth: getLongOrDef(extraPtr + 20, 10),
-                  minimumHeight: getLongOrDef(extraPtr + 24, 10),
-                  menuColor: getStringOrDef(extraPtr + 28, "#B0B0B0"),
-                  yPadding: getLongOrDef(extraPtr + 32, 5),
-                  minChildHeight: getLongOrDef(extraPtr + 36, 10),
-                  borderColor: getStringOrDef(extraPtr + 40, "black"),
-                  borderWidth: getLongOrDef(extraPtr + 44, 1.0),
+                  minimumWidth: getLongOrDef(extraPtr + 4, 10),
+                  minimumHeight: getLongOrDef(extraPtr + 8, 10),
+                  menuColor: this.widgetSettings.borderColor,
+                  yPadding: this.widgetSettings.yPadding,
+                  minChildHeight: getLongOrDef(extraPtr + 12, 10),
+                  borderColor: this.widgetSettings.menuBorderColor,
+                  borderWidth: this.widgetSettings.menuBorderWidth,
                },
 
-               offset: getLongOrDef(extraPtr + 48, 0),
+               offset: this.widgetSettings.subMenuOpenOffset,
                openToRight: true,
                suffixText: "▶",
             };
@@ -1979,32 +2065,18 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             //     * defaults to ""
             //     */
             //    const char* unchecked_symbol;
-            //    /**
-            //     * amount of space to reserve for the checked and unchecked symbol prefixes
-            //     * defaults to max(width(checked_symbol),width(unchecked_symbol)) + width(" ") * 2
-            //     */
-            //    long reserved_prefix_space;
-            //    /// @brief defaults to "16px Seriph"
-            //    const char* text_font;
-            //    /// @brief defaults to "Black"
-            //    const char* text_color;
-            //    /// @brief defaults to #B0B0B0
-            //    const char* button_color;
-            //    /// @brief defaults to #D0D0D0
-            //    const char* selected_button_color;
             // };
 
             const props: CheckBoxWidgetConstructor = {
                text: getStringOrDef(extraPtr + 0, "Lorem Ipsum"),
                checkedSymbol: getStringOrDef(extraPtr + 4, "*"),
                unCheckedSymbol: getStringOrDef(extraPtr + 8, ""),
-               reservedPrefixSpace: getLongOrDef(extraPtr + 12, undefined),
-               textFont: getStringOrDef(extraPtr + 16, "16px Seriph"),
-               textColor: getStringOrDef(extraPtr + 20, "Black"),
-               buttonColor: getStringOrDef(extraPtr + 24, "#B0B0B0"),
-               selectedButtonColor: getStringOrDef(extraPtr + 28, "#D0D0D0"),
+               reservedPrefixSpace: this.widgetSettings.reservedPrefixLen,
+               textFont: this.widgetSettings.widgetTextFont,
+               textColor: this.widgetSettings.textColor,
+               buttonColor: this.widgetSettings.borderColor,
+               selectedButtonColor: this.widgetSettings.selectedColor,
             };
-            console.log("checkbox: ", props);
             const widget: CheckBox = menu.addChild(this.ctx, id, CheckBox, props);
             this.widgets.set(id, [WidgetType.CheckBox, widget]);
          }
@@ -2082,5 +2154,12 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       radio.addOption(this.ctx, mod.getString(optionPtr));
    }
 
+
+   twrWindowMenuWidgetSetVisibility(mod: IWasmModuleAsync | IWasmModule, widgetID: number, visibility: number) {
+      if (!this.widgets.has(widgetID)) throw new Error(`twrWindowMenuWidgetSetVisibility: Error! was given an invalid widgetID (${widgetID})`);
+      const widget = this.widgets.get(widgetID)!;
+
+      widget[1].setVisibility(this.ctx, visibility > 0 ? true : false);
+   }
 
 }

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -1609,7 +1609,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    drawCanvasHeight: number;
    readonly drawCanvas: twrConsoleCanvas;
 
-   private windowEventHandlers: Map<WindowEventTypes, [IWasmModule|IWasmModuleAsync, number][]> = new Map();
+   private windowEventHandlers: Map<WindowEventTypes, [WeakRef<IWasmModule|IWasmModuleAsync>, number][]> = new Map();
    widgets: Map<
       number, 
       [WidgetType.Button, Button]
@@ -1725,8 +1725,17 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       const handlers = this.windowEventHandlers.get(eventType);
       if (handlers == undefined) return;
 
-      for (const [mod, eventID] of handlers) {
-         mod.postEvent(eventID, ...extraArgs);
+      // for (const [mod, eventID] of handlers) {
+      //    mod.postEvent(eventID, ...extraArgs);
+      // }
+      for (let i = handlers.length-1; i >= 0; i--) {
+         const [mod, eventID] = handlers[i];
+         const derefedMod = mod.deref();
+         if (derefedMod) {
+            derefedMod.postEvent(eventID, ...extraArgs);
+         } else {
+            handlers.splice(i, 1);
+         }
       }
    }
 
@@ -1741,11 +1750,11 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       }
 
       for (let i = 0; i < eventHandlers.length; i++) {
-         if (eventHandlers[i][0] == callingMod && eventHandlers[i][1] == eventID)
+         if (eventHandlers[i][0].deref() == callingMod && eventHandlers[i][1] == eventID)
             throw new Error(`twrRegisterEvent: eventID ${eventID} is already registered for module ${callingMod.id}!`);
       }
 
-      eventHandlers.push([callingMod, eventID]);
+      eventHandlers.push([new WeakRef(callingMod), eventID]);
    }
    twrUnregisterEvent(callingMod: IWasmModuleAsync | IWasmModule, eventType: number, eventID: number) {
       if (WindowEventTypes[eventType] == undefined) throw new Error(`twrUnregisterEvent: Invalid event type ${eventType} for twrConsoleWindow!`);
@@ -1755,8 +1764,8 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       if (eventHandlers == undefined || eventHandlers.length == 0)
          throw new Error(`twrUnregisterEvent: There are no events registered for event type ${WindowEventTypes[eventType]}!`);
 
-      for (let i = 0; i < eventHandlers.length; i++) {
-         if (eventHandlers[i][0] == callingMod && eventHandlers[i][1] == eventID) {
+      for (let i = eventHandlers.length-1; i >= 0; i--) {
+         if (eventHandlers[i][0].deref() == callingMod && eventHandlers[i][1] == eventID) {
             eventHandlers.splice(i, 1);
             return;
          }
@@ -1766,7 +1775,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    twrUnregisterAllEvents(callingMod: IWasmModuleAsync | IWasmModule) {
       for (const [, handlers] of this.windowEventHandlers) {
          for (let i = handlers.length-1; i >= 0; i--) {
-            if (handlers[i][0] == callingMod) {
+            if (handlers[i][0].deref() == callingMod) {
                handlers.splice(i, 1);
             }
          }
@@ -2031,32 +2040,50 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       if (!this.widgets.has(widgetID)) throw new Error(`twrWindowMenuButtonAddCallback: Error! was given an invalid widgetID (${widgetID})`);
       const widget = this.widgets.get(widgetID)!;
 
+      const weakMod = new WeakRef(mod);
       switch (widget[0]) {
          case WidgetType.Button:
          {
             const button: Button = widget[1];
-
-            button.addEvent(() => {
-               mod.postEvent(eventID, extraPtr)
-            });
+            const callbackFunc = () => {
+               const strongMod = weakMod.deref();
+               if (strongMod) {
+                  strongMod.postEvent(eventID, extraPtr);
+               } else {
+                  button.removeEvent(callbackFunc);
+               }
+            }
+            button.addEvent(callbackFunc);
          }
          break;
 
          case WidgetType.RadioItem:
          {
             const radioItem: RadioItem = widget[1];
-            radioItem.addEvent((ctx: CanvasRenderingContext2D, selected: boolean) => {
-               mod.postEvent(eventID, extraPtr, selected ? 1 : 0);
-            });
+            const callbackFunc = (ctx: CanvasRenderingContext2D, selected: boolean) => {
+               const strongMod = weakMod.deref();
+               if (strongMod) {
+                  strongMod.postEvent(eventID, extraPtr, selected ? 1 : 0);
+               } else {
+                  radioItem.removeEvent(callbackFunc);
+               }
+            };
+            radioItem.addEvent(callbackFunc);
          }
          break;
 
          case WidgetType.CheckBox:
          {
             const checkBox: CheckBox = widget[1];
-            checkBox.addEvent((ctx: CanvasRenderingContext2D, selected: boolean) => {
-               mod.postEvent(eventID, extraPtr, selected ? 1 : 0);
-            });
+            const callbackFunc = (ctx: CanvasRenderingContext2D, selected: boolean) => {
+               const strongMod = weakMod.deref();
+               if (strongMod) {
+                  strongMod.postEvent(eventID, extraPtr, selected ? 1 : 0);
+               } else {
+                  checkBox.removeEvent(callbackFunc);
+               }
+            };
+            checkBox.addEvent(callbackFunc);
          }
          break;
 

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -60,6 +60,8 @@ type MenuItemEventData = MenuItemHoverEvent
 interface GlobalWidgetProperties {
    borderColor: string,
    selectedColor: string,
+   disabledColor: string,
+   disabledTextColor: string,
    widgetTextFont: string,
    menuOpenOffset: number,
    subMenuOpenOffset: number,
@@ -76,6 +78,22 @@ interface GlobalWidgetProperties {
    radioMenuCheckedPrefix: string;
    radioMenuUncheckedPrefix?: string;
 };
+enum PropBaseType {
+   String,
+   Boolean,
+   Number,
+   Undefined,
+   Combination
+};
+type PropType = [PropBaseType.String]
+   | [PropBaseType.Boolean]
+   | [PropBaseType.Number]
+   | [PropBaseType.Combination, ...PropBaseType[]];
+enum PropPerms {
+   ReadOnly,
+   SetOnly,
+   ReadAndSet,
+}
 interface WidgetManager {
    getCtx: () => CanvasRenderingContext2D;
    childUpdated: (ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) => void;
@@ -91,8 +109,10 @@ interface Widget {
    readonly parent: WidgetManager; 
    readonly id: number;
    readonly handledEvents: MenuItemEvents[];
-   set visible(val: boolean);
-   get visible(): boolean;
+   // readonly publicProperties: { [propName: string]: [PropPerms, PropType] };
+   get publicProperties(): { [propName: string]: [PropPerms, PropType] };
+   set isVisible(val: boolean);
+   get isVisible(): boolean;
 
    set width(val: number|undefined);
    get width(): number|undefined;
@@ -102,6 +122,9 @@ interface Widget {
    get usedHeight(): number;
    get minWidth(): number;
    get minHeight(): number;
+
+   set isDisabled(val: boolean);
+   get isDisabled(): boolean;
 
    render: (ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) => void;
    handleMenuEvent: (ctx: CanvasRenderingContext2D, event: MenuItemEventData) => void;
@@ -123,16 +146,30 @@ function cloneJSONObject<T>(to_copy: T): T {
    }
 }
 
+type PublicPropertiesType = { [propName: string]: [PropPerms, PropType]; };
 let NEXT_WIDGET_ID: number = 0;
 abstract class WidgetImpl implements Widget {
    readonly globalProps: GlobalWidgetProperties;
    readonly parent: WidgetManager;
    readonly id: number;
    abstract readonly handledEvents: MenuItemEvents[];
+   get publicProperties(): PublicPropertiesType {
+      return {
+         "width": [PropPerms.ReadAndSet, [PropBaseType.Combination, PropBaseType.Number, PropBaseType.Boolean]],
+         "height": [PropPerms.ReadAndSet, [PropBaseType.Combination, PropBaseType.Number, PropBaseType.Boolean]],
+         "isVisible": [PropPerms.ReadAndSet, [PropBaseType.Boolean]],
+         "isDisabled": [PropPerms.ReadAndSet, [PropBaseType.Boolean]],
+         "minWidth": [PropPerms.ReadOnly, [PropBaseType.Number]],
+         "usedWidth": [PropPerms.ReadOnly, [PropBaseType.Number]],
+         "minHeight": [PropPerms.ReadOnly, [PropBaseType.Number]],
+         "usedHeight": [PropPerms.ReadOnly, [PropBaseType.Number]]
+      }
+   }
 
    protected abstract _width?: number;
    protected abstract _height?: number;
-   protected _visible: boolean = true;
+   protected _isVisible: boolean = true;
+   protected _isDisabled: boolean = false;
 
    constructor(globalProps: GlobalWidgetProperties, parent: WidgetManager, cons: WidgetConstructor) {
       this.id = ++NEXT_WIDGET_ID;
@@ -146,13 +183,22 @@ abstract class WidgetImpl implements Widget {
    abstract fullUpdate(ctx: CanvasRenderingContext2D): void;
    protected abstract propagateUpdate(ctx?: CanvasRenderingContext2D): void;
 
-   set visible(val: boolean) {
-      if (this._visible != val) {
-         this._visible = val;
+   set isVisible(val: boolean) {
+      if (this._isVisible != val) {
+         this._isVisible = val;
          this.propagateUpdate();
       }
    }
-   get visible() {return this._visible};
+   get isVisible() {return this._isVisible};
+
+   protected abstract disableStateChange(): void;
+   set isDisabled(val: boolean) {
+      if (this._isDisabled != val) {
+         this._isDisabled = val;
+         this.disableStateChange();
+      }
+   }
+   get isDisabled() {return this._isDisabled};
 
    set width(val: number|undefined) {
       if (this._width != val) {
@@ -218,10 +264,17 @@ abstract class ButtonBase extends WidgetImpl {
 
    set text(val: string) {this._text = val; this.propagateUpdate(undefined, true)};
    get text(): string {return this._text};
-   set prefixText(val: string|undefined) {this._prefixText = val; this.propagateUpdate(undefined, true)};
-   get prefixText(): string|undefined {return this._prefixText};
-   set suffixText(val: string|undefined) {this._suffixText = val; this.propagateUpdate(undefined, true)};
-   get suffixText(): string|undefined {return this._suffixText};
+   protected set prefixText(val: string|undefined) {this._prefixText = val; this.propagateUpdate(undefined, true)};
+   protected get prefixText(): string|undefined {return this._prefixText};
+   protected set suffixText(val: string|undefined) {this._suffixText = val; this.propagateUpdate(undefined, true)};
+   protected get suffixText(): string|undefined {return this._suffixText};
+
+   get publicProperties(): PublicPropertiesType {
+      return {
+         ...super.publicProperties,
+         "text": [PropPerms.ReadAndSet, [PropBaseType.String]]
+      }
+   };
 
 
 
@@ -349,19 +402,27 @@ abstract class ButtonBase extends WidgetImpl {
    }
 
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
-      if (!this._visible)
+      if (!this._isVisible)
          return;
 
       ctx.save();
 
       const textOffsets = this.calculatedFields.textOffsets;
 
-      const button_color = this.mousedOver ? this.globalProps.selectedColor : this.globalProps.borderColor;
+      const button_color = this._isDisabled 
+         ? this.globalProps.disabledColor
+         : (this.mousedOver 
+            ? this.globalProps.selectedColor 
+            : this.globalProps.borderColor);
+      
       ctx.fillStyle = button_color;
       ctx.fillRect(offsetX, offsetY, this.usedWidth, this.usedHeight);
 
       ctx.font = this.getFont();
-      ctx.fillStyle = this.globalProps.textColor;
+      ctx.fillStyle = this._isDisabled 
+         ? this.globalProps.disabledTextColor
+         : this.globalProps.textColor;
+         
       if (this._prefixText != undefined) {
          ctx.fillText(
             this._prefixText,
@@ -385,7 +446,7 @@ abstract class ButtonBase extends WidgetImpl {
       ctx.restore();
    }
    handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
-      if (!this._visible)
+      if (!this._isVisible || this._isDisabled)
          return;
 
       switch (event.type) {
@@ -411,12 +472,28 @@ abstract class ButtonBase extends WidgetImpl {
             throw new Error(`Button handleMenuEvent was given an unrecognized event ${MenuItemEvents[event.type] ?? event.type}!`);
       }
    }
+   protected disableStateChange(): void {
+      this.mousedOver = false;
+   }
 
    abstract buttonPressed(ctx: CanvasRenderingContext2D): void;
 }
 
 class Button extends ButtonBase implements WidgetEvents {
    private events: Set<((ctx: CanvasRenderingContext2D) => void)> = new Set();
+
+   get suffixText(): string|undefined {return super.suffixText};
+   set suffixText(val: string|undefined) {super.suffixText = val};
+   get prefixText(): string|undefined {return super.prefixText};
+   set prefixText(val: string|undefined) {super.prefixText = val};
+
+   get publicProperties(): PublicPropertiesType {
+      return {
+         ...super.publicProperties,
+         "suffixText": [PropPerms.ReadAndSet, [PropBaseType.Combination, PropBaseType.String, PropBaseType.Undefined]],
+         "prefixText": [PropPerms.ReadAndSet, [PropBaseType.Combination, PropBaseType.String, PropBaseType.Undefined]],
+      }
+   } 
 
    buttonPressed(ctx: CanvasRenderingContext2D): void {
       for (const callback of this.events.keys()) {
@@ -501,7 +578,7 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
 
    protected propagateUpdate(ctx?: CanvasRenderingContext2D, click_off: boolean = false): void {
       const n_ctx = ctx ?? this.parent.getCtx();
-      if (!this._visible) return;
+      if (!this._isVisible) return;
       if (click_off)
          this.handleMenuEvent(n_ctx, {type: MenuItemEvents.CLICKED_OFF});
       else 
@@ -590,7 +667,7 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
       return this._calculatedDimensions.y;
    }
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0): void {
-      if (!this._visible)
+      if (!this._isVisible)
          return;
 
 		ctx.save();
@@ -629,7 +706,7 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
 	}
    
    private dispatchEvent(ctx: CanvasRenderingContext2D, widget: Widget, event: MenuItemEventData) {
-      if (widget.handledEvents.includes(event.type) && widget.visible) {
+      if (widget.handledEvents.includes(event.type) && widget.isVisible) {
          widget.handleMenuEvent(ctx, event);
       }
    }
@@ -645,7 +722,7 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
    private updateSelectedObject(ctx: CanvasRenderingContext2D,x: number, y: number) {
       //check if hovering over selected item
       if (this.selectedItem) {
-         if (this.mouseInWidgetBounds(this.selectedItem, x, y) && this.selectedItem.widget.visible) {
+         if (this.mouseInWidgetBounds(this.selectedItem, x, y) && this.selectedItem.widget.isVisible) {
             return; //the selected item is in bounds
          } else {
             //selected item is out of bounds
@@ -656,7 +733,7 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
       //otherwise, find what object (if any) are hovered over
       for (const child of this.children) {
          //found child it's hovering over
-         if (this.mouseInWidgetBounds(child, x, y) && child.widget.visible) {
+         if (this.mouseInWidgetBounds(child, x, y) && child.widget.isVisible) {
             this.selectedItem = child;
             this.dispatchEvent(ctx, child.widget, {type:MenuItemEvents.HOVERING});
             //break early
@@ -665,7 +742,7 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
       }
    }
    handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData): void {
-      if (!this._visible)
+      if (!this._isVisible)
          return;
 		switch (event.type) {
          case MenuItemEvents.MOUSE_MOVE:
@@ -737,6 +814,14 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
       }
    }
 
+   protected disableStateChange(): void {
+      //TODO@ figure out what to do here?
+      //should menus be capable of being disabled?
+      // in fact, since RadioMenu was converted to linked Radio Items
+      // is there any point in menus being considered Widgets at all?
+      // you can link them to widgets just fine with things like MenuButtons
+   }
+
 }
 
 interface MenuWidgetConstructor extends WidgetConstructor {
@@ -776,7 +861,7 @@ class Menu extends WidgetContainer {
       let childWidth = 0;
       let childHeight = 0;
       for (const {widget} of this.children) {
-         if (!widget.visible)
+         if (!widget.isVisible)
             continue;
          const width = widget.minWidth;
          childWidth = Math.max(childWidth, width);
@@ -803,7 +888,7 @@ class Menu extends WidgetContainer {
          let curHeight = this.globalProps.menuBorderWidth;
          this.supressChildUpdates = true;
          for (const child of this.children) {
-            if (!child.widget.visible)
+            if (!child.widget.isVisible)
                continue;
             child.widget.width = newWidth - this.globalProps.menuBorderWidth * 4;
             child.y = curHeight;
@@ -830,7 +915,7 @@ class MenuBar extends WidgetContainer {
       let minHeight = this.globalProps.emptyMenuWidth;
       let width = 0;
       for (const {widget} of this.children) {
-         if (!widget.visible)
+         if (!widget.isVisible)
             continue;
 
          const [widgetWidth, widgetHeight] = [widget.usedWidth, widget.usedHeight];
@@ -851,7 +936,7 @@ class MenuBar extends WidgetContainer {
       let pos = 0;
       this.supressChildUpdates = true;
       for (const child of this.children) {
-         if (!child.widget.visible)
+         if (!child.widget.isVisible)
             continue;
 
          const widgetWidth = child.widget.usedWidth;
@@ -965,7 +1050,7 @@ class RootWidgetManager implements WidgetManager {
    }
    private updateSelected(ctx: CanvasRenderingContext2D, x: number, y: number) {
       if (this.selectedWidget) {
-         if (this.widgetInBounds(this.selectedWidget[0], this.selectedWidget[1], this.selectedWidget[2], x, y) && this.selectedWidget[0].visible) {
+         if (this.widgetInBounds(this.selectedWidget[0], this.selectedWidget[1], this.selectedWidget[2], x, y) && this.selectedWidget[0].isVisible) {
             return;
          } else {
             this.dispatchEvent(ctx, this.selectedWidget[0], {type: MenuItemEvents.UNHOVERED});
@@ -988,7 +1073,7 @@ class RootWidgetManager implements WidgetManager {
       for (let i = this.boundWidgets.length-1; i >= 0; i--) {
          const [widget, widgetX, widgetY] = this.boundWidgets[i];
 
-         if (this.widgetInBounds(widget, widgetX, widgetY, x, y) && widget.visible) {
+         if (this.widgetInBounds(widget, widgetX, widgetY, x, y) && widget.isVisible) {
             this.selectedWidget = [widget, widgetX, widgetY];
             this.dispatchEvent(ctx, widget, {type: MenuItemEvents.HOVERING});
             return;
@@ -1129,12 +1214,15 @@ class MenuButton extends ButtonBase implements WidgetManager {
       this.supressHandleDelete = false;
       return deleted;
    }
+   private closeSubMenu(ctx: CanvasRenderingContext2D) {
+      if (this.menuOpened) {
+         this.menu.handleMenuEvent(ctx, {type: MenuItemEvents.CLICKED_OFF});
+         this.parent.closePopup(ctx, this.menu);
+      }
+   }
    handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
       if (event.type == MenuItemEvents.CLICKED_OFF) {
-         if (this.menuOpened) {
-            this.menu.handleMenuEvent(ctx, {type: MenuItemEvents.CLICKED_OFF});
-            this.parent.closePopup(ctx, this.menu);
-         }
+         this.closeSubMenu(ctx);
       } else {
          super.handleMenuEvent(ctx, event);
       }
@@ -1154,6 +1242,9 @@ class MenuButton extends ButtonBase implements WidgetManager {
    }
    closePopup(ctx: CanvasRenderingContext2D, widget: Widget) {
       this.parent.closePopup(ctx, widget);
+   }
+   protected disableStateChange(): void {
+      this.closeSubMenu(this.parent.getCtx());
    }
 }
 
@@ -1176,6 +1267,13 @@ class Seperator extends WidgetImpl {
 
    set text(val: string) {this._text = val; this.fullUpdate(this.parent.getCtx())};
    get text(): string {return this._text};
+
+   get publicProperties(): PublicPropertiesType {
+      return {
+         ...super.publicProperties,
+         "text": [PropPerms.ReadAndSet, [PropBaseType.String]]
+      }
+   }
 
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, props: SeperatorWidgetConstructor, globalProps: GlobalWidgetProperties) {
       super(globalProps, parent, {});
@@ -1229,7 +1327,7 @@ class Seperator extends WidgetImpl {
    }
 
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0) {
-      if (!this._visible)
+      if (!this._isVisible)
          return;
 
       ctx.save();
@@ -1250,6 +1348,9 @@ class Seperator extends WidgetImpl {
    }
    protected propagateUpdate(ctx?: CanvasRenderingContext2D): void {
       this.updateText(ctx ?? this.parent.getCtx());
+   }
+   protected disableStateChange(): void {
+      //Do nothing, seperator can't really be disabled...
    }
 }
 
@@ -1429,6 +1530,8 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    widgetSettings: GlobalWidgetProperties = {
       borderColor: "#B0B0B0",
       selectedColor: "#D0D0D0",
+      disabledColor: "#808080",
+      disabledTextColor: "#D0D0D0",
       widgetTextFont: "12px Seriph",
       menuOpenOffset: 5,
       subMenuOpenOffset: 1,
@@ -1840,11 +1943,11 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       if (!this.widgets.has(widgetID)) throw new Error(`twrWindowMenuWidgetSetVisibility: Error! was given an invalid widgetID (${widgetID})`);
       const widget = this.widgets.get(widgetID)!;
 
-      widget[1].visible = visibility > 0 ? true : false;
+      widget[1].isVisible = visibility > 0 ? true : false;
    }
 
-   setStringProperty() {
-      
+   twrWindowMenuWidgetSetProp(mod: IWasmModuleAsync | IWasmModule, widgetID: number, dataPtr: number) {
+
    }
 
 }

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -164,7 +164,10 @@ enum PropPerms {
    SetOnly = 2,    //0b10
    ReadAndSet = 3, //0b11 -- Just addition of above two flags
 }
-interface WidgetManager {
+interface ManagerAndWidgetCombined {
+   fullUpdate: (ctx: CanvasRenderingContext2D) => void;
+}
+interface WidgetManager extends ManagerAndWidgetCombined {
    getCtx: () => CanvasRenderingContext2D;
    childUpdated: (ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) => void;
 
@@ -174,52 +177,51 @@ interface WidgetManager {
 
    resendLastMove: () => void;
 }
-interface Widget {
+type PublicPropertiesType = { [propName: string]: [[undefined|(() => string|number|undefined|boolean), undefined|((val: any) => void)], PropType]; };
+
+interface Widget extends ManagerAndWidgetCombined {
    readonly globalProps: GlobalWidgetProperties;
    readonly parent: WidgetManager; 
    readonly id: number;
    readonly handledEvents: MenuItemEvents[];
    // readonly publicProperties: { [propName: string]: [PropPerms, PropType] };
-   get publicProperties(): { [propName: string]: [PropPerms, PropType] };
-   set isVisible(val: boolean);
-   get isVisible(): boolean;
+   getPublicProperties: () => PublicPropertiesType;
+   setIsVisible: (val: boolean) => void;
+   getIsVisible: () => boolean;
 
-   set width(val: number|undefined);
-   get width(): number|undefined;
-   set height(val: number|undefined);
-   get height(): number|undefined;
-   get usedWidth(): number;
-   get usedHeight(): number;
-   get minWidth(): number;
-   get minHeight(): number;
+   setWidth: (val: number|undefined) => void;
+   getWidth: () => number|undefined;
+   setHeight: (val: number|undefined) => void;
+   getHeight: () => number|undefined;
+   getUsedWidth: () => number;
+   getUsedHeight: () => number;
+   getMinWidth: () => number;
+   getMinHeight: () => number;
 
-   set isDisabled(val: boolean);
-   get isDisabled(): boolean;
+   setIsDisabled: (val: boolean) => void;
+   getIsDisabled: () => boolean;
 
    render: (ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) => void;
    handleMenuEvent: (ctx: CanvasRenderingContext2D, event: MenuItemEventData) => void;
    delete: (ctx: CanvasRenderingContext2D) => Widget[];
-
-   fullUpdate: (ctx: CanvasRenderingContext2D) => void;
 }
 
-type PublicPropertiesType = { [propName: string]: [PropPerms, PropType]; };
 let NEXT_WIDGET_ID: number = 0;
 abstract class WidgetImpl implements Widget {
    readonly globalProps: GlobalWidgetProperties;
    readonly parent: WidgetManager;
    readonly id: number;
    abstract readonly handledEvents: MenuItemEvents[];
-   get publicProperties(): PublicPropertiesType {
+   getPublicProperties(): PublicPropertiesType {
       return {
-         "width": [PropPerms.ReadAndSet, [PropBaseType.Combination, PropBaseType.Number, PropBaseType.Undefined]],
-         "height": [PropPerms.ReadAndSet, [PropBaseType.Combination, PropBaseType.Number, PropBaseType.Undefined]],
-         "isVisible": [PropPerms.ReadAndSet, [PropBaseType.Boolean]],
-         "isDisabled": [PropPerms.ReadAndSet, [PropBaseType.Boolean]],
-         "minWidth": [PropPerms.ReadOnly, [PropBaseType.Number]],
-         "usedWidth": [PropPerms.ReadOnly, [PropBaseType.Number]],
-         "minHeight": [PropPerms.ReadOnly, [PropBaseType.Number]],
-         "usedHeight": [PropPerms.ReadOnly, [PropBaseType.Number]]
+         "width": [[this.getWidth.bind(this), this.setWidth.bind(this)], [PropBaseType.Combination, PropBaseType.Number, PropBaseType.Undefined]],
+         "height": [[this.getHeight.bind(this), this.setHeight.bind(this)], [PropBaseType.Combination, PropBaseType.Number, PropBaseType.Undefined]],
+         "isVisible": [[this.getIsVisible.bind(this), this.setIsVisible.bind(this)], [PropBaseType.Boolean]],
+         "isDisabled": [[this.getIsDisabled.bind(this), this.setIsDisabled.bind(this)], [PropBaseType.Boolean]],
+         "minWidth": [[this.getMinWidth.bind(this), undefined], [PropBaseType.Number]],
+         "usedWidth": [[this.getUsedWidth.bind(this), undefined], [PropBaseType.Number]],
+         "minHeight": [[this.getMinHeight.bind(this), undefined], [PropBaseType.Number]],
+         "usedHeight": [[this.getUsedHeight.bind(this), undefined], [PropBaseType.Number]]
       }
    }
 
@@ -240,45 +242,45 @@ abstract class WidgetImpl implements Widget {
    abstract fullUpdate(ctx: CanvasRenderingContext2D): void;
    protected abstract propagateUpdate(ctx?: CanvasRenderingContext2D): void;
 
-   set isVisible(val: boolean) {
+   setIsVisible(val: boolean) {
       if (this._isVisible != val) {
          this._isVisible = val;
          this.propagateUpdate();
       }
    }
-   get isVisible() {return this._isVisible};
+   getIsVisible() {return this._isVisible};
 
    protected abstract disableStateChange(): void;
-   set isDisabled(val: boolean) {
+   setIsDisabled(val: boolean) {
       if (this._isDisabled != val) {
          this._isDisabled = val;
          this.disableStateChange();
       }
    }
-   get isDisabled() {return this._isDisabled};
+   getIsDisabled() {return this._isDisabled};
 
-   set width(val: number|undefined) {
+   setWidth(val: number|undefined) {
       if (this._width != val) {
          this._width = val;
          this.propagateUpdate();
       }
    }
-   get width() {return this._width};
-   abstract get minWidth(): number;
-   get usedWidth(): number {
-      return this._width ?? this.minWidth;
+   getWidth() {return this._width};
+   abstract getMinWidth(): number;
+   getUsedWidth(): number {
+      return this._width ?? this.getMinWidth();
    }
 
-   set height(val: number|undefined) {
+   setHeight(val: number|undefined) {
       if (this._height != val) {
          this._height = val;
          this.propagateUpdate();
       }
    }
-   get height() {return this._height};
-   abstract get minHeight(): number;
-   get usedHeight(): number {
-      return this._height ?? this.minHeight;
+   getHeight() {return this._height};
+   abstract getMinHeight(): number;
+   getUsedHeight(): number {
+      return this._height ?? this.getMinHeight();
    }
 }
 
@@ -319,17 +321,17 @@ abstract class ButtonBase extends WidgetImpl {
    private centeredHorizontally: boolean;
    private reservePrefixSpace: boolean;
 
-   set text(val: string) {this._text = val; this.propagateUpdate(undefined, true)};
-   get text(): string {return this._text};
-   protected set prefixText(val: string|undefined) {this._prefixText = val; this.propagateUpdate(undefined, true)};
-   protected get prefixText(): string|undefined {return this._prefixText};
-   protected set suffixText(val: string|undefined) {this._suffixText = val; this.propagateUpdate(undefined, true)};
-   protected get suffixText(): string|undefined {return this._suffixText};
+   setText(val: string) {this._text = val; this.propagateUpdate(undefined, true)};
+   getText(): string {return this._text};
+   protected setPrefixText(val: string|undefined) {this._prefixText = val; this.propagateUpdate(undefined, true)};
+   protected getPrefixText(): string|undefined {return this._prefixText};
+   protected setSuffixText(val: string|undefined) {this._suffixText = val; this.propagateUpdate(undefined, true)};
+   protected getSuffixText(): string|undefined {return this._suffixText};
 
-   get publicProperties(): PublicPropertiesType {
+   getPublicProperties(): PublicPropertiesType {
       return {
-         ...super.publicProperties,
-         "text": [PropPerms.ReadAndSet, [PropBaseType.String]]
+         ...super.getPublicProperties(),
+         "text": [[this.getText.bind(this), this.setText.bind(this)], [PropBaseType.String]]
       }
    };
 
@@ -392,10 +394,10 @@ abstract class ButtonBase extends WidgetImpl {
       }
 
       textOffsets.mainTextX = this.centeredHorizontally 
-         ? (this.usedWidth - (minWidth - minPrefix - minSuffix))/2.0 
+         ? (this.getUsedWidth() - (minWidth - minPrefix - minSuffix))/2.0 
          : minPrefix;
       
-      textOffsets.y = (this.usedHeight + getHeight(ctx, this.getFont()))/2.0;
+      textOffsets.y = (this.getUsedHeight() + getHeight(ctx, this.getFont()))/2.0;
       textOffsets.suffixX = minSuffix;
    }
 
@@ -448,11 +450,11 @@ abstract class ButtonBase extends WidgetImpl {
       return [minWidth, minHeight, minPrefix, minSuffix];
    }
 
-   get minWidth() {
+   getMinWidth() {
       return this.calculatedFields.width;
    }
 
-   get minHeight() {
+   getMinHeight() {
       return this.calculatedFields.height;
    }
 
@@ -471,7 +473,7 @@ abstract class ButtonBase extends WidgetImpl {
             : this.globalProps.borderColor);
       
       ctx.fillStyle = button_color;
-      ctx.fillRect(offsetX, offsetY, this.usedWidth, this.usedHeight);
+      ctx.fillRect(offsetX, offsetY, this.getUsedWidth(), this.getUsedHeight());
 
       ctx.font = this.getFont();
       ctx.fillStyle = this._isDisabled 
@@ -493,7 +495,7 @@ abstract class ButtonBase extends WidgetImpl {
       if (this._suffixText != undefined) {
          ctx.fillText(
             " " + this._suffixText,
-            offsetX + (this.usedWidth - textOffsets.suffixX),
+            offsetX + (this.getUsedWidth() - textOffsets.suffixX),
             textOffsets.y + offsetY
          );
       }
@@ -537,16 +539,16 @@ abstract class ButtonBase extends WidgetImpl {
 class Button extends ButtonBase implements WidgetEvents {
    private events: Set<((ctx: CanvasRenderingContext2D) => void)> = new Set();
 
-   get suffixText(): string|undefined {return super.suffixText};
-   set suffixText(val: string|undefined) {super.suffixText = val};
-   get prefixText(): string|undefined {return super.prefixText};
-   set prefixText(val: string|undefined) {super.prefixText = val};
+   getSuffixText(): string|undefined {return super.getSuffixText()};
+   setSuffixText(val: string|undefined) {super.setSuffixText(val)};
+   getPrefixText(): string|undefined {return super.getPrefixText()};
+   setPrefixText(val: string|undefined) {super.setPrefixText(val)};
 
-   get publicProperties(): PublicPropertiesType {
+   getPublicProperties(): PublicPropertiesType {
       return {
-         ...super.publicProperties,
-         "suffixText": [PropPerms.ReadAndSet, [PropBaseType.Combination, PropBaseType.String, PropBaseType.Undefined]],
-         "prefixText": [PropPerms.ReadAndSet, [PropBaseType.Combination, PropBaseType.String, PropBaseType.Undefined]],
+         ...super.getPublicProperties(),
+         "suffixText": [[this.getSuffixText.bind(this), this.setSuffixText.bind(this)], [PropBaseType.Combination, PropBaseType.String, PropBaseType.Undefined]],
+         "prefixText": [[this.getPrefixText.bind(this), this.setPrefixText.bind(this)], [PropBaseType.Combination, PropBaseType.String, PropBaseType.Undefined]],
       }
    } 
 
@@ -591,8 +593,8 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
    private clickedOffHandlers: (() => void)[] = [];
 
    protected _calculatedDimensions: Vec2;
-   protected get calculatedDimensions() {return this._calculatedDimensions};
-   protected set calculatedDimensions(val: Vec2) {
+   protected getCalculatedDimensions() {return this._calculatedDimensions};
+   protected setCalculatedDimensions(val: Vec2) {
       this._calculatedDimensions = val;
       if (this._width == undefined || this._height == undefined) {
          this.parent.childUpdated(this.parent.getCtx());
@@ -602,7 +604,7 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
    private selectedItem?: ContainedWidget;
 
    private _drawOutline: boolean;
-   get drawOutline() {return this._drawOutline};
+   getDrawOutline() {return this._drawOutline};
    
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, props: MenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
       super(globalProps, parent, {});
@@ -640,11 +642,11 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
          this.handleMenuEvent(n_ctx, {type: MenuItemEvents.UNHOVERED});
 
       const prev_dims = {
-         x: this.usedWidth,
-         y: this.usedHeight,
+         x: this.getUsedWidth(),
+         y: this.getUsedHeight(),
       };
       this.updateChildSize();
-      if (prev_dims.x != this.usedWidth || prev_dims.y != this.usedHeight) {
+      if (prev_dims.x != this.getUsedWidth() || prev_dims.y != this.getUsedHeight()) {
          this.parent.childUpdated(this.parent.getCtx());
       }
 
@@ -715,10 +717,10 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
       return widget;
    }
 
-   get minWidth() {
+   getMinWidth() {
       return this._calculatedDimensions.x;
    }
-   get minHeight() {
+   getMinHeight() {
       return this._calculatedDimensions.y;
    }
    render(ctx: CanvasRenderingContext2D, offsetX: number = 0, offsetY: number = 0): void {
@@ -761,15 +763,15 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
 	}
    
    private dispatchEvent(ctx: CanvasRenderingContext2D, widget: Widget, event: MenuItemEventData) {
-      if (widget.handledEvents.includes(event.type) && widget.isVisible) {
+      if (widget.handledEvents.includes(event.type) && widget.getIsVisible()) {
          widget.handleMenuEvent(ctx, event);
       }
    }
 
    private mouseInWidgetBounds(widgetContainer: ContainedWidget, x: number, y: number) {
       const {widget, x: widgetX, y: widgetY} = widgetContainer;
-      return widgetX <= x && x <= widgetX + widget.usedWidth
-            && widgetY <= y && y <= widgetY + widget.usedHeight;
+      return widgetX <= x && x <= widgetX + widget.getUsedWidth()
+            && widgetY <= y && y <= widgetY + widget.getUsedHeight();
    }
 
    //updates the currently selected object using the given coords
@@ -777,7 +779,7 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
    private updateSelectedObject(ctx: CanvasRenderingContext2D,x: number, y: number) {
       //check if hovering over selected item
       if (this.selectedItem) {
-         if (this.mouseInWidgetBounds(this.selectedItem, x, y) && this.selectedItem.widget.isVisible) {
+         if (this.mouseInWidgetBounds(this.selectedItem, x, y) && this.selectedItem.widget.getIsVisible()) {
             return; //the selected item is in bounds
          } else {
             //selected item is out of bounds
@@ -788,7 +790,7 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
       //otherwise, find what object (if any) are hovered over
       for (const child of this.children) {
          //found child it's hovering over
-         if (this.mouseInWidgetBounds(child, x, y) && child.widget.isVisible) {
+         if (this.mouseInWidgetBounds(child, x, y) && child.widget.getIsVisible()) {
             this.selectedItem = child;
             this.dispatchEvent(ctx, child.widget, {type:MenuItemEvents.HOVERING});
             //break early
@@ -916,11 +918,11 @@ class Menu extends WidgetContainer {
       let childWidth = 0;
       let childHeight = 0;
       for (const {widget} of this.children) {
-         if (!widget.isVisible)
+         if (!widget.getIsVisible())
             continue;
-         const width = widget.minWidth;
+         const width = widget.getMinWidth();
          childWidth = Math.max(childWidth, width);
-         childHeight += widget.usedHeight + this.globalProps.yPadding;
+         childHeight += widget.getUsedHeight() + this.globalProps.yPadding;
       }
       childWidth += this.globalProps.menuBorderWidth * 4;
       childHeight += this.globalProps.menuBorderWidth * 2;
@@ -929,8 +931,8 @@ class Menu extends WidgetContainer {
       childWidth = Math.max(childWidth, this.globalProps.emptyMenuWidth);
       childHeight = Math.max(childHeight, this.globalProps.emptyMenuHeight);
 
-      const newWidth = super.width ?? childWidth;
-      const newHeight = super.height ?? childHeight;
+      const newWidth = super.getWidth() ?? childWidth;
+      const newHeight = super.getHeight() ?? childHeight;
       this._calculatedDimensions = {
          x: newWidth,
          y: newHeight
@@ -943,11 +945,11 @@ class Menu extends WidgetContainer {
          let curHeight = this.globalProps.menuBorderWidth;
          this.supressChildUpdates = true;
          for (const child of this.children) {
-            if (!child.widget.isVisible)
+            if (!child.widget.getIsVisible())
                continue;
-            child.widget.width = newWidth - this.globalProps.menuBorderWidth * 4;
+            child.widget.setWidth(newWidth - this.globalProps.menuBorderWidth * 4);
             child.y = curHeight;
-            curHeight += child.widget.usedHeight + this.globalProps.yPadding;
+            curHeight += child.widget.getUsedHeight() + this.globalProps.yPadding;
          }
          this.supressChildUpdates = false;
 
@@ -970,11 +972,11 @@ class MenuBar extends WidgetContainer {
       let minHeight = this.globalProps.emptyMenuWidth;
       let width = 0;
       for (const {widget} of this.children) {
-         if (!widget.isVisible)
+         if (!widget.getIsVisible())
             continue;
 
-         const [widgetWidth, widgetHeight] = [widget.usedWidth, widget.usedHeight];
-         const [widgetMinWidth, widgetMinHeight] = [widget.minWidth, widget.minHeight];
+         const [widgetWidth, widgetHeight] = [widget.getUsedWidth(), widget.getUsedHeight()];
+         const [widgetMinWidth, widgetMinHeight] = [widget.getMinWidth(), widget.getMinHeight()];
          
          minHeight = Math.max(minHeight, widgetHeight, widgetMinHeight);
          width += Math.max(this.globalProps.emptyMenuWidth, widgetWidth, widgetMinWidth) + this.globalProps.xPadding;
@@ -985,20 +987,20 @@ class MenuBar extends WidgetContainer {
          y: minHeight
       };
 
-      const tmpHeight = super.height ?? minHeight;
-      const tmpWidth = super.width ?? width;
+      const tmpHeight = super.getHeight() ?? minHeight;
+      const tmpWidth = super.getWidth() ?? width;
       
       let pos = 0;
       this.supressChildUpdates = true;
       for (const child of this.children) {
-         if (!child.widget.isVisible)
+         if (!child.widget.getIsVisible())
             continue;
 
-         const widgetWidth = child.widget.usedWidth;
-         const minWidgetWidth = child.widget.minWidth;
+         const widgetWidth = child.widget.getUsedWidth();
+         const minWidgetWidth = child.widget.getMinWidth();
          const nWidth = Math.max(this.globalProps.emptyMenuWidth, widgetWidth, minWidgetWidth);
-         child.widget.width = nWidth;
-         child.widget.height = tmpHeight;
+         child.widget.setWidth(nWidth);
+         child.widget.setHeight(tmpHeight);
 
          child.x = pos;
          pos += nWidth + this.globalProps.xPadding;
@@ -1011,7 +1013,7 @@ class MenuBar extends WidgetContainer {
    >(ctx: CanvasRenderingContext2D, cons: WidgetCreation<T, U>, props: U): T {
       return super.addChild(
          ctx, cons, props,
-         0, super.drawOutline ? this.globalProps.menuBorderWidth/2 : 0
+         0, super.getDrawOutline() ? this.globalProps.menuBorderWidth/2 : 0
       );
    }
 
@@ -1050,6 +1052,14 @@ class RootWidgetManager implements WidgetManager {
             this.childUpdated(ctx);
             return;
          }
+      }
+   }
+   fullUpdate(ctx?: CanvasRenderingContext2D) {
+      for (let i = 0; i < this.boundWidgets.length; i++) {
+         this.boundWidgets[i][0].fullUpdate(this.ctx);
+      }
+      for (const [widget, ] of this.popupWidgets) {
+         widget.fullUpdate(this.ctx);
       }
    }
 
@@ -1094,7 +1104,7 @@ class RootWidgetManager implements WidgetManager {
    }
 
    private widgetInBounds(widget: Widget, widgetX: number, widgetY: number, x: number, y: number): boolean {
-      const [wW, wH] = [widget.usedWidth, widget.usedHeight];
+      const [wW, wH] = [widget.getUsedWidth(), widget.getUsedHeight()];
       return widgetX <= x && x <= widgetX + wW
          && widgetY <= y && y <= widgetY + wH;
    }
@@ -1105,7 +1115,7 @@ class RootWidgetManager implements WidgetManager {
    }
    private updateSelected(ctx: CanvasRenderingContext2D, x: number, y: number) {
       if (this.selectedWidget) {
-         if (this.widgetInBounds(this.selectedWidget[0], this.selectedWidget[1], this.selectedWidget[2], x, y) && this.selectedWidget[0].isVisible) {
+         if (this.widgetInBounds(this.selectedWidget[0], this.selectedWidget[1], this.selectedWidget[2], x, y) && this.selectedWidget[0].getIsVisible()) {
             return;
          } else {
             this.dispatchEvent(ctx, this.selectedWidget[0], {type: MenuItemEvents.UNHOVERED});
@@ -1128,7 +1138,7 @@ class RootWidgetManager implements WidgetManager {
       for (let i = this.boundWidgets.length-1; i >= 0; i--) {
          const [widget, widgetX, widgetY] = this.boundWidgets[i];
 
-         if (this.widgetInBounds(widget, widgetX, widgetY, x, y) && widget.isVisible) {
+         if (this.widgetInBounds(widget, widgetX, widgetY, x, y) && widget.getIsVisible()) {
             this.selectedWidget = [widget, widgetX, widgetY];
             this.dispatchEvent(ctx, widget, {type: MenuItemEvents.HOVERING});
             return;
@@ -1236,7 +1246,7 @@ class MenuButton extends ButtonBase implements WidgetManager {
       this.parent.resendLastMove();
    }
    buttonPressed(ctx: CanvasRenderingContext2D): void {
-      const [width, height] = [super.usedWidth, super.usedHeight];
+      const [width, height] = [super.getUsedWidth(), super.getUsedHeight()];
       let x = this.openToRight ? width + this.offset : 0;
       let y = this.openToRight ? 0 : height + this.offset;
       this.parent.openPopup(ctx, this.menu, x, y, this);
@@ -1320,13 +1330,13 @@ class Seperator extends WidgetImpl {
    private textXOffset: number = 0;
    private textYOffset: number = 0;
 
-   set text(val: string) {this._text = val; this.fullUpdate(this.parent.getCtx())};
-   get text(): string {return this._text};
+   setText(val: string) {this._text = val; this.fullUpdate(this.parent.getCtx())};
+   getText(): string {return this._text};
 
-   get publicProperties(): PublicPropertiesType {
+   getPublicProperties(): PublicPropertiesType {
       return {
-         ...super.publicProperties,
-         "text": [PropPerms.ReadAndSet, [PropBaseType.String]]
+         ...super.getPublicProperties(),
+         "text": [[this.getText.bind(this), this.setText.bind(this)], [PropBaseType.String]]
       }
    }
 
@@ -1354,26 +1364,26 @@ class Seperator extends WidgetImpl {
       ctx.font = this.globalProps.widgetTextFont;
       const metrics = ctx.measureText(this.seperatorText);
 
-      const repeats = Math.floor(this.usedWidth/metrics.width);
+      const repeats = Math.floor(this.getUsedWidth()/metrics.width);
       const width = repeats*metrics.width;
       const height = metrics.actualBoundingBoxAscent;
       this._minHeight = height;
 
       this._text = this.seperatorText.repeat(repeats);
 
-      this.textXOffset = (this.usedWidth - width)/2.0;
-      this.textYOffset = (this.usedHeight + height)/2.0;
+      this.textXOffset = (this.getUsedWidth() - width)/2.0;
+      this.textYOffset = (this.getUsedHeight() + height)/2.0;
       
 
       ctx.restore();
    }
 
 
-   get minWidth() {
+   getMinWidth() {
       return 0;
    }
 
-   get minHeight() {
+   getMinHeight() {
       if (this._width == 0) {
          return 0;
       } else {
@@ -1422,7 +1432,7 @@ class CheckBox extends ButtonBase implements WidgetEvents {
       if (val == this._selected) return;
       this._selected = val;
       //prefixText uses builtin getter/setter to auto update properties
-      super.prefixText = this.globalProps[this._selected ? "checkBoxCheckedPrefix" : "checkBoxUncheckedPrefix"];
+      super.setPrefixText(this.globalProps[this._selected ? "checkBoxCheckedPrefix" : "checkBoxUncheckedPrefix"]);
       
       if (!supressEventPassdown) {
          const n_ctx = ctx ?? this.parent.getCtx();
@@ -1435,7 +1445,7 @@ class CheckBox extends ButtonBase implements WidgetEvents {
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, cons: ButtonWidgetConstructor, globalProps: GlobalWidgetProperties) {
       super(ctx, parent, cons, globalProps);
 
-      super.prefixText = globalProps.checkBoxUncheckedPrefix;
+      super.setPrefixText(globalProps.checkBoxUncheckedPrefix);
    }
 
    buttonPressed(ctx: CanvasRenderingContext2D): void {
@@ -1495,7 +1505,7 @@ class RadioItem extends ButtonBase implements WidgetEvents {
 
       this.radioGroup = new RadioItemGroup(this, this.deselect.bind(this), this.setRadioGroup.bind(this));
 
-      super.prefixText = globalProps.radioMenuCheckedPrefix;
+      super.setPrefixText(globalProps.radioMenuCheckedPrefix);
    }
 
    buttonPressed(ctx: CanvasRenderingContext2D): void {
@@ -1506,7 +1516,7 @@ class RadioItem extends ButtonBase implements WidgetEvents {
 
    private deselect(ctx: CanvasRenderingContext2D) {
       this._selected = false;
-      this.prefixText = this.globalProps.radioMenuUncheckedPrefix;
+      this.setPrefixText(this.globalProps.radioMenuUncheckedPrefix);
       for (const callback of this.callbacks) {
          callback(ctx, false);
       }
@@ -1518,7 +1528,7 @@ class RadioItem extends ButtonBase implements WidgetEvents {
    makeSelected(sendEvent: boolean = true, ctx?: CanvasRenderingContext2D) {
       const n_ctx = ctx ?? this.parent.getCtx();
       this.radioGroup.optionSeleted(this, this.parent.getCtx());
-      this.prefixText = this.globalProps.radioMenuCheckedPrefix;
+      this.setPrefixText(this.globalProps.radioMenuCheckedPrefix);
       this._selected = true;
       if (sendEvent) {
          for (const callback of this.callbacks) {
@@ -1874,8 +1884,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             //    long minimum_menu_width;
             //    /// @brief defaults to 10
             //    long minimum_menu_height;
-            //    /// @brief defaults to 10
-            //    long min_child_height;
             // };
 
             const cons: MenuButtonWidgetConstructor = {
@@ -1990,10 +1998,10 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    }
 
 
-   private checkValiditity(propField: [PropPerms, PropType], propName: string, typ: PropBaseType, widget: [WidgetType, Widget]) {
-      if (propField[1][0] == typ)
+   private checkValiditity(propType: PropType, propName: string, typ: PropBaseType, widget: [WidgetType, Widget]) {
+      if (propType[0] == typ)
          return;
-      else if (propField[1][0] == PropBaseType.Combination && propField[1].includes(typ)) {
+      else if (propType[0] == PropBaseType.Combination && propType.includes(typ)) {
          return;
       } else {
          throw new Error(`twrWindowMenuWidgetSetProp: Property "${propName}" does not accept type ${PropBaseType[typ] ?? typ} in widget ${widget[1].id} of type ${WidgetType[widget[0]] ?? widget[0]}`);
@@ -2015,9 +2023,10 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       if (widget == undefined) throw new Error(`twrWindowMenuWidgetSetProp: Error! was given an invalid widgetID (${widgetID})`);
       
       const propName = mod.getString(propNamePtr);
-      const propField = widget[1].publicProperties[propName];
+      const propField = widget[1].getPublicProperties()[propName];
       if (propField == undefined) throw new Error(`twrWindowMenuWidgetSetProp: Couldn't find prop name "${propName}" in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
-      if (propField[0] == PropPerms.ReadOnly) throw new Error(`twrWindowMenuWidgetSetProp: Property "${propName}" is read only in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
+      const propSetter = propField[0][1];
+      if (propSetter == undefined) throw new Error(`twrWindowMenuWidgetSetProp: Property "${propName}" is read only in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
       
       const typ = mod.getLong(typPtr) as PropBaseType;
       
@@ -2025,7 +2034,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       switch (typ) {
          case PropBaseType.String: 
          {
-            this.checkValiditity(propField, propName, typ, widget);
+            this.checkValiditity(propField[1], propName, typ, widget);
 
             let str;
             const strPtr = mod.getLong(valPtr);
@@ -2036,28 +2045,32 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
                str = mod.getString(strPtr);
             }
 
-            (widget[1] as any)[propName] = str;
+            // (widget[1] as any)[propName] = str;
+            propSetter(str);
          }
          break;
          case PropBaseType.Boolean:
          {
-            this.checkValiditity(propField, propName, typ, widget);
+            this.checkValiditity(propField[1], propName, typ, widget);
 
             let val = mod.getLong(valPtr) != 0;
-            (widget[1] as any)[propName] = val;
+            // (widget[1] as any)[propName] = val;
+            propSetter(val);
          }
          break;
          case PropBaseType.Number:
          {
-            this.checkValiditity(propField, propName, typ, widget);
+            this.checkValiditity(propField[1], propName, typ, widget);
 
-            (widget[1] as any)[propName] = mod.getDouble(valPtr);
+            // (widget[1] as any)[propName] = mod.getDouble(valPtr);
+            propSetter(mod.getDouble(valPtr));
          }
          break;
          case PropBaseType.Undefined:
          {
-            this.checkValiditity(propField, propName, typ, widget);
-            (widget[1] as any)[propName] = undefined;
+            this.checkValiditity(propField[1], propName, typ, widget);
+            // (widget[1] as any)[propName] = undefined;
+            propSetter(undefined);
          }
          break;
          default: 
@@ -2077,11 +2090,13 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       if (widget == undefined) throw new Error(`twrWindowMenuWidgetGetProp: Error! was given an invalid widgetID (${widgetID})`);
       
       const propName = mod.getString(propNamePtr);
-      const propField = widget[1].publicProperties[propName];
+      const propField = widget[1].getPublicProperties()[propName];
       if (propField == undefined) throw new Error(`twrWindowMenuWidgetGetProp: Couldn't find prop name "${propName}" in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
-      if (propField[0] == PropPerms.SetOnly) throw new Error(`twrWindowMenuWidgetGetProp: Property "${propName}" is set only in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
+      const propGetter = propField[0][0];
+      if (propGetter == undefined) throw new Error(`twrWindowMenuWidgetGetProp: Property "${propName}" is set only in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
 
-      const val = (widget[1] as any)[propName];
+      // const val = (widget[1] as any)[propName];
+      const val = propGetter();
       let propType: [PropBaseType.String, Uint8Array]
          | [PropBaseType.Number, number]
          | [PropBaseType.Boolean, boolean]
@@ -2167,7 +2182,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       if (widget == undefined) throw new Error(`twrWindowMenuWidgetGetPropDetails: Error! was given an invalid widgetID (${widgetID})`);
 
       const propName = mod.wasmMem.getString(namePtr);
-      const propField = widget[1].publicProperties[propName];
+      const propField = widget[1].getPublicProperties()[propName];
       if (propField == undefined) throw new Error(`twrWindowMenuWidgetGetPropDetails: Couldn't find prop name "${propName}" in widget ${widgetID} of type ${WidgetType[widget[0]] ?? widget[0]}`);
 
       let typ = 0;
@@ -2180,7 +2195,21 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       }
       mod.wasmMem.setLong(typePtr, typ);
 
-      mod.wasmMem.setLong(accessPtr, propField[0]);
+      // mod.wasmMem.setLong(accessPtr, propField[0]);
+      const canGet = propField[0][0] != undefined;
+      const canSet = propField[0][1] != undefined;
+      let perm: PropPerms;
+      if (canGet && canSet) {
+         perm = PropPerms.ReadAndSet;
+      } else if (canGet) {
+         perm = PropPerms.ReadOnly;
+      } else if (canSet) {
+         perm = PropPerms.SetOnly;
+      } else {
+         throw new Error(`shouldn't be valid?`);
+      }
+      mod.wasmMem.setLong(accessPtr, perm);
+
    }
 
    private twrWindowMenuWidgetListPropsHelper(mod: IWasmModuleAsync | IWasmModule, widgetID: number, lengthPtr: number) {
@@ -2199,12 +2228,24 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       
       const props: [Uint8Array<ArrayBufferLike>, PropPerms, PropType][] = [];
       let totalSize = 0;
-      for (const name in widget[1].publicProperties) {
+      for (const name in widget[1].getPublicProperties()) {
          const ru8=mod.wasmMem.stringToU8(name);
          totalSize += baseStructSize + ru8.length + 1;
 
-         const [propPerms, propType] = widget[1].publicProperties[name];
-         props.push([ru8, propPerms, propType]);
+         const [propFuncs, propType] = widget[1].getPublicProperties()[name];
+         const canGet = propFuncs[0] != undefined;
+         const canSet = propFuncs[1] != undefined;
+         let perm: PropPerms;
+         if (canGet && canSet) {
+            perm = PropPerms.ReadAndSet;
+         } else if (canGet) {
+            perm = PropPerms.ReadOnly;
+         } else if (canSet) {
+            perm = PropPerms.SetOnly;
+         } else {
+            throw new Error(`shouldn't be valid?`);
+         }
+         props.push([ru8, perm, propType]);
       }
       mod.wasmMem.setLong(lengthPtr, props.length);
 
@@ -2300,7 +2341,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             mod.wasmMem.setLong(structBase + typeOffset, propTyp);
 
             mod.wasmMem.mem8u.set(propName, nameStringOffset);
-            mod.wasmMem.mem8u[nameStringOffset + propName.length + 1] = 0; //null character
+            mod.wasmMem.mem8u[nameStringOffset + propName.length] = 0; //null character
             nameStringOffset += propName.length + 1;
          }
 
@@ -2374,6 +2415,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
          default:
             throw new Error(`twrWindowMenuSetProp was given an invalid type (${PropBaseType[typ] ?? typ})!`);
       }
+      this.manager.fullUpdate();
    }
 
    twrWindowMenuGetPropHelper(mod: IWasmModule | IWasmModuleAsync, propNamePtr: number) {
@@ -2423,7 +2465,7 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
             case PropBaseType.String:
                mod.wasmMem.setLong(retPtr + valOffset, baseStructSize + retPtr);
                mod.wasmMem.mem8u.set(retVal[1], retPtr + baseStructSize); //load string at end of struct alloc
-               mod.wasmMem.mem8u[retVal[1].length + retPtr + baseStructSize + 1] = 0; //insert null character
+               mod.wasmMem.mem8u[retVal[1].length + retPtr + baseStructSize] = 0; //insert null character
             break;
             case PropBaseType.Boolean:
                mod.wasmMem.setLong(retPtr + valOffset, retVal[1] ? 1 : 0);

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -48,11 +48,6 @@ type MenuItemMouseMoveEvent = {
 type MenuItemClickedOffEvent = {
    type: MenuItemEvents.CLICKED_OFF
 };
-// type MenuItemEventData = [ MenuItemEvents.HOVERING ]
-//    | [ MenuItemEvents.UNHOVERED ]
-//    | [ MenuItemEvents.CLICKED, number, number, number]
-//    | [ MenuItemEvents.MOUSE_MOVE, number, number]
-//    | [ MenuItemEvents.CLICKED_OFF];
 type MenuItemEventData = MenuItemHoverEvent
    | MenuItemUnhoverEvent
    | MenuItemClickedEvent
@@ -65,7 +60,6 @@ type MenuItemEventData = MenuItemHoverEvent
 interface GlobalWidgetProperties {
    borderColor: string,
    selectedColor: string,
-   // menuOptionFont: string,
    widgetTextFont: string,
    menuOpenOffset: number,
    subMenuOpenOffset: number,
@@ -89,6 +83,8 @@ interface WidgetManager {
    openPopup: (ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) => void;
    closePopup: (ctx: CanvasRenderingContext2D, widget: Widget) => void;
    handleDelete: (ctx: CanvasRenderingContext2D, widget: Widget) => void;
+
+   resendLastMove: () => void;
 }
 interface Widget {
    readonly globalProps: GlobalWidgetProperties;
@@ -203,8 +199,8 @@ interface ButtonWidgetConstructor extends WidgetConstructor {
 
    reservePrefixSpace?: boolean;
 }
- 
-class Button extends WidgetImpl implements WidgetEvents {
+
+abstract class ButtonBase extends WidgetImpl {
    readonly handledEvents: MenuItemEvents[] = [
       MenuItemEvents.CLICKED,
       MenuItemEvents.HOVERING,
@@ -220,17 +216,16 @@ class Button extends WidgetImpl implements WidgetEvents {
    private centeredHorizontally: boolean;
    private reservePrefixSpace: boolean;
 
-   set text(val: string) {this._text = val; this.propagateUpdate()};
+   set text(val: string) {this._text = val; this.propagateUpdate(undefined, true)};
    get text(): string {return this._text};
-   set prefixText(val: string|undefined) {this._prefixText = val; this.propagateUpdate()};
+   set prefixText(val: string|undefined) {this._prefixText = val; this.propagateUpdate(undefined, true)};
    get prefixText(): string|undefined {return this._prefixText};
-   set suffixText(val: string|undefined) {this._suffixText = val; this.propagateUpdate()};
+   set suffixText(val: string|undefined) {this._suffixText = val; this.propagateUpdate(undefined, true)};
    get suffixText(): string|undefined {return this._suffixText};
 
 
 
    private mousedOver: boolean = false;
-   private events: Set<((ctx: CanvasRenderingContext2D) => void)> = new Set();
 
    private calculatedFields = {
       width: 0,
@@ -258,11 +253,16 @@ class Button extends WidgetImpl implements WidgetEvents {
       this.updateCalculatedFields(ctx);
    }
 
-   protected propagateUpdate(ctx?: CanvasRenderingContext2D): void {
+   protected propagateUpdate(ctx?: CanvasRenderingContext2D, text_based: boolean = false): void {
       const n_ctx = ctx ?? this.parent.getCtx();
 
+      const prev = {
+         x: this.calculatedFields.width,
+         y: this.calculatedFields.height
+      };
       this.updateCalculatedFields(n_ctx);
-      this.parent.childUpdated(n_ctx);
+      if (!text_based || prev.x != this.calculatedFields.width || prev.y != this.calculatedFields.height)
+         this.parent.childUpdated(n_ctx);
    }
 
    private updateCalculatedFields(ctx: CanvasRenderingContext2D) {
@@ -289,7 +289,6 @@ class Button extends WidgetImpl implements WidgetEvents {
       
       textOffsets.y = (this.usedHeight + getHeight(ctx, this.getFont()))/2.0;
       textOffsets.suffixX = minSuffix;
-      // console.log(`test: ${textOffsets.mainTextX}, ${textOffsets.y}, ${textOffsets.suffixX}, ${minPrefix}, ${minWidth}, ${minSuffix}, ${this.width}, ${this.height}, ${getHeight(ctx, this.getFont())}, ${minSuffix}`);
    }
 
    fullUpdate(ctx: CanvasRenderingContext2D) {
@@ -328,7 +327,7 @@ class Button extends WidgetImpl implements WidgetEvents {
             minHeight = Math.max(minHeight, measure.actualBoundingBoxAscent + measure.actualBoundingBoxDescent);
             partWidths[i] = width; 
          } else {
-            minWidth += minPartWidth;
+            minWidth += minPartWidth + ((i != parts.length-1) ? spaceWidth : 0 );
             partWidths[i] = minPartWidth;
          }
       }
@@ -337,7 +336,6 @@ class Button extends WidgetImpl implements WidgetEvents {
 
       const [minPrefix, minSuffix, ] = partWidths;
 
-      // console.log(`getFullMinSize: ${minWidth}, ${minHeight}, ${minPrefix}, ${minSuffix}`);
 
       return [minWidth, minHeight, minPrefix, minSuffix];
    }
@@ -393,9 +391,7 @@ class Button extends WidgetImpl implements WidgetEvents {
       switch (event.type) {
          case MenuItemEvents.CLICKED:
          {
-            for (const callback of this.events.keys()) {
-               callback(ctx);
-            }
+            this.buttonPressed(ctx);
          }
          break;
 
@@ -416,10 +412,22 @@ class Button extends WidgetImpl implements WidgetEvents {
       }
    }
 
+   abstract buttonPressed(ctx: CanvasRenderingContext2D): void;
+}
+
+class Button extends ButtonBase implements WidgetEvents {
+   private events: Set<((ctx: CanvasRenderingContext2D) => void)> = new Set();
+
+   buttonPressed(ctx: CanvasRenderingContext2D): void {
+      for (const callback of this.events.keys()) {
+         callback(ctx);
+      }
+   }
+
    addEvent(callback: (ctx: CanvasRenderingContext2D) => void) {
       this.events.add(callback);
    }
-   removeEvent(callback: () => void) {
+   removeEvent(callback: (ctx: CanvasRenderingContext2D) => void) {
       return this.events.delete(callback);
    }
 }
@@ -450,7 +458,7 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
    private unhoverHandlers: (() => void)[] = [];
    private clickedOffHandlers: (() => void)[] = [];
 
-   private _calculatedDimensions: Vec2;
+   protected _calculatedDimensions: Vec2;
    protected get calculatedDimensions() {return this._calculatedDimensions};
    protected set calculatedDimensions(val: Vec2) {
       this._calculatedDimensions = val;
@@ -476,6 +484,9 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
 
       this._drawOutline = props.drawOutline ?? false;
    }
+   resendLastMove() {
+      this.parent.resendLastMove();
+   }
    getCtx() {
       return this.parent.getCtx();
    }
@@ -485,17 +496,28 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
       }
       this.updateChildSize();
       this.selectedItem = undefined;
+      this.parent.resendLastMove();
    }
 
-   protected propagateUpdate(ctx?: CanvasRenderingContext2D): void {
-      // this.supressChildUpdates = true;
+   protected propagateUpdate(ctx?: CanvasRenderingContext2D, click_off: boolean = false): void {
       const n_ctx = ctx ?? this.parent.getCtx();
-      this.handleMenuEvent(n_ctx, {type: MenuItemEvents.CLICKED_OFF});
+      if (!this._visible) return;
+      if (click_off)
+         this.handleMenuEvent(n_ctx, {type: MenuItemEvents.CLICKED_OFF});
+      else 
+         this.handleMenuEvent(n_ctx, {type: MenuItemEvents.UNHOVERED});
 
-      if (this._visible) {
-         this.updateChildSize();
+      const prev_dims = {
+         x: this.usedWidth,
+         y: this.usedHeight,
+      };
+      this.updateChildSize();
+      if (prev_dims.x != this.usedWidth || prev_dims.y != this.usedHeight) {
+         this.parent.childUpdated(this.parent.getCtx());
       }
-      // this.supressChildUpdates = false;
+
+      this.parent.resendLastMove();
+      
    }
 
    pauseDeleteHandle: boolean = false;
@@ -541,9 +563,7 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
       if (sendToRoot) {
          this.parent.childUpdated(ctx, widget, true);
       } else if (!this.supressChildUpdates) {
-         this.updateChildSize();
-         this.selectedItem = undefined;
-         this.parent.childUpdated(ctx, this, false);
+         this.propagateUpdate(ctx);
       }
    }
    protected addChild<
@@ -616,7 +636,6 @@ abstract class WidgetContainer extends WidgetImpl implements WidgetManager {
 
    private mouseInWidgetBounds(widgetContainer: ContainedWidget, x: number, y: number) {
       const {widget, x: widgetX, y: widgetY} = widgetContainer;
-      // const [widgetWidth, widgetHeight] = widget.getDimensions();
       return widgetX <= x && x <= widgetX + widget.usedWidth
             && widgetY <= y && y <= widgetY + widget.usedHeight;
    }
@@ -772,25 +791,25 @@ class Menu extends WidgetContainer {
 
       const newWidth = super.width ?? childWidth;
       const newHeight = super.height ?? childHeight;
-      super.calculatedDimensions = {
+      this._calculatedDimensions = {
          x: newWidth,
          y: newHeight
       };
-
+      
       if (this.lastWidth != newWidth || this.lastHeight != newHeight || forceRun) {
          this.lastWidth = newWidth;
          this.lastHeight = newHeight;
          
          let curHeight = this.globalProps.menuBorderWidth;
+         this.supressChildUpdates = true;
          for (const child of this.children) {
             if (!child.widget.visible)
                continue;
-            this.supressChildUpdates = true;
             child.widget.width = newWidth - this.globalProps.menuBorderWidth * 4;
             child.y = curHeight;
-            this.supressChildUpdates = false;
             curHeight += child.widget.usedHeight + this.globalProps.yPadding;
          }
+         this.supressChildUpdates = false;
 
       }
    }
@@ -821,7 +840,7 @@ class MenuBar extends WidgetContainer {
          width += Math.max(this.globalProps.emptyMenuWidth, widgetWidth, widgetMinWidth) + this.globalProps.xPadding;
       }
 
-      super.calculatedDimensions = {
+      this._calculatedDimensions = {
          x: width,
          y: minHeight
       };
@@ -841,7 +860,6 @@ class MenuBar extends WidgetContainer {
          child.widget.width = nWidth;
          child.widget.height = tmpHeight;
 
-         console.log(`${tmpHeight}, ${super.height}, ${child.y}`);
          child.x = pos;
          pos += nWidth + this.globalProps.xPadding;
       }
@@ -977,8 +995,16 @@ class RootWidgetManager implements WidgetManager {
          }
       }
    }
-
+   
+   private lastMouseMove: [number, number]|undefined = undefined;
+   resendLastMove() {
+      if (this.lastMouseMove != undefined) {
+         const [x, y] = this.lastMouseMove;
+         this.handleCanvasMouseEvent(this.ctx, CanvasEventTypes.MOUSE_MOVE, x, y, 0);
+      }
+   }
    handleCanvasMouseEvent(ctx: CanvasRenderingContext2D, event: CanvasEventTypes, x: number, y: number, button: number): boolean {
+      this.lastMouseMove = [x, y];
       this.updateSelected(ctx, x, y);
       if (!this.selectedWidget) {
          if (event == CanvasEventTypes.MOUSE_CLICK) {
@@ -1035,7 +1061,7 @@ interface MenuButtonWidgetConstructor extends ButtonWidgetConstructor {
    openToRight?: boolean,
    offset?: number,
 }
-class MenuButton extends Button implements WidgetManager {
+class MenuButton extends ButtonBase implements WidgetManager {
    readonly handledEvents: MenuItemEvents[] = [
       MenuItemEvents.CLICKED,
       MenuItemEvents.HOVERING,
@@ -1061,17 +1087,20 @@ class MenuButton extends Button implements WidgetManager {
          drawOutline: true,
       }, globalProps);
 
-      super.addEvent((() => {
-         const [width, height] = [super.usedWidth, super.usedHeight];
-         let x = this.openToRight ? width + this.offset : 0;
-         let y = this.openToRight ? 0 : height + this.offset;
-         this.parent.openPopup(ctx, this.menu, x, y, this);
-         this.menuOpened = true;
-      }).bind(this));
       this.menu.bindClickedOffEvent((() => {
          this.parent.closePopup(ctx, this.menu);
          this.menuOpened = false;
       }).bind(this));
+   }
+   resendLastMove() {
+      this.parent.resendLastMove();
+   }
+   buttonPressed(ctx: CanvasRenderingContext2D): void {
+      const [width, height] = [super.usedWidth, super.usedHeight];
+      let x = this.openToRight ? width + this.offset : 0;
+      let y = this.openToRight ? 0 : height + this.offset;
+      this.parent.openPopup(ctx, this.menu, x, y, this);
+      this.menuOpened = true;
    }
    getCtx() {
       return this.parent.getCtx();
@@ -1107,7 +1136,6 @@ class MenuButton extends Button implements WidgetManager {
             this.parent.closePopup(ctx, this.menu);
          }
       } else {
-         // this.button.handleMenuEvent(ctx, event);
          super.handleMenuEvent(ctx, event);
       }
    }
@@ -1229,7 +1257,7 @@ class Seperator extends WidgetImpl {
 interface CheckBoxWidgetConstructor extends WidgetConstructor {
    text: string;
 }
-class CheckBox extends Button {
+class CheckBox extends ButtonBase implements WidgetEvents {
    private callbacks: Set<(ctx: CanvasRenderingContext2D, selected: boolean) => void> = new Set();
 
    private _selected = false;
@@ -1252,10 +1280,10 @@ class CheckBox extends Button {
       super(ctx, parent, cons, globalProps);
 
       super.prefixText = globalProps.checkBoxUncheckedPrefix;
-      
-      super.addEvent((ctx) => {
-         this.setSelected(!this._selected, false, ctx);
-      });
+   }
+
+   buttonPressed(ctx: CanvasRenderingContext2D): void {
+      this.setSelected(!this._selected, false, ctx);
    }
 
 
@@ -1300,7 +1328,7 @@ class RadioItemGroup {
       }
    }
 }
-class RadioItem extends Button {
+class RadioItem extends ButtonBase implements WidgetEvents {
    private callbacks: Set<(ctx: CanvasRenderingContext2D, selected: boolean) => void> = new Set();
 
    private _selected = true;
@@ -1312,12 +1340,12 @@ class RadioItem extends Button {
       this.radioGroup = new RadioItemGroup(this, this.deselect.bind(this), this.setRadioGroup.bind(this));
 
       super.prefixText = globalProps.radioMenuCheckedPrefix;
-      
-      super.addEvent((ctx) => {
-         if (!this._selected) {
-            this.makeSelected(true, ctx);
-         }
-      });
+   }
+
+   buttonPressed(ctx: CanvasRenderingContext2D): void {
+      if (!this._selected) {
+         this.makeSelected(true, ctx);
+      }
    }
 
    private deselect(ctx: CanvasRenderingContext2D) {
@@ -1370,7 +1398,6 @@ const MENU_START_X = BORDER_SIZE;
 enum WidgetType {
    Button,
    Seperator,
-   // RadioMenu,
    RadioItem,
    SubMenu,
    CheckBox,
@@ -1391,7 +1418,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       number, 
       [WidgetType.Button, Button]
       | [WidgetType.Seperator, Seperator]
-      // | [WidgetType.RadioMenu, RadioMenu]
       | [WidgetType.RadioItem, RadioItem]
       | [WidgetType.SubMenu, MenuButton]
       | [WidgetType.CheckBox, CheckBox]
@@ -1403,7 +1429,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    widgetSettings: GlobalWidgetProperties = {
       borderColor: "#B0B0B0",
       selectedColor: "#D0D0D0",
-      // menuOptionFont: "16px Seriph",
       widgetTextFont: "12px Seriph",
       menuOpenOffset: 5,
       subMenuOpenOffset: 1,
@@ -1464,12 +1489,8 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       };
 
       const menuBarCons: MenuWidgetConstructor = {
-         // minChildWidth: 10,
-         // menuColor: "#B0B0B0",
          height: TOP_BAR_SIZE - 2,
-         // xPadding: MENU_PADDING_X,
       };
-      // console.log(`Menu Bar target size: ${menuBarCons.height}, ${TOP_BAR_SIZE - 0.5}`);
       this.menu = this.manager.addChild(this.ctx, MenuBar, menuBarCons, this.widgetSettings, BORDER_SIZE + MENU_PADDING_X, 0);
    }
 
@@ -1556,14 +1577,8 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
    twrWindowAddMenu(mod: IWasmModuleAsync | IWasmModule, textPtr: number) {
       const text = mod.getString(textPtr);
 
-      // const id = ++this.nextWidgetID;
 
       const menuOptions: MenuWidgetConstructor = {
-         // menuColor: "#B0B0B0",
-         // minimumHeight: TOP_BAR_SIZE/2.0,
-         // yPadding: 2,
-         // borderWidth: 1.0,
-         // borderColor: "black"
       };
 
       const button: MenuButton = this.menu.addChild(this.ctx, MenuButton, {
@@ -1591,13 +1606,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
 
       const menu = widgetBase[1];
 
-      // struct twr_widget_constructor {
-      //    enum WindowWidget type;
-      //    long x;
-      //    long y;
-      //    long width;
-      //    long height;
-      // };
       function getLongOrDef<T>(ptr: number, def: T): number|T {
          const ptrx32=Math.floor(ptr/4);
          if (ptrx32*4!=ptr) throw new Error("getLongOrDef passed non long aligned address")
@@ -1626,7 +1634,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
 
       const extraPtr = consPtr + 12;
 
-      // const id = ++this.nextWidgetID;
       switch (type) {
          case WidgetType.Button:
          {
@@ -1640,10 +1647,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
                width: width,
                height: height,
                text: getStringOrDef(extraPtr + 0, "Lorem Ipsum"),
-               // textFont: this.widgetSettings.widgetTextFont,
-               // textColor: this.widgetSettings.textColor,
-               // buttonColor: this.widgetSettings.borderColor,
-               // selectedButtonColor: this.widgetSettings.selectedColor,
             };
             const widget: Button = menu.addChild(this.ctx, Button, button);
             this.widgets.set(widget.id, [WidgetType.Button, widget]);
@@ -1665,8 +1668,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
                width: width,
                height: height,
                seperatorText: getStringOrDef(extraPtr + 0, "-"),
-               // seperatorFont: getStringOrDef(extraPtr + 4, this.widgetSettings.widgetTextFont),
-               // seperatorColor: this.widgetSettings.textColor
             };
             const widget: Seperator = menu.addChild(this.ctx, Seperator, seperator);
             this.widgets.set(widget.id, [WidgetType.Seperator, widget]);
@@ -1717,20 +1718,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
                width: width,
                height: height,
                text: getStringOrDef(extraPtr + 0, "Lorem Ipsum"),
-               // textFont: this.widgetSettings.widgetTextFont,
-               // textColor: this.widgetSettings.textColor,
-               // buttonColor: this.widgetSettings.borderColor,
-               // selectedButtonColor: this.widgetSettings.selectedColor,
-
-               // menuOptions: {
-                  // minimumWidth: getLongOrDef(extraPtr + 4, 10),
-                  // minimumHeight: getLongOrDef(extraPtr + 8, 10),
-                  // menuColor: this.widgetSettings.borderColor,
-                  // yPadding: this.widgetSettings.yPadding,
-                  // minChildHeight: getLongOrDef(extraPtr + 12, 10),
-                  // borderColor: this.widgetSettings.menuBorderColor,
-                  // borderWidth: this.widgetSettings.menuBorderWidth,
-               // },
                menuWidth: getLongOrDef(extraPtr + 4, undefined),
                menuHeight: getLongOrDef(extraPtr + 8, undefined),
 
@@ -1768,13 +1755,6 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
 
             const props: CheckBoxWidgetConstructor = {
                text: getStringOrDef(extraPtr + 0, "Lorem Ipsum"),
-               // checkedSymbol: getStringOrDef(extraPtr + 4, "*"),
-               // unCheckedSymbol: getStringOrDef(extraPtr + 8, ""),
-               // reservedPrefixSpace: this.widgetSettings.reservedPrefixLen,
-               // textFont: this.widgetSettings.widgetTextFont,
-               // textColor: this.widgetSettings.textColor,
-               // buttonColor: this.widgetSettings.borderColor,
-               // selectedButtonColor: this.widgetSettings.selectedColor,
             };
             const widget: CheckBox = menu.addChild(this.ctx, CheckBox, props);
             this.widgets.set(widget.id, [WidgetType.CheckBox, widget]);
@@ -1861,6 +1841,10 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       const widget = this.widgets.get(widgetID)!;
 
       widget[1].visible = visibility > 0 ? true : false;
+   }
+
+   setStringProperty() {
+      
    }
 
 }

--- a/source/twr-ts/twrconwindow.ts
+++ b/source/twr-ts/twrconwindow.ts
@@ -50,9 +50,10 @@ interface GlobalWidgetProperties {
    menuBorderColor: string,
    emptyMenuHeight: number,
    emptyMenuWidth: number,
-   radioMenuPrefix: string;
    checkBoxCheckedPrefix: string;
    checkBoxUncheckedPrefix: string;
+   radioMenuCheckedPrefix: string;
+   radioMenuUncheckedPrefix?: string;
 };
 interface WidgetManager {
    getCtx: () => CanvasRenderingContext2D;
@@ -801,7 +802,7 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
    fullUpdate(ctx: CanvasRenderingContext2D) {
       if (this.selected != undefined)
          // this.options.get(this.selected)!.setButtonPrefixText(ctx, this.globalProps.radioMenuPrefix);
-         this.options.get(this.selected)!.prefixText = this.globalProps.radioMenuPrefix;
+         this.options.get(this.selected)!.prefixText = this.globalProps.radioMenuCheckedPrefix;
       this.menu.fullUpdate(ctx);
    }
    set visible(visible: boolean) {
@@ -818,7 +819,7 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
       let prefix = undefined;
       if (this.selected == undefined) {
          this.selected = opt;
-         prefix = this.globalProps.radioMenuPrefix;
+         prefix = this.globalProps.radioMenuCheckedPrefix;
       }
 
       // console.log(`Radio menu adding button: Menu width is: ${this.menu.getDimensions()[0]}`);
@@ -849,7 +850,7 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
          }
          this.selected = opt;
          // this.options.get(this.selected)!.setButtonPrefixText(ctx, this.globalProps.radioMenuPrefix);
-         this.options.get(this.selected)!.prefixText = this.globalProps.radioMenuPrefix;
+         this.options.get(this.selected)!.prefixText = this.globalProps.radioMenuCheckedPrefix;
 
          for (const event of this.events) {
             event(ctx, this.selected);
@@ -908,7 +909,6 @@ class RadioMenu implements Widget, WidgetManager, WidgetEvents {
    }
 
 }
-
 
 class MenuBar extends WidgetContainer {
    constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: MenuWidgetConstructor, globalProps: GlobalWidgetProperties) {
@@ -1355,111 +1355,115 @@ class Seperator implements Widget {
       }
    }
 }
+
+///gets a union of all the keys of an object that are of type U
+// for instance, if I had {a: string, b: number, c: number} and filtered by number, it would return
+//    a type union of "b"|"c"
+type FilteredKeys<T, U> = {
+   [K in keyof T]: T[K] extends U ? K : never;
+ }[keyof T];
+
 interface CheckBoxWidgetConstructor extends WidgetConstructor {
    text: string;
 }
-class CheckBox implements Widget, WidgetManager, WidgetEvents {
-   readonly globalProps: GlobalWidgetProperties;
-   readonly parent: WidgetManager;
-   readonly id: number;
-   readonly handledEvents: MenuItemEvents[];
+class CheckBox extends Button {
+   private callbacks: Set<(ctx: CanvasRenderingContext2D, selected: boolean) => void> = new Set();
 
-   private button: Button;
-   private changeEventHandlers: Set<(ctx: CanvasRenderingContext2D, selected: boolean) => void> = new Set();
-   private selected = false;
+   private _selected = false;
 
-   get text(): string {return this.button.text};
-   set text(val: string) {this.button.text = val;};
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, cons: ButtonWidgetConstructor, globalProps: GlobalWidgetProperties) {
+      super(ctx, parent, id, cons, globalProps);
 
-   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, props: CheckBoxWidgetConstructor, globalProps: GlobalWidgetProperties) {
-      this.globalProps = globalProps;
-      this.parent = parent;
-      this.id = id;
+      super.prefixText = globalProps.checkBoxUncheckedPrefix;
+      
+      super.addEvent((ctx) => {
+         this._selected = !this._selected;
 
-
-      const buttonCons: ButtonWidgetConstructor = {
-         text: props.text,
-         width: props.width,
-         height: props.height,
-         prefixText: this.globalProps.checkBoxUncheckedPrefix,
-      };
-      this.button = new Button(ctx, this, 0, buttonCons, this.globalProps);
-      this.handledEvents = this.button.handledEvents;
-
-      this.button.addEvent((ctx) => {
-         this.selected = !this.selected;
-         if (this.selected) {
-            // this.button.setButtonPrefixText(ctx, this.globalProps.checkBoxCheckedPrefix);
-            this.button.prefixText = this.globalProps.checkBoxCheckedPrefix;
-         } else {
-            // this.button.setButtonPrefixText(ctx, this.globalProps.checkBoxUncheckedPrefix);
-            this.button.prefixText = this.globalProps.checkBoxUncheckedPrefix;
+         super.prefixText = globalProps[this._selected ? "checkBoxCheckedPrefix" : "checkBoxUncheckedPrefix"];
+         for (const callback of this.callbacks) {
+            callback(ctx, this._selected);
          }
-         for (const callback of this.changeEventHandlers) {
-            callback(ctx, this.selected);
-         }
-      })
+      });
    }
-   getCtx() {
-      return this.parent.getCtx();
-   }
-   fullUpdate(ctx: CanvasRenderingContext2D) {
-      this.button.fullUpdate(ctx);
-      // this.button.setButtonPrefixText(
-      //    ctx,
-      //    this.selected
-      //       ? this.globalProps.checkBoxCheckedPrefix
-      //       : this.globalProps.checkBoxUncheckedPrefix
-      // );
-      this.button.prefixText = this.selected
-         ? this.globalProps.checkBoxCheckedPrefix
-         : this.globalProps.checkBoxUncheckedPrefix;
-   }
-   set visible(visibility: boolean) {
-      this.button.visible = visibility;
-   }
-   get visible() {
-      return this.button.visible;
-   }
+
    addEvent(callback: (ctx: CanvasRenderingContext2D, selected: boolean) => void) {
-      this.changeEventHandlers.add(callback);
+      this.callbacks.add(callback);
    }
    removeEvent(callback: (ctx: CanvasRenderingContext2D, selected: boolean) => void) {
-      this.changeEventHandlers.delete(callback);
-   }
-
-   getMinSize(): [number, number] {
-      return this.button.getMinSize();
-   }
-   render(ctx: CanvasRenderingContext2D, offsetX?: number, offsetY?: number) {
-      this.button.render(ctx, offsetX, offsetY);
-   }
-   handleMenuEvent(ctx: CanvasRenderingContext2D, event: MenuItemEventData) {
-      this.button.handleMenuEvent(ctx, event);
-   }
-   getDimensions(): [number, number] {
-      return this.button.getDimensions();
-   }
-   setDimensions(width?: number, height?: number) {
-      this.button.setDimensions(width, height);
-   }
-   delete(ctx: CanvasRenderingContext2D): Widget[] {
-      this.button.delete(ctx);
-      return [this];
-   }
-   childUpdated(ctx: CanvasRenderingContext2D, widget?: Widget, sendToRoot?: boolean) {
-      this.parent.childUpdated(ctx, this, sendToRoot);
-   }
-   openPopup(ctx: CanvasRenderingContext2D, widget: Widget, x: number, y: number, relativeChild?: Widget) {
-      throw new Error(`CheckBox should never have openPopup be called on it!`);
-   }
-   closePopup(ctx: CanvasRenderingContext2D, widget: Widget) {
-      throw new Error(`CheckBox should never have closePopup be called on it!`);
-   }
-   handleDelete(ctx: CanvasRenderingContext2D, widget: Widget) {
-      //do nothing
+      return this.callbacks.delete(callback);
    }
 }
+
+class RadioItemGroup {
+   private items: Set<[RadioItem, (ctx: CanvasRenderingContext2D)=>void, (group: RadioItemGroup)=>void]> = new Set();
+   constructor(item: RadioItem, deselect: (ctx: CanvasRenderingContext2D)=>void, setRadioGroup: (group: RadioItemGroup)=>void) {
+      this.items.add([item, deselect, setRadioGroup]);
+   }
+
+   optionSeleted(item: RadioItem, ctx: CanvasRenderingContext2D) {
+      for (const [n_item,  deselect,] of this.items) {
+         if (n_item == item)
+            continue;
+         deselect(ctx);
+      }
+   }
+
+   mergeGroups(oth: RadioItemGroup) {
+      if (oth == this) return;
+
+      
+   }
+   
+   
+}
+class RadioItem extends Button {
+   private callbacks: Set<(ctx: CanvasRenderingContext2D, selected: boolean) => void> = new Set();
+
+   private _selected = false;
+   private radioGroup: RadioItemGroup;
+
+   constructor(ctx: CanvasRenderingContext2D, parent: WidgetManager, id: number, cons: ButtonWidgetConstructor, globalProps: GlobalWidgetProperties) {
+      super(ctx, parent, id, cons, globalProps);
+
+      this.radioGroup = new RadioItemGroup(this, this.deselect.bind(this), this.setRadioGroup.bind(this));
+
+      super.prefixText = globalProps.radioMenuUncheckedPrefix;
+      
+      super.addEvent((ctx) => {
+         if (!this._selected) {
+            this._selected = true;
+            this.radioGroup.optionSeleted(this, ctx);
+            super.prefixText = globalProps.radioMenuCheckedPrefix;
+            for (const callback of this.callbacks) {
+               callback(ctx, this._selected);
+            }
+         }
+      });
+   }
+
+   private deselect(ctx: CanvasRenderingContext2D) {
+      this._selected = false;
+      this.prefixText = this.globalProps.radioMenuUncheckedPrefix;
+      for (const callback of this.callbacks) {
+         callback(ctx, false);
+      }
+   }
+   private setRadioGroup(group: RadioItemGroup) {
+      this.radioGroup = group;
+   }
+
+   makeSelected() {
+
+   }
+
+   addEvent(callback: (ctx: CanvasRenderingContext2D, selected: boolean) => void) {
+      this.callbacks.add(callback);
+   }
+   removeEvent(callback: (ctx: CanvasRenderingContext2D, selected: boolean) => void) {
+      return this.callbacks.delete(callback);
+   }
+}
+
 interface WidgetEvents {
    addEvent: (callback: () => void) => void;
    removeEvent: (callback: () => void) => void;
@@ -1520,7 +1524,8 @@ export class twrConsoleWindow extends twrLibrary implements ICanvasEvents, ICons
       xPadding: 5,
       emptyMenuHeight: 20,
       emptyMenuWidth: 20,
-      radioMenuPrefix: "*",
+      radioMenuCheckedPrefix: "*",
+      radioMenuUncheckedPrefix: undefined,
       checkBoxCheckedPrefix: "[*]",
       checkBoxUncheckedPrefix: "[  ]"
    };

--- a/source/twr-ts/twrlibscreen.ts
+++ b/source/twr-ts/twrlibscreen.ts
@@ -1,3 +1,4 @@
+
 import { keyEventToCodePoint } from "./twrcon.js";
 import { TLibImports, twrLibrary, twrLibraryInstanceRegistry } from "./twrlibrary.js";
 import { IWasmModule } from "./twrmod";
@@ -57,7 +58,7 @@ export default class twrLibAudio extends twrLibrary {
    };
    
    tabs: { [id: FullID]: [IWasmModule|IWasmModuleAsync, ...any] } = {};
-   registeredEvents: { [id: FullID]: { [eventID: number]: number}[] } = {};
+   registeredEvents: Map<number, Array<Map<number, number>>> = new Map();
    selectedTab: number = -1;
 
    // every library should have this line
@@ -101,16 +102,58 @@ export default class twrLibAudio extends twrLibrary {
    }
 
    internalSendEvent(event_type: EventTypes, ...args: number[]) {
-      if (!(this.selectedTab in this.registeredEvents)) return;
+      const event_types = this.registeredEvents.get(this.selectedTab);
+      if (event_types == undefined) return;
 
-      const event_handlers = this.registeredEvents[this.selectedTab][event_type];
+      const event_handlers = event_types[event_type];
 
-      for (let i = 0; i < event_handlers.length; i++) {
+      for (const [i, _] of event_handlers) {
          this.tabs[this.selectedTab][0].postEvent(
-            this.registeredEvents[this.selectedTab][event_type][1],
+            i,
             ...args
          );
       } 
+   }
+
+   twrRegisterEvent(mod: IWasmModule|IWasmModuleAsync, tabID: number, eventType: EventTypes, eventID: number) {
+      if (0 < eventType || eventType >= NUM_EVENTS) throw new Error(`twrRegisterEvent was given an out of bounds event type (${eventType})!`);
+
+      const fullTabID = calculateID(mod, tabID);
+      
+      const tabEvents = this.registeredEvents.get(tabID);
+      if (tabEvents == undefined) throw new Error(`twrRegisterEvent was given an unregistered tab (${tabID})!`);
+
+      const eventHandlers = tabEvents[eventType];
+      
+      const prevValTmp = eventHandlers.get(eventID);
+      const prevVal = prevValTmp == undefined ? 0 : prevValTmp;
+      if (prevValTmp != undefined) console.log("warning! twrRegisterEvent was given an already registered eventID!");
+
+      eventHandlers.set(eventID, prevVal+1);
+   }
+
+   twrUnregisterEvent(mod: IWasmModule|IWasmModuleAsync, tabID: number, eventType: EventTypes, eventID: number) {
+      if (0 < eventType || eventType >= NUM_EVENTS) throw new Error(`twrUnregisterEvent was given an out of bounds event type (${eventType})!`);
+
+      const fullTabID = calculateID(mod, tabID);
+      
+      const tabEvents = this.registeredEvents.get(tabID);
+      if (tabEvents == undefined) throw new Error(`twrUnregisterEvent was given an unregistered tab (${tabID})!`);
+
+      const eventHandlers = tabEvents[eventType];
+
+      const prevVal = eventHandlers.get(eventID);
+
+      if (prevVal == undefined) {
+         throw new Error(`twrUnregisterEvent was given an eventID that isn't registered (${eventID})!`);
+      } else if (prevVal == 0) {
+         throw new Error(`twrUnregisterEvent was given an eventID that isn't registered (${eventID}) and it wasn't properly removed!`);
+      } else if (prevVal == 1) {
+         eventHandlers.delete(prevVal);
+      } else {
+         console.log(`warning: twrUnregisterEvent didn't unregister eventID ${eventID} since it still has ${prevVal-1} registration(s) left!`);
+         eventHandlers.set(eventID, prevVal-1);
+      }
    }
 
 

--- a/source/twr-ts/twrlibscreen.ts
+++ b/source/twr-ts/twrlibscreen.ts
@@ -1,0 +1,117 @@
+import { keyEventToCodePoint } from "./twrcon.js";
+import { TLibImports, twrLibrary, twrLibraryInstanceRegistry } from "./twrlibrary.js";
+import { IWasmModule } from "./twrmod";
+import { IWasmModuleAsync } from "./twrmodasync";
+
+
+
+//nominal type - Allows FullID to be considered a unique type compared to number
+//can easily remove { readonly '': unique symbol } to make it a simple type alias
+// type FullID = number & { readonly '': unique symbol };
+
+type FullID = number;
+
+enum EventTypes {
+   KEY_DOWN,
+   KEY_UP,
+
+   MOUSE_DOWN,
+   MOUSE_UP,
+   MOUSE_CLICK,
+   MOUSE_DBLCLICK,
+   MOUSE_MOVE,
+
+   WHEEL
+}
+const NUM_EVENTS = EventTypes.WHEEL - EventTypes.KEY_DOWN + 1;
+
+const EVENTS = [
+   "keydown",
+   "keyup",
+   
+   "mousedown",
+   "mouseup",
+   "click",
+   "dblclick",
+   "mousemove",
+
+   "wheel"
+]
+
+
+function calculateID(mod:IWasmModule|IWasmModuleAsync, id: number): FullID {
+   if (mod.id >= (2**20)) throw new Error("twrlibaudio was given a module ID greater than 20 bits long!");
+   if (id >= (2**32)) throw new Error("twrlibaudio was given an object ID greater than 32 bits!");
+   //should be equivalent to (mod.id << 32) | id
+   //can't use shift operations without being limited to 32-bit signed integers or using bignumber
+   return ((mod.id & (2**20 - 1)) * 2**32 + id) as FullID;
+}
+
+export default class twrLibAudio extends twrLibrary {
+   id: number;
+
+   readonly canvas: HTMLCanvasElement;
+
+   imports: TLibImports = {
+      
+   };
+   
+   tabs: { [id: FullID]: [IWasmModule|IWasmModuleAsync, ...any] } = {};
+   registeredEvents: { [id: FullID]: { [eventID: number]: number}[] } = {};
+   selectedTab: number = -1;
+
+   // every library should have this line
+   libSourcePath = new URL(import.meta.url).pathname;
+
+   constructor(canvas: HTMLCanvasElement) {
+      // all library constructors should start with these two lines
+      super();
+      this.id=twrLibraryInstanceRegistry.register(this);
+
+      this.canvas = canvas;
+
+      
+      const register_similar_events = (rangeStart: number, rangeEnd: number, handler: (e: any) => number[] | void) => {
+         for (let i = rangeStart; i <= rangeEnd; i++) {
+            canvas.addEventListener(EVENTS[i], (e) => {
+               const res = handler(e);
+               if (res != undefined)
+                  this.internalSendEvent(i, ...res);
+            });
+         };
+      }
+
+      register_similar_events(EventTypes.KEY_DOWN, EventTypes.KEY_UP, (e: KeyboardEvent) => {
+         const r=keyEventToCodePoint(e);  // twr-wasm utility function
+         if (r) {
+            // postEvent can only post numbers -- no translation of arguments is performed prior to making the C event callback
+            // See ex_append_two_strings below for an example using strings.
+            return [r];
+         }
+      });
+
+      register_similar_events(EventTypes.MOUSE_DOWN, EventTypes.MOUSE_MOVE, (e: MouseEvent) => {
+         return [e.pageX + window.scrollX, e.pageY + window.scrollY];
+      });
+
+      register_similar_events(EventTypes.WHEEL, EventTypes.WHEEL, (e: WheelEvent) => {
+         return [e.deltaX, e.deltaY, e.deltaZ, e.deltaMode];
+      });
+
+   }
+
+   internalSendEvent(event_type: EventTypes, ...args: number[]) {
+      if (!(this.selectedTab in this.registeredEvents)) return;
+
+      const event_handlers = this.registeredEvents[this.selectedTab][event_type];
+
+      for (let i = 0; i < event_handlers.length; i++) {
+         this.tabs[this.selectedTab][0].postEvent(
+            this.registeredEvents[this.selectedTab][event_type][1],
+            ...args
+         );
+      } 
+   }
+
+
+}


### PR DESCRIPTION
A large collection of changes I made while implementing a window class.
* Added events for keyboard and mouse that are passed down from a hierarchy. For instance, if window is at the top, it passed keyboard and mouse events down to it's internal d2d_canvas class. This performs operations like focus and offsets mouse coordinates as needed.
* Added a console interface called ICanvasEvents that allows a console to provide interfaces for registering and preregistering events. This is used in d2d canvas for the mouse and keyboard events talked about above.
* Created window console that acts as a chrome around the d2d canvas with things like resizing and menu widgets.
  * Menu widgets are based around the Widget class that contains some common functionality for events, drawing, and properties that can be modified by C.
  * Main widgets created are as follows:
    * Menu bars (like the drop down menu buttons at the top of a window)
    * Drop down menus
    * Buttons
    * Separators
    * Check boxes
    * Radio Items

TODO:
* Look into the potential focus bug I was thinking about
* Fix some weird vertical centering issues with text
* Possibly move the menu widgets into their own library/console